### PR TITLE
fix(edit-content): use selected locale for both sides of version compare

### DIFF
--- a/core-web/libs/edit-content/src/lib/store/features/history/history.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/history/history.feature.spec.ts
@@ -1297,4 +1297,75 @@ describe('HistoryFeature', () => {
             expect(store.uiState().view).toBe('form');
         });
     });
+
+    describe('compareData', () => {
+        const compareContent = { ...mockContentlet, inode: 'compare-inode', title: 'Compare' };
+
+        beforeEach(() => {
+            patchState(store, { compareContentlet: compareContent });
+        });
+
+        it('should build the language key from languageCode and countryCode for a non-default locale', () => {
+            patchState(store, {
+                currentLocale: {
+                    id: 2,
+                    language: 'Spanish',
+                    languageCode: 'es',
+                    countryCode: 'ES'
+                }
+            });
+
+            expect(store.compareData()).toEqual({
+                inode: 'compare-inode',
+                identifier: mockContentlet.identifier,
+                language: 'es-es'
+            });
+        });
+
+        it('should use only the languageCode when the locale has no country code', () => {
+            patchState(store, {
+                currentLocale: {
+                    id: 3,
+                    language: 'Italian',
+                    languageCode: 'it'
+                }
+            });
+
+            expect(store.compareData().language).toBe('it');
+        });
+
+        it('should prefer the lowercased isoCode when present', () => {
+            patchState(store, {
+                currentLocale: {
+                    id: 1,
+                    language: 'English',
+                    languageCode: 'en',
+                    countryCode: 'US',
+                    isoCode: 'en-US'
+                }
+            });
+
+            expect(store.compareData().language).toBe('en-us');
+        });
+
+        it('should fall back to en-us when there is no current locale', () => {
+            patchState(store, { currentLocale: null });
+
+            expect(store.compareData().language).toBe('en-us');
+        });
+
+        it('should keep en-us for the default en-US locale (regression)', () => {
+            patchState(store, {
+                currentLocale: {
+                    id: 1,
+                    language: 'English',
+                    languageCode: 'en',
+                    countryCode: 'US',
+                    defaultLanguage: true
+                }
+            });
+
+            expect(store.compareData().language).toBe('en-us');
+        });
+    });
 });

--- a/core-web/libs/edit-content/src/lib/store/features/history/history.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/history/history.feature.ts
@@ -53,10 +53,24 @@ export function withHistory() {
         { state: type<EditContentState>() },
         withComputed((store) => ({
             compareData: computed(() => {
+                // Derive the version-map key from the currently selected locale so the
+                // "current" side of the diff reflects the active locale, not the default one.
+                // Matches backend Language.getIsoCode(): lowercase `languageCode-countryCode`
+                // (or just `languageCode` when there is no country code).
+                const locale = store.currentLocale();
+                const language = locale
+                    ? (
+                          locale.isoCode ||
+                          (locale.countryCode
+                              ? `${locale.languageCode}-${locale.countryCode}`
+                              : locale.languageCode)
+                      ).toLowerCase()
+                    : 'en-us';
+
                 return {
                     inode: store.compareContentlet()?.inode,
                     identifier: store.compareContentlet()?.identifier,
-                    language: 'en-us'
+                    language
                 };
             })
         })),


### PR DESCRIPTION
## Summary

In the new Edit Contentlet mode, comparing versions from the History Tab while viewing a non-default locale produced a cross-locale diff: the previous side showed the selected locale, but the current side showed the default locale's working version.

Root cause: the `compareData` computed in the history feature store hardcoded `language: 'en-us'` as the version-map key passed to `DotContentCompareStore`. Since the compare store resolves the "current" (working) version from the version list of that language key, it always came back in the default locale.

The fix derives the key from the store's `currentLocale`, matching the backend `Language.getIsoCode()` key format used by `GET /api/v1/content/versions?groupByLang=1`: lowercase `languageCode-countryCode`, or bare `languageCode` for language-only locales. `'en-us'` remains only as the fallback when no locale is loaded yet.

Closes #35756

<img width="3170" height="1526" alt="CleanShot 2026-07-07 at 16 32 39@2x" src="https://github.com/user-attachments/assets/bc8b52a5-1197-43c6-8a5d-e43330e343b2" />

<img width="3016" height="1234" alt="CleanShot 2026-07-07 at 16 32 25@2x" src="https://github.com/user-attachments/assets/3c19ce4c-0dc4-4a0b-9ae7-c1250e909be4" />


## Acceptance Criteria

- [x] When viewing a non-default locale version and clicking Compare, the "current" side of the diff shows the latest version in the selected locale — not the default locale
- [x] The "previous" side shows the selected older version in the same selected locale
- [x] Both sides of the compare diff always reflect the same locale context the user is currently viewing
- [x] Original reproduction scenario (non-default locale, compare old version, current side shows default locale) no longer reproduces
- [x] Compare in the default locale continues to work correctly (no regression)

## Test Plan

New `describe('compareData')` block in `history.feature.spec.ts`:

- Non-default locale (`es`/`ES`) resolves to `es-es`
- Language-only locale (`it`, no country code) resolves to `it`
- `isoCode` takes precedence and is lowercased (`en-US` to `en-us`)
- Null `currentLocale` falls back to `en-us`
- Default locale `en-US` still resolves to `en-us` (regression)

Verification run: `pnpm nx lint edit-content`, `pnpm nx test edit-content` (65 tests passing), `pnpm nx affected:lint` and `pnpm nx affected:test` against `origin/main` — all green.

## Changed Files

- `core-web/libs/edit-content/src/lib/store/features/history/history.feature.ts` — derive compare language key from `currentLocale`
- `core-web/libs/edit-content/src/lib/store/features/history/history.feature.spec.ts` — new `compareData` locale tests