### PR TITLE
fix(opensearch): classify OS startup connection errors + test Phase 3 abort (#36244)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexAPIImpl.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -89,6 +90,23 @@ public class OSIndexAPIImpl implements IndexAPI {
     private OSClientProvider clientProvider;
 
     /**
+     * Seam over the JVM-terminating exit used by the Phase 3 abort branch of the startup
+     * connection gate. Defaults to the real {@link com.dotcms.shutdown.SystemExitManager}, which
+     * calls {@code Runtime.halt()} and has no test guard. Tests override this via
+     * {@link #setExitHandler(ExitHandler)} so the Phase 3 abort contract can be asserted without
+     * killing the test JVM (issue #36244 follow-up).
+     */
+    private ExitHandler exitHandler = com.dotcms.shutdown.SystemExitManager::immediateExit;
+
+    /**
+     * Functional seam for {@link com.dotcms.shutdown.SystemExitManager#immediateExit(int, String)}.
+     */
+    @FunctionalInterface
+    interface ExitHandler {
+        void exit(int exitCode, String reason);
+    }
+
+    /**
      * No-arg constructor required by CDI for proxy creation.
      * The {@code clientProvider} dependency is injected via field injection after construction.
      */
@@ -101,6 +119,14 @@ public class OSIndexAPIImpl implements IndexAPI {
      */
     OSIndexAPIImpl(OSClientProvider clientProvider) {
         this.clientProvider = clientProvider;
+    }
+
+    /**
+     * Package-private test seam: replaces the JVM-terminating exit so the Phase 3 abort branch of
+     * {@link #waitUtilIndexReady()} can be observed in tests instead of halting the JVM.
+     */
+    void setExitHandler(final ExitHandler exitHandler) {
+        this.exitHandler = exitHandler;
     }
 
     // =========================================================================
@@ -573,20 +599,21 @@ public class OSIndexAPIImpl implements IndexAPI {
     private boolean handleConnectionExhausted(final int attempts, final Exception lastError) {
         final MigrationPhase phase = MigrationPhase.current();
         final String cause = lastError != null ? lastError.getMessage() : "unknown";
+        final ConnectionFailureKind kind = classifyConnectionError(lastError);
         final String detail = "OpenSearch is not reachable after " + attempts + " attempt(s)."
                 + " phase=" + phase.name()
                 + ", endpoints=" + resolveEndpointsForLogging()
-                + ", cause=" + cause;
+                + ", likelyCause=" + kind.name() + " (" + kind.remediation() + ")"
+                + ", error=" + cause;
 
         if (phase.isMigrationComplete()) {
             // Phase 3: OS is primary and ES is decommissioned — no fallback is possible.
             Logger.fatal(this.getClass(), detail
                     + " — OS is the primary store in " + phase.name() + "; cannot fall back to ES."
-                    + " Verify OS_ENDPOINTS, OS_PROTOCOL/OS_TLS_ENABLED (scheme must match the"
-                    + " server), and credentials, then restart dotCMS.");
-            com.dotcms.shutdown.SystemExitManager.immediateExit(1,
-                    "OpenSearch connection failed in PHASE_3_OPENSEARCH_ONLY");
-            return false; // unreachable — immediateExit terminates the JVM
+                    + " Fix the connection per the likely cause above, then restart dotCMS.");
+            exitHandler.exit(1, "OpenSearch connection failed in PHASE_3_OPENSEARCH_ONLY: "
+                    + kind.name());
+            return false; // unreachable in production — immediateExit terminates the JVM
         }
 
         // Phase 1 / 2 (shadow): ES still holds the authoritative state. Fall back to ES-only
@@ -594,7 +621,8 @@ public class OSIndexAPIImpl implements IndexAPI {
         Logger.error(this.getClass(), detail
                 + " — OS is a shadow store in " + phase.name() + "; falling back to ES-only"
                 + " (resetting FEATURE_FLAG_OPEN_SEARCH_PHASE to 0 via haltMigration)."
-                + " Fix OS connectivity and re-enable the migration phase when ready.");
+                + " Fix OS connectivity per the likely cause above and re-enable the migration"
+                + " phase when ready.");
         IndexConfigHelper.haltMigration();
         return false;
     }
@@ -614,6 +642,87 @@ public class OSIndexAPIImpl implements IndexAPI {
         final String hostname = IndexConfigHelper.getString(OSIndexProperty.HOSTNAME, "localhost");
         final int    port     = IndexConfigHelper.getInt(OSIndexProperty.PORT, 9200);
         return protocol + "://" + hostname + ":" + port;
+    }
+
+    /**
+     * Likely root cause of an OpenSearch connection failure, inferred from the exception chain,
+     * so the fatal (Phase 3) / fallback (Phase 1-2) message can name the actual problem and its fix
+     * instead of only echoing a raw transport message (issue #36244 follow-up: error classification
+     * hardening). Motivated by a TLS-scheme mismatch (an {@code http://} client against an
+     * {@code https}-only OS 3.x port) that surfaced only as an opaque {@code ConnectionClosedException}.
+     */
+    enum ConnectionFailureKind {
+        TLS_SCHEME_MISMATCH("TLS/scheme mismatch — the client scheme likely does not match the"
+                + " server (e.g. http:// against an https-only OS port, or https:// against a"
+                + " plaintext port). Align OS_PROTOCOL / OS_TLS_ENABLED with the server's scheme"
+                + " and check the server certificate."),
+        AUTH_FORBIDDEN("authentication/authorization rejected (HTTP 401/403) — verify the OS"
+                + " credentials and that the user has the required cluster permissions."),
+        UNREACHABLE("cluster unreachable (connection refused / timed out / unknown host) — verify"
+                + " OS_ENDPOINTS host:port and that OpenSearch is running and network-reachable."),
+        UNKNOWN("cause could not be classified — inspect the underlying error and stack trace.");
+
+        private final String remediation;
+
+        ConnectionFailureKind(final String remediation) {
+            this.remediation = remediation;
+        }
+
+        String remediation() {
+            return remediation;
+        }
+    }
+
+    /**
+     * Classifies an OpenSearch connection failure by walking the exception chain and matching on
+     * exception type (simple name) and message text. Simple-name / message matching is used
+     * deliberately so this stays free of any compile dependency on transport-layer types (e.g.
+     * Apache HttpClient's {@code ConnectionClosedException}) and remains unit-testable with plain
+     * synthetic exception chains.
+     *
+     * <p>Order matters: TLS/scheme is checked first (its symptoms — closed connection, SSL/plaintext
+     * — otherwise look like a generic unreachable), then auth (401/403), then unreachable.</p>
+     *
+     * @param error the last connection error observed, or {@code null}
+     * @return the inferred {@link ConnectionFailureKind}; never {@code null}
+     */
+    static ConnectionFailureKind classifyConnectionError(final Throwable error) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            final String type = t.getClass().getName().toLowerCase(Locale.ROOT);
+            final String msg  = t.getMessage() == null
+                    ? "" : t.getMessage().toLowerCase(Locale.ROOT);
+
+            // TLS / scheme mismatch: SSL handshake errors, or a connection closed with no response
+            // (the classic symptom of speaking http:// to an https-only port).
+            if (type.contains("sslexception")
+                    || type.contains("sslhandshake")
+                    || type.contains("connectionclosedexception")
+                    || msg.contains("unrecognized ssl message")
+                    || msg.contains("plaintext")
+                    || msg.contains("ssl")
+                    || msg.contains("certificat") // certificate / certification path (PKIX)
+                    || msg.contains("pkix")
+                    || msg.contains("connection closed")) {
+                return ConnectionFailureKind.TLS_SCHEME_MISMATCH;
+            }
+            // Authentication / authorization.
+            if (msg.contains("401") || msg.contains("403")
+                    || msg.contains("unauthorized") || msg.contains("forbidden")) {
+                return ConnectionFailureKind.AUTH_FORBIDDEN;
+            }
+            // Host/port unreachable.
+            if (type.contains("connectexception")
+                    || type.contains("unknownhostexception")
+                    || type.contains("sockettimeoutexception")
+                    || type.contains("nohttpresponseexception")
+                    || msg.contains("connection refused")
+                    || msg.contains("timed out")
+                    || msg.contains("timeout")
+                    || msg.contains("unknown host")) {
+                return ConnectionFailureKind.UNREACHABLE;
+            }
+        }
+        return ConnectionFailureKind.UNKNOWN;
     }
 
 

--- a/dotCMS/src/test/java/com/dotcms/content/index/opensearch/OSIndexAPIImplConnectionClassifyTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/opensearch/OSIndexAPIImplConnectionClassifyTest.java
@@ -1,0 +1,111 @@
+package com.dotcms.content.index.opensearch;
+
+import static org.junit.Assert.assertEquals;
+
+import com.dotcms.content.index.opensearch.OSIndexAPIImpl.ConnectionFailureKind;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import javax.net.ssl.SSLException;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link OSIndexAPIImpl#classifyConnectionError(Throwable)} — the OpenSearch
+ * connection-error classification hardening (issue #36244 follow-up).
+ *
+ * <p>Pure function, no container: the classifier walks the exception chain and matches on exception
+ * simple-name and message text, so synthetic exception chains are sufficient to exercise every
+ * branch. Same package as {@link OSIndexAPIImpl} to reach the package-private classifier and
+ * {@link ConnectionFailureKind}.</p>
+ *
+ * @author Fabrizzio Araya
+ */
+public class OSIndexAPIImplConnectionClassifyTest {
+
+    /** Synthetic type whose simple name matches Apache HttpClient's transport exception. */
+    private static final class ConnectionClosedException extends IOException {
+        ConnectionClosedException(final String message) {
+            super(message);
+        }
+    }
+
+    private static ConnectionFailureKind classify(final Throwable t) {
+        return OSIndexAPIImpl.classifyConnectionError(t);
+    }
+
+    // ---- TLS / scheme mismatch ------------------------------------------------------------------
+
+    @Test
+    public void sslException_isTlsSchemeMismatch() {
+        assertEquals(ConnectionFailureKind.TLS_SCHEME_MISMATCH,
+                classify(new SSLException("Unrecognized SSL message, plaintext connection?")));
+    }
+
+    @Test
+    public void connectionClosed_httpAgainstHttpsPort_isTlsSchemeMismatch() {
+        // The classic symptom of speaking http:// to an https-only OS 3.x port.
+        assertEquals(ConnectionFailureKind.TLS_SCHEME_MISMATCH,
+                classify(new ConnectionClosedException("Connection is closed")));
+    }
+
+    @Test
+    public void certificateMessage_isTlsSchemeMismatch() {
+        assertEquals(ConnectionFailureKind.TLS_SCHEME_MISMATCH,
+                classify(new IOException("unable to find valid certification path to requested target")));
+    }
+
+    // ---- Auth -----------------------------------------------------------------------------------
+
+    @Test
+    public void forbidden403_isAuthForbidden() {
+        assertEquals(ConnectionFailureKind.AUTH_FORBIDDEN,
+                classify(new RuntimeException("method [HEAD], status line [HTTP/1.1 403 Forbidden]")));
+    }
+
+    @Test
+    public void unauthorized401_isAuthForbidden() {
+        assertEquals(ConnectionFailureKind.AUTH_FORBIDDEN,
+                classify(new RuntimeException("401 Unauthorized")));
+    }
+
+    // ---- Unreachable ----------------------------------------------------------------------------
+
+    @Test
+    public void connectException_isUnreachable() {
+        assertEquals(ConnectionFailureKind.UNREACHABLE,
+                classify(new ConnectException("Connection refused")));
+    }
+
+    @Test
+    public void unknownHost_isUnreachable() {
+        assertEquals(ConnectionFailureKind.UNREACHABLE,
+                classify(new UnknownHostException("no-such-host")));
+    }
+
+    @Test
+    public void socketTimeout_isUnreachable() {
+        assertEquals(ConnectionFailureKind.UNREACHABLE,
+                classify(new SocketTimeoutException("connect timed out")));
+    }
+
+    // ---- Cause-chain walking & fallback ---------------------------------------------------------
+
+    @Test
+    public void walksCauseChain_wrappedSslException_isTlsSchemeMismatch() {
+        final Throwable wrapped = new RuntimeException("io error",
+                new IOException("handshake failed", new SSLException("bad_certificate")));
+        assertEquals(ConnectionFailureKind.TLS_SCHEME_MISMATCH, classify(wrapped));
+    }
+
+    @Test
+    public void nullError_isUnknown() {
+        assertEquals(ConnectionFailureKind.UNKNOWN, classify(null));
+    }
+
+    @Test
+    public void unrecognizedError_isUnknown() {
+        assertEquals(ConnectionFailureKind.UNKNOWN,
+                classify(new IllegalStateException("something else entirely")));
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSIndexAPIImplWaitReadyIT.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSIndexAPIImplWaitReadyIT.java
@@ -3,10 +3,13 @@ package com.dotcms.content.index.opensearch;
 import static com.dotcms.content.index.IndexConfigHelper.MigrationPhase.FLAG_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.dotcms.content.index.IndexConfigHelper.MigrationPhase;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.util.Config;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -35,9 +38,12 @@ import org.opensearch.client.opensearch.OpenSearchClient;
  *   <li><strong>Phase 1 / 2 (shadow)</strong> — covered: the gate must NOT kill the JVM; it halts
  *       the migration (phase reset to 0) and returns {@code false}. These two cases use the failing
  *       client provider, so they do not need the live OpenSearch container.</li>
- *   <li><strong>Phase 3 (OS primary)</strong> — intentionally NOT tested here: the gate aborts via
- *       {@code SystemExitManager.immediateExit}, which calls {@code Runtime.halt()} and would kill
- *       the test JVM. The Phase 3 abort is verified by manual QA instead.</li>
+ *   <li><strong>Phase 3 (OS primary)</strong> — covered via a test exit seam
+ *       ({@link OSIndexAPIImpl#setExitHandler}): the gate must request an abort (exit code 1) and
+ *       must NOT fall back (phase stays {@code PHASE_3}). The seam replaces
+ *       {@code SystemExitManager.immediateExit} — which calls {@code Runtime.halt()} and would
+ *       otherwise kill the test JVM — so the abort contract is observable without terminating the
+ *       process.</li>
  *   <li><strong>Success path</strong> — covered by the other OpenSearch integration tests that run
  *       against the live cluster (a reachable {@code client.info()}).</li>
  * </ul>
@@ -111,5 +117,61 @@ public class OSIndexAPIImplWaitReadyIT {
         assertFalse("Phase 2 must NOT abort: the gate returns false (ES-only fallback)", ready);
         assertEquals("Migration phase must be reset to PHASE_0 after the ES fallback",
                 MigrationPhase.PHASE_0_MIGRATION_NOT_STARTED, MigrationPhase.current());
+    }
+
+    /**
+     * Given : Phase 3 (OpenSearch only) and an unreachable OpenSearch cluster.
+     * When  : waitUtilIndexReady() exhausts its retries.
+     * Then  : the gate ABORTS (requests exit code 1 via the seam) and does NOT fall back — OS is the
+     *         primary store in Phase 3, so the migration phase must remain PHASE_3 (haltMigration is
+     *         never called). The exit is captured by the seam instead of killing the test JVM.
+     */
+    @Test
+    public void test_phase3_osUnreachable_aborts_noFallback() {
+        setPhase(3);
+        final OSIndexAPIImpl api = new OSIndexAPIImpl(new FailingClientProvider());
+
+        final AtomicInteger exitCode = new AtomicInteger(Integer.MIN_VALUE);
+        final AtomicReference<String> exitReason = new AtomicReference<>();
+        api.setExitHandler((code, reason) -> {
+            exitCode.set(code);
+            exitReason.set(reason);
+        });
+
+        final boolean ready = api.waitUtilIndexReady();
+
+        assertFalse("Phase 3 gate must not report OS as ready when unreachable", ready);
+        assertEquals("Phase 3 must request a JVM abort with exit code 1", 1, exitCode.get());
+        assertTrue("Abort reason must identify the Phase 3 store",
+                exitReason.get() != null && exitReason.get().contains("PHASE_3"));
+        assertEquals("Phase 3 must NOT fall back: the migration phase must remain PHASE_3",
+                MigrationPhase.PHASE_3_OPENSEARCH_ONLY, MigrationPhase.current());
+    }
+
+    /**
+     * Given : Phase 3 and an unreachable cluster whose failure looks like a TLS/scheme mismatch.
+     * When  : waitUtilIndexReady() exhausts its retries.
+     * Then  : the abort reason names the classified cause (TLS_SCHEME_MISMATCH), proving the
+     *         error-classification hardening reaches the actionable Phase 3 message.
+     */
+    @Test
+    public void test_phase3_tlsMismatch_abortReasonNamesCause() {
+        setPhase(3);
+        final OSIndexAPIImpl api = new OSIndexAPIImpl(new OSClientProvider() {
+            @Override
+            public OpenSearchClient getClient() {
+                throw new RuntimeException(
+                        new javax.net.ssl.SSLException("Unrecognized SSL message, plaintext connection?"));
+            }
+        });
+
+        final AtomicReference<String> exitReason = new AtomicReference<>();
+        api.setExitHandler((code, reason) -> exitReason.set(reason));
+
+        api.waitUtilIndexReady();
+
+        assertTrue("Abort reason must name the classified TLS/scheme cause",
+                exitReason.get() != null && exitReason.get().contains(
+                        OSIndexAPIImpl.ConnectionFailureKind.TLS_SCHEME_MISMATCH.name()));
     }
 }


### PR DESCRIPTION
## Description

Follow-up to PR #36248 (issue #36244), completing the two items the original PR explicitly deferred as **out of scope**:

1. **Error classification hardening** of the OpenSearch startup connection `catch`.
2. **Automated coverage of the Phase 3 abort branch** (previously zero — untestable because it halts the JVM).

This is a **follow-up**, not a re-fix: the base gating/fallback rework (AC A/B/C) already landed in `main` via #36248. This PR completes the two remaining deferred items.

Closes #36244

## What changed

### 1. Error classification — `OSIndexAPIImpl.classifyConnectionError(Throwable)`
Walks the exception cause-chain and infers the likely root cause, so the fatal (Phase 3) / fallback (Phase 1‑2) message names the actual problem and its fix instead of echoing a raw transport message:

| Kind | Signals | Remediation hint |
|---|---|---|
| `TLS_SCHEME_MISMATCH` | `SSLException`, `ConnectionClosedException`, `plaintext`, `ssl`, `certificat`/`pkix`, connection closed | align `OS_PROTOCOL`/`OS_TLS_ENABLED` with the server scheme; check cert |
| `AUTH_FORBIDDEN` | 401/403, unauthorized/forbidden | verify credentials + cluster permissions |
| `UNREACHABLE` | `ConnectException`/`UnknownHost`/`SocketTimeout`, connection refused / timed out | verify `OS_ENDPOINTS` host:port + reachability |
| `UNKNOWN` | anything else | inspect the underlying error |

Matching is by exception **simple-name + message text** (no compile dependency on transport-layer types), so it stays unit-testable with synthetic chains. Motivated by the original `http://`-vs-`https` OS 3.x mismatch that surfaced only as an opaque `ConnectionClosedException`.

The classified cause now feeds `likelyCause=` in both the Phase 3 `Logger.fatal` and the Phase 1/2 `Logger.error` messages.

### 2. Phase 3 abort coverage — test seam
`SystemExitManager.immediateExit` calls `Runtime.halt()` with no test guard, so the Phase 3 abort branch could not be exercised without killing the test JVM. Added a package-private `ExitHandler` seam + `setExitHandler()` (defaults to the real `SystemExitManager::immediateExit`). Tests inject a capturing handler to assert the abort contract without terminating the process.

## Tests
- **`OSIndexAPIImplConnectionClassifyTest`** (unit, `dotcms-core`) — 11 cases across every classification branch + cause-chain walking. ✅ green locally.
- **`OSIndexAPIImplWaitReadyIT`** (integration, registered in `OpenSearchUpgradeSuite`) — adds:
  - `test_phase3_osUnreachable_aborts_noFallback`: Phase 3 requests exit code 1 and does **not** fall back (phase stays `PHASE_3`).
  - `test_phase3_tlsMismatch_abortReasonNamesCause`: the classified cause reaches the abort reason.
  - Existing Phase 1/2 fallback tests unchanged.

Verified locally: `dotcms-core` installs, unit test 11/11 green, `dotcms-integration` test-compiles. The IT suite runs in CI under the `opensearch-upgrade` profile.

## QA note (carried over from #36244)
`haltMigration()` → `MigrationPhase.reset()` is **runtime-only / in-memory**. If the phase flag was set via the DB-backed `ConfigSystemTable`, the reset is a no-op and the Phase 1/2 ES fallback would not take effect — worth validating explicitly in the migration QA scenario. Not changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36244