### PR TITLE
fix(containers): show all matching containers in template builder dropdown (#30047)

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.spec.ts
@@ -99,7 +99,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&perPage=${perPage}&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&per_page=${perPage}&system=false`,
                 HttpMethod.GET
             );
             expect(req.request.method).toBe('GET');
@@ -118,7 +118,7 @@ describe('DotContainersService', () => {
                 });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&perPage=${perPage}&system=true`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&per_page=${perPage}&system=true`,
                 HttpMethod.GET
             );
             expect(req.request.method).toBe('GET');
@@ -134,7 +134,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&perPage=${perPage}&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&per_page=${perPage}&system=false`,
                 HttpMethod.GET
             );
             req.flush({ entity: mockContainers });
@@ -149,7 +149,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&perPage=${perPage}&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&per_page=${perPage}&system=false`,
                 HttpMethod.GET
             );
             req.flush({ entity: mockContainers });
@@ -165,7 +165,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&perPage=1&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&per_page=1&system=false`,
                 HttpMethod.GET
             );
             expect(req.request.method).toBe('GET');
@@ -181,7 +181,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&perPage=1&system=true`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&per_page=1&system=true`,
                 HttpMethod.GET
             );
             expect(req.request.method).toBe('GET');
@@ -197,7 +197,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&perPage=1&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&per_page=1&system=false`,
                 HttpMethod.GET
             );
             req.flush({ entity: multipleContainers });
@@ -211,7 +211,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&perPage=1&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&per_page=1&system=false`,
                 HttpMethod.GET
             );
             req.flush({ entity: [] });
@@ -225,7 +225,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&perPage=1&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&per_page=1&system=false`,
                 HttpMethod.GET
             );
             req.flush({ entity: [] });
@@ -246,7 +246,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&perPage=${perPage}&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${filter}&per_page=${perPage}&system=false`,
                 HttpMethod.GET
             );
             req.flush('Server Error', errorResponse);
@@ -264,7 +264,7 @@ describe('DotContainersService', () => {
             });
 
             const req = spectator.expectOne(
-                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&perPage=1&system=false`,
+                `${EXPECTED_CONTAINER_API_URL}?filter=${title}&per_page=1&system=false`,
                 HttpMethod.GET
             );
             req.flush('Not Found', errorResponse);

--- a/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.ts
@@ -92,7 +92,7 @@ export class DotContainersService {
         perPage: number,
         fetchSystemContainers = false
     ): Observable<DotContainer[]> {
-        const url = `${this.#CONTAINER_API_URL}?filter=${filter}&perPage=${perPage}&system=${fetchSystemContainers}`;
+        const url = `${this.#CONTAINER_API_URL}?filter=${filter}&per_page=${perPage}&system=${fetchSystemContainers}`;
 
         return this.#http
             .get<{ entity: DotContainer[] }>(url)
@@ -107,7 +107,7 @@ export class DotContainersService {
      * @memberof DotContainersService
      */
     getContainerByTitle(title: string, system = false): Observable<DotContainer | null> {
-        const url = `${this.#CONTAINER_API_URL}?filter=${title}&perPage=1&system=${system}`;
+        const url = `${this.#CONTAINER_API_URL}?filter=${title}&per_page=1&system=${system}`;
 
         return this.#http.get<{ entity: DotContainer[] }>(url).pipe(
             map((response) => response.entity),

--- a/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.ts
+++ b/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.ts
@@ -35,7 +35,10 @@ export class DotContainerOptionsDirective implements OnInit {
     private readonly changeDetectorRef = inject(ChangeDetectorRef);
 
     private readonly control: Select;
-    private readonly maxOptions = 10;
+    // Fetch a generous page so every matching Container is shown in the grouped dropdown.
+    // The dropdown also filters server-side as the user types (see onFilter), so this is
+    // the upper bound of options shown at once, not the total the user can reach.
+    private readonly maxOptions = 100;
     private readonly loadErrorMessage: string;
 
     constructor() {


### PR DESCRIPTION
### Proposed Changes
* Fix `DotContainersService.getFiltered()` and `getContainerByTitle()` to send the page size as `per_page` (the REST endpoint's actual query param) instead of `perPage`. The mismatched name was silently ignored, so the server always fell back to its default page size of 10.
* Raise `DotContainerOptionsDirective.maxOptions` from 10 → 100 so the grouped container dropdown in the template builder shows all matching containers. The dropdown filters server-side as the user types, so this is the upper bound shown at once, not the total reachable.
* Update `dot-containers.service.spec.ts` URL assertions to `per_page` (they had been asserting the buggy URL).

### Root Cause
The template-builder "add container" dropdown (`p-select[dotContainerOptions]`) only ever displayed the first 10 containers with no pagination or scroll-to-load. Two stacked defects: the ignored `perPage` param capped the server response at its default of 10, and `maxOptions` was hardcoded to 10 as well. Searching a term that matched more than 10 containers left the rest unreachable.

### Checklist
- [x] Tests (updated `dot-containers.service.spec.ts`; `data-access` service spec 15/15 and `ui` directive spec 2/2 pass)
- [ ] Translations
- [x] Security Implications Contemplated — none; a client-side query-param rename aligning to the existing backend contract, no auth/permission changes.

### Additional Info
* `p-select` has no clean server-side lazy-load-on-scroll, and it already filters server-side, so "show all (up to a generous bound, refine by typing)" is the appropriate fix for this control rather than infinite scroll.
* Known limitation: a single filter term matching more than 100 containers still truncates; typing narrows the server query so any specific container remains reachable.
* Separately noted latent bug (not addressed here): `ContainerFactoryImpl.findContainers()` caps `totalResults` at ~500 via its counting loop — worth a follow-up ticket for Sites with very large container counts.

Refs: #30047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #30047