### PR TITLE
fix(search): guard non-finite _score in /api/es/search response (#36478)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -359,11 +359,24 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 			arr.put(new JSONObject()
 					.put("_id", hit.getId())
 					.put("_index", hit.getIndex())
-					.put("_score", hit.getScore())
+					.put("_score", finiteOrNull(hit.getScore()))
 					.put("_source", new JSONObject(hit.getSourceAsMap())));
 		}
 		hitsObj.put("hits", arr);
 		return hitsObj;
+	}
+
+	/**
+	 * Elasticsearch emits a non-finite {@code _score} ({@code NaN}) for hits that are not
+	 * relevance-scored — field-sorted queries (unless {@code track_scores=true}), and
+	 * filter/{@code constant_score}/aggregation-only contexts. dotCMS's JSON writer rejects
+	 * {@code NaN}/{@code Infinity} ({@code JSONObject.testValidity} throws "JSON does not allow
+	 * non-finite numbers"), so coerce non-finite values to {@code null} — matching Elasticsearch's
+	 * native wire format, which the legacy {@code /api/es/search} contract emitted before the
+	 * phase-aware SearchAPI cutover (#36398).
+	 */
+	private static Object finiteOrNull(final float value) {
+		return Float.isFinite(value) ? Float.valueOf(value) : JSONObject.NULL;
 	}
 
 	/** Maps the neutral aggregation tree (keyed by aggregation name) to the ES-native {@code aggregations} JSON. */

--- a/dotCMS/src/test/java/com/dotcms/rest/elasticsearch/ESContentResourcePortletNaNScoreTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/elasticsearch/ESContentResourcePortletNaNScoreTest.java
@@ -1,0 +1,92 @@
+package com.dotcms.rest.elasticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.dotcms.content.index.domain.Relation;
+import com.dotcms.content.index.domain.SearchHit;
+import com.dotcms.content.index.domain.SearchHits;
+import com.dotcms.content.index.domain.TotalHits;
+import com.dotmarketing.util.json.JSONArray;
+import com.dotmarketing.util.json.JSONObject;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Regression coverage for <a href="https://github.com/dotCMS/core/issues/36478">#36478</a>.
+ *
+ * <p>After the phase-aware SearchAPI cutover (#36398), {@code /api/es/search} rebuilds the legacy
+ * Elasticsearch-wire response through dotCMS's {@link JSONObject}. Elasticsearch returns a
+ * non-finite {@code _score} ({@code NaN}) for hits that are not relevance-scored (field-sorted
+ * queries, filter/{@code constant_score}/aggregation-only contexts). {@code JSONObject.put(...)}
+ * rejects non-finite numbers with "JSON does not allow non-finite numbers", producing an HTTP 500.
+ *
+ * <p>These fast unit tests drive the private {@code hitsToLegacyJson} mapping directly and assert
+ * that a {@code NaN} score serializes as {@code null} (matching ES's native wire format) instead of
+ * throwing, while finite scores are preserved unchanged.
+ */
+public class ESContentResourcePortletNaNScoreTest {
+
+    private static JSONObject hitsToLegacyJson(final SearchHits hits) throws Exception {
+        final Method method = ESContentResourcePortlet.class
+                .getDeclaredMethod("hitsToLegacyJson", SearchHits.class);
+        method.setAccessible(true);
+        try {
+            return (JSONObject) method.invoke(null, hits);
+        } catch (final InvocationTargetException e) {
+            // Surface the real cause (e.g. the pre-fix JSONException) to the test.
+            throw (Exception) e.getCause();
+        }
+    }
+
+    private static SearchHits hitsWithScore(final float score) {
+        final SearchHit hit = SearchHit.builder()
+                .id("abc123")
+                .index("live_index")
+                .score(score)
+                .sourceAsMap(Map.of("title", "example"))
+                .build();
+        return new SearchHits(false, List.of(hit), new TotalHits(1L, Relation.EQUAL_TO));
+    }
+
+    /**
+     * A {@code NaN} hit score (field-sorted / aggregation query) must not throw and must serialize
+     * as {@code _score: null}. Before the fix this threw
+     * {@code JSONException("JSON does not allow non-finite numbers.")}.
+     */
+    @Test
+    public void test_nan_score_serializes_as_null() throws Exception {
+        final JSONObject result = hitsToLegacyJson(hitsWithScore(Float.NaN));
+
+        final JSONObject firstHit = result.getJSONArray("hits").getJSONObject(0);
+        assertTrue("_score must be null for a non-finite (NaN) score", firstHit.isNull("_score"));
+
+        // The whole response must be serializable — the production 500 happened on write/put.
+        final String json = result.toString();
+        assertTrue("serialized response must contain a null _score",
+                json.contains("\"_score\":null") || json.contains("\"_score\": null"));
+    }
+
+    /** Positive/negative infinity is likewise coerced to {@code null} rather than throwing. */
+    @Test
+    public void test_infinite_score_serializes_as_null() throws Exception {
+        final JSONObject result = hitsToLegacyJson(hitsWithScore(Float.POSITIVE_INFINITY));
+        final JSONObject firstHit = result.getJSONArray("hits").getJSONObject(0);
+        assertTrue("_score must be null for a non-finite (Infinity) score", firstHit.isNull("_score"));
+    }
+
+    /** A normal relevance score must be preserved unchanged. */
+    @Test
+    public void test_finite_score_is_preserved() throws Exception {
+        final JSONObject result = hitsToLegacyJson(hitsWithScore(1.5f));
+
+        final JSONArray arr = result.getJSONArray("hits");
+        final JSONObject firstHit = arr.getJSONObject(0);
+        assertTrue("_score must be present for a finite score", !firstHit.isNull("_score"));
+        assertEquals(1.5d, firstHit.getDouble("_score"), 0.0001d);
+    }
+}


### PR DESCRIPTION
### Proposed Changes

Fixes #36478. Canonical fix on `main`; will be cherry-picked to `release-26.07.06-01` after merge (per dotCMS backport convention).

* Coerce non-finite hit `_score` values (`NaN`/`Infinity`) to `null` in `ESContentResourcePortlet.hitsToLegacyJson`, restoring the pre-regression Elasticsearch-native wire format.
* Add a fast unit regression test (`ESContentResourcePortletNaNScoreTest`) covering `NaN`, `Infinity`, and finite scores.

### Root cause

Regression introduced by #36398 (route `/api/es/raw` & `/api/es/search` through the phase-aware SearchAPI), first released in **v26.07.04-01**.

The endpoints now rebuild the legacy ES-wire response via dotCMS's `com.dotmarketing.util.json.JSONObject` instead of returning ES's native JSON. The per-hit score was written as a raw `float`:

```java
.put("_score", hit.getScore())   // hit.getScore() can be Float.NaN
```

Elasticsearch returns a non-finite `_score` (`NaN`) for hits that are **not relevance-scored** — most commonly any query that **sorts by a field** (unless `track_scores=true`), plus filter/`constant_score`/aggregation-only contexts. `JSONObject.put(...)` runs `testValidity()`, which throws `JSONException("JSON does not allow non-finite numbers.")` on non-finite values → **HTTP 500**. The previous implementation returned `SearchResponse.toString()` (ES XContent), which serializes `NaN` as `null`, so the error did not occur before the cutover.

Impact was systemic and not content-related (reproducible on Production/Staging/UAT), affecting custom `/api/es/search` calls and built-in Site Search.

### Fix

```java
.put("_score", finiteOrNull(hit.getScore()))
...
private static Object finiteOrNull(final float value) {
    return Float.isFinite(value) ? Float.valueOf(value) : JSONObject.NULL;
}
```

No response-shape change for finite scores; a score that previously 500'd now serializes as `"_score": null`.

### Checklist
- [x] Tests — `ESContentResourcePortletNaNScoreTest` (3 tests, all passing): `NaN` → `null`, `Infinity` → `null`, finite score preserved.
- [x] Translations — N/A (no user-facing strings).
- [x] Security Implications Contemplated — none; no schema, index, or API-contract change.

### Additional Info

**Interim workaround for affected customers (no deploy):** for client-controlled queries, add `"track_scores": true` to sorted queries so ES returns a finite score. Does **not** cover built-in Site Search — that is resolved by this patch.

Suggester `score` fields are unaffected: they carry only finite ES suggester scores and are not the reproduced path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36478