### PR TITLE
fix(ci): backend reviewer upserts a sticky comment and unblocks fixed PRs

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -95,7 +95,7 @@ jobs:
       enable_mention_detection: false
       claude_args: >-
         --allowedTools
-        "Agent,Bash(git diff*),Bash(git log*),Bash(git show*),Bash(cat CLAUDE.md*),Bash(cat docs/backend/*),Bash(cat docs/core/*),Bash(cat dotCMS/src/*),Bash(find dotCMS/src -name '*.java'*),Bash(grep -rn dotCMS/src*),Bash(gh pr comment*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/issues/comments/*),Bash(jq*)"
+        "Agent,Bash(git diff*),Bash(git log*),Bash(git show*),Bash(cat CLAUDE.md*),Bash(cat docs/backend/*),Bash(cat docs/core/*),Bash(cat dotCMS/src/*),Bash(find dotCMS/src -name '*.java'*),Bash(grep -rn dotCMS/src*),Bash(gh pr comment*),Bash(gh pr review*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/issues/comments/*),Bash(jq*)"
       prompt: |
         You are the orchestrator of a dotCMS backend code review pipeline.
         Your job is to coordinate specialized sub-agents, collect their findings,
@@ -264,8 +264,11 @@ jobs:
 
         ## STEP 6 — Submit a formal GitHub review
 
-        After posting the comment, submit a formal PR review so that merging is
-        blocked until Critical or High findings are resolved.
+        After upserting the comment, submit a formal PR review so that merging is
+        blocked while Critical or High findings remain, and unblocked once they
+        are resolved. Always submit a review on every run: this reviewer's latest
+        review supersedes its previous one, so a later --approve automatically
+        clears an earlier --request-changes once the findings are fixed.
 
         Check whether the review body contains any Critical or High findings:
 

--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -253,8 +253,13 @@ jobs:
         existing marker comment when one exists and only creates a new comment on
         the first run. Do not skip it, even when the result is "no issues found":
 
-          EXISTING_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --paginate --jq '[.[] | select(.body | contains("<!-- dotcms-backend-review -->"))] | last | .id')
-          if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
+          # Emit one bare id per matching comment and take the last globally with
+          # tail -n1. Do NOT use an aggregate jq filter (e.g. `[...] | last`) here:
+          # with --paginate, gh runs --jq once PER PAGE and concatenates, so an
+          # aggregate returns a per-page result and non-matching pages emit `null`,
+          # yielding a multi-line EXISTING_ID that breaks the PATCH on busy PRs.
+          EXISTING_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --paginate --jq '.[] | select(.body | contains("<!-- dotcms-backend-review -->")) | .id' | tail -n1)
+          if [ -n "$EXISTING_ID" ]; then
             gh api repos/${{ github.repository }}/issues/comments/$EXISTING_ID --method PATCH -F body=@/tmp/dotcms_review_body.md
             echo "Updated existing backend-review comment $EXISTING_ID"
           else

--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -210,15 +210,21 @@ jobs:
            do NOT treat it as NO_FINDINGS. Instead include a warning in the comment:
            ⚠️ **<Domain> review unavailable** — sub-agent failed, manual review required for this area.
 
-        ## STEP 5 — Post a single PR comment
+        ## STEP 5 — Upsert a single sticky PR comment
 
-        Write the full review body to a temp file, then post it with --body-file.
-        This avoids any risk of shell injection from delimiter collisions.
+        Keep exactly ONE backend-review comment per PR and edit it in place on
+        every run, so it always reflects the CURRENT state of the branch. This is
+        mandatory: when a push resolves earlier findings, the previous comment
+        must be updated (to the smaller finding set, or to "no issues found") —
+        never leave a stale comment showing findings that have already been fixed.
+
+        Write the full review body to a temp file first (posting with a file
+        avoids any risk of shell injection from delimiter collisions).
 
         Write findings to /tmp/dotcms_review_body.md using this format.
         The FIRST LINE must always be exactly: <!-- dotcms-backend-review -->
-        This marker is invisible in GitHub's rendered markdown and identifies this
-        as a dotCMS backend review comment.
+        This marker is invisible in GitHub's rendered markdown and is how you
+        find the existing comment to edit on later runs.
 
         <!-- dotcms-backend-review -->
         ## 🔍 dotCMS Backend Review
@@ -237,16 +243,24 @@ jobs:
         **Next steps**
         - 🔴 / 🟠 Fix locally and push — these need your judgment
         - 🟡 You can ask me to handle mechanical fixes inline: `@claude fix <issue description> in <File.java>`
-        - Every new push triggers a fresh review automatically
-
-        Then post it as a new comment (each push gets its own comment for a historical record):
-
-          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/dotcms_review_body.md
+        - Every new push updates this comment automatically
 
         If ALL agents returned NO_FINDINGS, write this to /tmp/dotcms_review_body.md instead:
           <!-- dotcms-backend-review -->
           ✅ **dotCMS Backend Review**: no issues found.
-        Then post it the same way.
+
+        Then UPSERT the comment. Always run this exact logic — it edits the
+        existing marker comment when one exists and only creates a new comment on
+        the first run. Do not skip it, even when the result is "no issues found":
+
+          EXISTING_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --paginate --jq '[.[] | select(.body | contains("<!-- dotcms-backend-review -->"))] | last | .id')
+          if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/$EXISTING_ID --method PATCH -F body=@/tmp/dotcms_review_body.md
+            echo "Updated existing backend-review comment $EXISTING_ID"
+          else
+            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/dotcms_review_body.md
+            echo "Created backend-review comment"
+          fi
 
         ## STEP 6 — Submit a formal GitHub review
 


### PR DESCRIPTION
### Proposed Changes
Fixes two problems with the **Claude Backend Code Reviewer** workflow (`.github/workflows/ai_claude-backend-reviewer.yml`) where the reviewer failed to reflect that reported issues had been fixed:

* **Sticky comment (STEP 5).** The reviewer posted a brand-new comment on every push and never updated the previous one, so once a push resolved the findings the stale comment kept showing already-fixed 🟠/🔴 issues, and the clean "no issues found" state was posted unreliably. It now **upserts a single comment** identified by the hidden `<!-- dotcms-backend-review -->` marker — editing it in place (`PATCH /issues/comments/{id}`) and creating one only on the first run. The upsert always runs, including when the result is "no issues found", so the comment always reflects the current state of the branch. No allowlist change was needed for this (listing + PATCHing issue comments were already permitted).

* **Formal review could never run (STEP 6).** STEP 6 already approves when no Critical/High findings remain — which supersedes a prior `--request-changes` and unblocks the PR — but `gh pr review` was never in the orchestrator's `allowedTools`, so the step was silently blocked and PRs stayed blocked even after fixes. Added `Bash(gh pr review*)` to `allowedTools` and clarified STEP 6 that the reviewer's latest review supersedes its previous one.

### Root cause
The prompt instructed *"post it as a new comment (each push gets its own comment for a historical record)"* with the clean-path as a weak secondary clause, and `gh pr review` was omitted from the sandbox allowlist.

### Checklist
- [ ] Tests
- [ ] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
**Security note:** no expansion of the sandbox beyond formal PR reviews. The comment upsert reuses the already-permitted `gh api .../issues/comments/*` scope; the only new capability is `gh pr review`, needed for the merge-gating that STEP 6 already intends to perform.

**Caveat to verify:** the STEP 6 `--approve` path also depends on the org/repo setting *"Allow GitHub Actions to create and approve pull requests."* If that setting is off, the bot's approve may still be rejected by GitHub regardless of the allowlist; the `--request-changes` path is unaffected. Worth confirming during rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)