### PR TITLE
fix(experiments): Bring back functionallity of variants inside/outside UVE

### DIFF
--- a/core-web/libs/sdk/experiments/src/lib/components/DotExperimentsProvider.tsx
+++ b/core-web/libs/sdk/experiments/src/lib/components/DotExperimentsProvider.tsx
@@ -37,9 +37,20 @@ export const DotExperimentsProvider = ({
         if (!insideEditor) {
             const dotExperimentsInstance = DotExperiments.getInstance(config);
 
-            dotExperimentsInstance.ready().then(() => {
-                setInstance(dotExperimentsInstance);
-            });
+            dotExperimentsInstance
+                .ready()
+                .catch((error) => {
+                    if (config.debug) {
+                        console.error(
+                            'DotExperimentsProvider: failed to initialize DotExperiments instance.',
+                            error
+                        );
+                    }
+                })
+                .finally(() => {
+                    // Expose the instance even on failure, so consumers stop waiting and render.
+                    setInstance(dotExperimentsInstance);
+                });
         } else {
             if (config.debug) {
                 console.warn(

--- a/core-web/libs/sdk/experiments/src/lib/hooks/useExperimentVariant.spec.tsx
+++ b/core-web/libs/sdk/experiments/src/lib/hooks/useExperimentVariant.spec.tsx
@@ -50,6 +50,21 @@ describe('useExperimentVariant', () => {
             expect(shouldWaitForVariant).toBe(false);
         });
 
+        it(' if is inside UVE in PREVIEW mode (not just EDIT)', () => {
+            const mockData = {
+                runningExperimentId: '1',
+                viewAs: { variantId: '1' }
+            } as DotCMSPageAsset;
+
+            jest.spyOn(uve, 'getUVEState').mockReturnValue({ mode: UVE_MODE.PREVIEW } as UVEState);
+
+            const { result } = renderHook(() => useExperimentVariant(mockData));
+
+            const { shouldWaitForVariant } = result.current;
+
+            expect(shouldWaitForVariant).toBe(false);
+        });
+
         it(' if `runningExperimentId` is undefined', () => {
             const mockData = {
                 viewAs: { variantId: EXPERIMENT_DEFAULT_VARIANT_NAME }

--- a/core-web/libs/sdk/experiments/src/lib/hooks/useExperimentVariant.ts
+++ b/core-web/libs/sdk/experiments/src/lib/hooks/useExperimentVariant.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
 
-import { DotCMSPageAsset, UVE_MODE } from '@dotcms/types';
+import { DotCMSPageAsset } from '@dotcms/types';
 import { getUVEState } from '@dotcms/uve';
 
 import DotExperimentsContext from '../contexts/DotExperimentsContext';
@@ -29,7 +29,8 @@ export const useExperimentVariant = (data: DotCMSPageAsset): { shouldWaitForVari
     const [shouldWaitForVariant, setShouldWaitForVariant] = useState<boolean>(true);
 
     useEffect(() => {
-        const isInsideEditor = getUVEState()?.mode === UVE_MODE.EDIT;
+        // Any UVE mode counts as "inside the editor" - must match DotExperimentsProvider's check.
+        const isInsideEditor = !!getUVEState()?.mode;
 
         if (isInsideEditor || !runningExperimentId) {
             setShouldWaitForVariant(false);

--- a/core-web/libs/sdk/react/src/lib/next/__test__/hook/useEditableDotCMSPage.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/hook/useEditableDotCMSPage.test.tsx
@@ -79,6 +79,35 @@ describe('useEditableDotCMSPage', () => {
         expect(mockUnsubscribe).toHaveBeenCalled();
     });
 
+    test('should sync to a new pageResponse prop outside UVE (e.g. after client-side navigation)', () => {
+        getUVEStateMock.mockReturnValue(undefined);
+
+        const { result, rerender } = renderHook(
+            ({ pageResponse }) => useEditableDotCMSPage(pageResponse),
+            { initialProps: { pageResponse: mockPageResponse } }
+        );
+
+        expect(result.current).toEqual(mockPageResponse);
+
+        const navigatedPageResponse = {
+            pageAsset: {
+                page: {
+                    pageURI: '/test-page',
+                    title: 'Test Page',
+                    metadata: {}
+                }
+            },
+            content: {
+                testContent: [{ title: 'Navigated Item' }]
+            },
+            graphql: {}
+        } as DotCMSPageResponse;
+
+        rerender({ pageResponse: navigatedPageResponse });
+
+        expect(result.current).toEqual(navigatedPageResponse);
+    });
+
     test('should update editable page when content changes are received', () => {
         getUVEStateMock.mockReturnValue({ mode: 'EDIT' });
 

--- a/core-web/libs/sdk/react/src/lib/next/hooks/useEditableDotCMSPage.ts
+++ b/core-web/libs/sdk/react/src/lib/next/hooks/useEditableDotCMSPage.ts
@@ -104,6 +104,12 @@ export const useEditableDotCMSPage = <T extends DotCMSExtendedPageResponse>(
 
     useEffect(() => {
         if (!getUVEState()) {
+            // Outside UVE, state only ever comes from props - keep it in sync with
+            // whatever pageResponse the parent re-renders with (e.g. after a client-side
+            // navigation refetches page data), since the initial useState value above is
+            // otherwise frozen after the first render.
+            setUpdatedPageResponse(pageResponse);
+
             return;
         }
 


### PR DESCRIPTION
fix(experiments): enhance DotExperimentsProvider initialization and improve useExperimentVariant logic

https://github.com/user-attachments/assets/be76ef08-1f35-45e4-b40d-30d8b63fd620


### Proposed Changes
- Updated `DotExperimentsProvider` to handle initialization errors gracefully by logging them in debug mode and ensuring the instance is set regardless of success or failure.
- Modified `useExperimentVariant` to consider any UVE mode as "inside the editor," aligning its logic with the updated provider check.
- Added a new test case for `useExperimentVariant` to verify behavior when in PREVIEW mode.

### Impact
These changes improve the robustness of the experiments handling and ensure that the application can render correctly even if the DotExperiments instance fails to initialize.

### Checklist
- [x] Tests updated for new behavior
- [x] Debug logging added for error handling

This PR fixes: #36484

This PR fixes: #36484