### PR TITLE
fix(index): deactivateIndex must not orphan the OS store when the last index is removed (#36501)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -3127,25 +3127,9 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     public void deactivateIndex(String indexName) throws DotDataException, IOException {
         if (isMigrationComplete()) {
             // ── Phase 3: OS only ─────────────────────────────────────────────
-            // Copy all existing OS slots, skipping the one being deactivated.
-            // An unset slot defaults to Optional.empty() in VersionedIndicesImpl.
-            // Failure is fatal: this is the primary store, not a shadow copy.
-            final Optional<VersionedIndices> osExisting =
-                    versionedIndicesAPI.loadDefaultVersionedIndices();
-            final VersionedIndicesImpl.Builder osBuilder = VersionedIndicesImpl.builder();
-            if (!IndexType.WORKING.is(indexName)) {
-                osExisting.flatMap(VersionedIndices::working).ifPresent(osBuilder::working);
-            }
-            if (!IndexType.LIVE.is(indexName)) {
-                osExisting.flatMap(VersionedIndices::live).ifPresent(osBuilder::live);
-            }
-            if (!IndexType.REINDEX_WORKING.is(indexName)) {
-                osExisting.flatMap(VersionedIndices::reindexWorking).ifPresent(osBuilder::reindexWorking);
-            }
-            if (!IndexType.REINDEX_LIVE.is(indexName)) {
-                osExisting.flatMap(VersionedIndices::reindexLive).ifPresent(osBuilder::reindexLive);
-            }
-            versionedIndicesAPI.saveIndices(osBuilder.build());
+            // Rebuild the OS store without the deactivated slot. Failure is fatal:
+            // this is the primary store, not a shadow copy, so it propagates.
+            mirrorDeactivateToOsStore(indexName);
             return;
         }
 
@@ -3164,30 +3148,51 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         legacyIndiciesAPI.point(builder.build());
 
         // ── OS mirror (Phases 1 and 2, best-effort) ──────────────────────────
-        // Copy all existing OS slots, skipping the slot that matches the deactivated index type.
-        // Failure is non-fatal: OS is a shadow copy during these phases.
+        // Rebuild the OS store without the deactivated slot. Failure is non-fatal:
+        // OS is a shadow copy during these phases, so it is logged and swallowed.
         if (isMigrationStarted()) {
             try {
-                final Optional<VersionedIndices> osExisting =
-                        versionedIndicesAPI.loadDefaultVersionedIndices();
-                final VersionedIndicesImpl.Builder osBuilder = VersionedIndicesImpl.builder();
-                if (!IndexType.WORKING.is(indexName)) {
-                    osExisting.flatMap(VersionedIndices::working).ifPresent(osBuilder::working);
-                }
-                if (!IndexType.LIVE.is(indexName)) {
-                    osExisting.flatMap(VersionedIndices::live).ifPresent(osBuilder::live);
-                }
-                if (!IndexType.REINDEX_WORKING.is(indexName)) {
-                    osExisting.flatMap(VersionedIndices::reindexWorking).ifPresent(osBuilder::reindexWorking);
-                }
-                if (!IndexType.REINDEX_LIVE.is(indexName)) {
-                    osExisting.flatMap(VersionedIndices::reindexLive).ifPresent(osBuilder::reindexLive);
-                }
-                versionedIndicesAPI.saveIndices(osBuilder.build());
+                mirrorDeactivateToOsStore(indexName);
             } catch (Exception e) {
                 Logger.warn(this, "Could not mirror index deactivation to OS store for index: "
                         + indexName, e);
             }
+        }
+    }
+
+    /**
+     * Rebuilds the OS {@link VersionedIndices} store, keeping every slot except the one that
+     * matches {@code indexName}, and persists the result.
+     *
+     * <p>When the deactivated slot was the last populated one the rebuilt record is empty, and
+     * {@link com.dotcms.content.index.VersionedIndicesAPI#saveIndices} rejects it by contract
+     * ("At least one index must be specified"). Persisting it naively would either throw
+     * (phase 3, primary store) or — worse — leave a dangling/stale store row that
+     * {@code initOSCatchup} would treat as authoritative on the next restart. So an empty
+     * rebuild removes the version row instead. This mirrors the guard in
+     * {@link #clearOsStorePointer(String)} (issue #35640).</p>
+     */
+    private void mirrorDeactivateToOsStore(final String indexName) throws DotDataException {
+        final Optional<VersionedIndices> osExisting =
+                versionedIndicesAPI.loadDefaultVersionedIndices();
+        final VersionedIndicesImpl.Builder osBuilder = VersionedIndicesImpl.builder();
+        if (!IndexType.WORKING.is(indexName)) {
+            osExisting.flatMap(VersionedIndices::working).ifPresent(osBuilder::working);
+        }
+        if (!IndexType.LIVE.is(indexName)) {
+            osExisting.flatMap(VersionedIndices::live).ifPresent(osBuilder::live);
+        }
+        if (!IndexType.REINDEX_WORKING.is(indexName)) {
+            osExisting.flatMap(VersionedIndices::reindexWorking).ifPresent(osBuilder::reindexWorking);
+        }
+        if (!IndexType.REINDEX_LIVE.is(indexName)) {
+            osExisting.flatMap(VersionedIndices::reindexLive).ifPresent(osBuilder::reindexLive);
+        }
+        final VersionedIndices osRebuilt = osBuilder.build();
+        if (osRebuilt.hasAnyIndex()) {
+            versionedIndicesAPI.saveIndices(osRebuilt);
+        } else {
+            versionedIndicesAPI.removeVersion(VersionedIndices.OPENSEARCH_3X);
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/OpenSearchUpgradeSuite.java
+++ b/dotcms-integration/src/test/java/com/dotcms/OpenSearchUpgradeSuite.java
@@ -1,5 +1,6 @@
 package com.dotcms;
 
+import com.dotcms.content.elasticsearch.business.DeactivateIndexEmptyStoreIT;
 import com.dotcms.content.elasticsearch.business.MigrationPhaseStoreBootstrapIT;
 import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplPhaseSwitchIntegrationTest;
 import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplMidReindexRollbackIT;
@@ -52,6 +53,7 @@ import org.junit.runners.Suite.SuiteClasses;
         ContentletIndexAPIImplPhaseSwitchIntegrationTest.class,
         ContentletIndexAPIImplMidReindexRollbackIT.class,
         MigrationPhaseStoreBootstrapIT.class,
+        DeactivateIndexEmptyStoreIT.class,
         OSSearchAPIImplIntegrationTest.class,
         OSSiteSearchAPIIntegrationTest.class,
         SiteSearchDualWriteRouterIT.class

--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/DeactivateIndexEmptyStoreIT.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/DeactivateIndexEmptyStoreIT.java
@@ -1,0 +1,126 @@
+package com.dotcms.content.elasticsearch.business;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.DataProviderWeldRunner;
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.content.index.IndexConfigHelper.MigrationPhase;
+import com.dotcms.content.index.VersionedIndices;
+import com.dotcms.content.index.VersionedIndicesAPI;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotcms.util.MigrationPhaseStoreBootstrap;
+import com.dotcms.util.MigrationPhaseStoreBootstrap.OpenSearchPhaseStore;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.util.Logger;
+import io.vavr.control.Try;
+import java.util.Optional;
+import javax.enterprise.context.ApplicationScoped;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Regression test for issue #36501: {@link ContentletIndexAPIImpl#deactivateIndex(String)} must
+ * handle the case where the deactivated slot was the <em>last</em> populated one in the OpenSearch
+ * {@link VersionedIndices} store.
+ *
+ * <h2>The bug</h2>
+ * <p>When the last populated slot is removed, the rebuilt {@code VersionedIndices} is empty, and
+ * {@code VersionedIndicesAPI.saveIndices} rejects it by contract ("At least one index must be
+ * specified"). Before the fix that meant:</p>
+ * <ul>
+ *   <li><strong>Phase 3</strong> (OS primary, no try/catch): the exception propagated and
+ *       {@code deactivateIndex} failed hard.</li>
+ *   <li><strong>Phases 1/2</strong> (best-effort OS mirror): the exception was swallowed with a
+ *       warning, leaving a <em>stale/dangling</em> store row that {@code initOSCatchup} would treat
+ *       as authoritative on the next restart.</li>
+ * </ul>
+ *
+ * <p>The fix removes the version row instead of saving an empty record (parity with
+ * {@code clearOsStorePointer}, issue #35640).</p>
+ *
+ * <h2>Environment</h2>
+ * <p>Runs in the single-cluster {@code opensearch-upgrade} profile. {@code deactivateIndex} only
+ * touches the DB-backed index stores (IndiciesInfo + VersionedIndices) and OS index admin — no ES
+ * content bulk writes — so it is unaffected by the single-cluster ES-against-OS-3.x limitation.</p>
+ *
+ * <pre>
+ *   ./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false \
+ *       -Dopensearch.upgrade.test=true -Dit.test=DeactivateIndexEmptyStoreIT
+ * </pre>
+ *
+ * @author Fabrizzio Araya
+ */
+@ApplicationScoped
+@RunWith(DataProviderWeldRunner.class)
+public class DeactivateIndexEmptyStoreIT extends IntegrationTestBase {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * PHASE 3: deactivating the last populated slot must NOT throw (before the fix it did) and must
+     * leave no dangling working/live pointer in the OS store.
+     */
+    @Test
+    public void deactivateLastIndex_phase3_doesNotThrow_andClearsStore() throws Exception {
+        assertDeactivateLastIndexHandlesEmptyStore(MigrationPhase.PHASE_3_OPENSEARCH_ONLY);
+    }
+
+    /**
+     * PHASE 1: deactivating the last populated slot must leave no stale OS store row (before the fix
+     * the swallowed exception left the row pointing at the just-deactivated index).
+     */
+    @Test
+    public void deactivateLastIndex_phase1_leavesNoStaleStoreRow() throws Exception {
+        assertDeactivateLastIndexHandlesEmptyStore(MigrationPhase.PHASE_1_DUAL_WRITE_ES_READS);
+    }
+
+    private void assertDeactivateLastIndexHandlesEmptyStore(final MigrationPhase phase)
+            throws Exception {
+
+        final OpenSearchPhaseStore store = MigrationPhaseStoreBootstrap.openForPhase(phase);
+        final ContentletIndexAPI indexAPI = APILocator.getContentletIndexAPI();
+        final VersionedIndicesAPI versionedIndicesAPI = APILocator.getVersionedIndicesAPI();
+
+        final String timeStamp = String.valueOf(System.currentTimeMillis());
+        final String workingIndex = IndexType.WORKING.getPrefix() + "_" + timeStamp;
+        final String liveIndex = IndexType.LIVE.getPrefix() + "_" + timeStamp;
+
+        try {
+            // Create + activate a working and live index so the OS store points only at them.
+            assertTrue(indexAPI.createContentIndex(workingIndex));
+            indexAPI.activateIndex(workingIndex);
+            assertTrue(indexAPI.createContentIndex(liveIndex));
+            indexAPI.activateIndex(liveIndex);
+
+            // Deactivate working: the store still has live, so it is non-empty — no throw.
+            indexAPI.deactivateIndex(workingIndex);
+
+            // Deactivate live: this removes the LAST populated slot. Before the fix this threw
+            // (phase 3) or left a stale row (phase 1). After the fix the version row is removed.
+            indexAPI.deactivateIndex(liveIndex);
+
+            // The OS versioned store must not carry a dangling working/live pointer. When the fix
+            // removed the version row, loadDefaultVersionedIndices() is empty and the assertions
+            // below are vacuously satisfied.
+            final Optional<VersionedIndices> after =
+                    versionedIndicesAPI.loadDefaultVersionedIndices();
+            after.ifPresent(vi -> {
+                assertFalse("working slot must be cleared after deactivating the last index",
+                        vi.working().isPresent());
+                assertFalse("live slot must be cleared after deactivating the last index",
+                        vi.live().isPresent());
+            });
+
+            Logger.info(this, "✅ deactivate-last-index handled cleanly under " + phase);
+        } finally {
+            Try.run(() -> indexAPI.delete(workingIndex));
+            Try.run(() -> indexAPI.delete(liveIndex));
+            store.close();
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Fixes the first product finding tracked in #36501, surfaced while enabling phased integration runs (#36320).

`ContentletIndexAPIImpl.deactivateIndex(String)` rebuilds the OpenSearch `VersionedIndices` store without the deactivated slot. When that slot was the **last populated one**, the rebuilt record is empty and `VersionedIndicesAPI.saveIndices` rejects it by contract (*"At least one index must be specified"*). Under a non-zero migration phase this caused:

| Site | Phase | Before |
|---|---|---|
| phase-3 branch | 3 (OS primary, no try/catch) | exception **propagated** → `deactivateIndex` failed hard 🔴 |
| phase-1/2 branch | 1 & 2 (best-effort mirror) | exception swallowed → **stale/dangling store row** left behind 🟠 (same failure mode as #35640) |

The stale row is exactly what `clearOsStorePointer` was written to prevent for #35640: on the next restart `initOSCatchup` would treat it as authoritative and recreate the deleted index empty.

### Fix
- Extract the OS-mirror rebuild into a shared private helper `mirrorDeactivateToOsStore(indexName)`, deduplicating the near-identical phase-3 and phase-1/2 blocks.
- The helper applies the same guard as `clearOsStorePointer`: if the rebuild is empty, **remove the version row** (`removeVersion(OPENSEARCH_3X)`) instead of saving an empty record. This gives the OS versioned store the same "empty = OK" semantics the legacy ES path already has.

### Test
- `DeactivateIndexEmptyStoreIT` (registered in `OpenSearchUpgradeSuite`) — deactivates the last index under **phase 3** (asserts no throw + store cleared) and **phase 1** (asserts no stale row). Verified locally: `Tests run: 2, Failures: 0`.

## Checklist
- [x] Regression IT added and passing (`opensearch-upgrade` profile).
- [x] Core compiles; IT green end-to-end locally.
- [x] Behavior parity with the existing `clearOsStorePointer` #35640 guard.

Related: #36501 (tracking), #36320 (phase-testing tooling), #35640 (original store-pointer guard).

This PR fixes: #36501