### PR TITLE
fix(osgi): restart on live-export state, not the shared upload folder (#36434)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
@@ -2,6 +2,7 @@ package com.dotcms.rest.api.v1.osgi;
 
 import com.dotcms.rest.ResponseEntityBooleanView;
 import com.dotcms.rest.ResponseEntityListView;
+import com.dotcms.rest.ResponseEntitySetStringView;
 import com.dotcms.rest.ResponseEntityStringView;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
@@ -662,7 +663,7 @@ public class OSGIResource {
                                     + "OSGI_BUNDLES_LOADED / OSGI_BUNDLES_UPLOAD_FAILED system events for "
                                     + "the outcome.",
                             content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseEntityStringView.class))),
+                                    schema = @Schema(implementation = ResponseEntitySetStringView.class))),
                     @ApiResponse(responseCode = "403", description = "Can not access the upload folder or invalid OSGI Upload request"),
             })
     public final Response uploadBundles(@Context final HttpServletRequest request,

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
@@ -718,7 +718,7 @@ public class OSGIResource {
         // refresh strategy is running by schedule job
         OSGIUtil.getInstance().checkUploadFolder();
 
-        return Response.ok(new ResponseEntityView<>(
+        return Response.ok(new ResponseEntitySetStringView(
                 files.stream().map(File::getName).collect(Collectors.toSet())))
                 .build();
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
@@ -624,7 +624,14 @@ public class OSGIResource {
     }
     
     /**
-     * This endpoint receives multiples jar files in order to upload to the osgi.
+     * This endpoint receives multiple jar files in order to upload them to the OSGi framework.
+     * <p>
+     * The response returns as soon as the jars are copied and processing is scheduled. If the
+     * uploaded plugins require new exported packages, the OSGi framework is restarted cluster-wide
+     * <strong>asynchronously</strong> after this method returns, so a {@code 200} confirms the upload
+     * was accepted, not that the plugin is live. Callers should react to the {@code OSGI_FRAMEWORK_RESTART}
+     * and {@code OSGI_BUNDLES_LOADED} system events for completion, and {@code OSGI_BUNDLES_UPLOAD_FAILED}
+     * for asynchronous failures.
      *
      * @param request
      * @param response
@@ -638,9 +645,22 @@ public class OSGIResource {
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(summary = "Upload bundles to the OSGI framework",
+            description = "Uploads one or more plugin JARs to the OSGi upload folder and schedules "
+                    + "their processing. A 200 confirms the upload was accepted, NOT that the plugin "
+                    + "is live: if new packages must be exported the OSGi framework is restarted "
+                    + "cluster-wide asynchronously, after this response returns. Restart completion is "
+                    + "signalled by the OSGI_FRAMEWORK_RESTART system event and successful deployment by "
+                    + "the OSGI_BUNDLES_LOADED event; an asynchronous failure is reported via the "
+                    + "OSGI_BUNDLES_UPLOAD_FAILED event and an error notification (check the server logs "
+                    + "for the full stack trace). Clients should react to these events rather than "
+                    + "assume the plugin is active once the 200 is received.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
+                            description = "Bundle upload accepted and scheduled. Any required OSGi "
+                                    + "restart happens asynchronously; watch the OSGI_FRAMEWORK_RESTART / "
+                                    + "OSGI_BUNDLES_LOADED / OSGI_BUNDLES_UPLOAD_FAILED system events for "
+                                    + "the outcome.",
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = ResponseEntityStringView.class))),
                     @ApiResponse(responseCode = "403", description = "Can not access the upload folder or invalid OSGI Upload request"),

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGISystem.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGISystem.java
@@ -36,6 +36,7 @@ public class OSGISystem {
     private static final String AUTO_DEPLOY_DIR_PROPERTY = AutoProcessor.AUTO_DEPLOY_DIR_PROPERTY;
     private static final String FELIX_FILEINSTALL_DIR = "felix.fileinstall.dir";
     private static final String FELIX_UNDEPLOYED_DIR = "felix.undeployed.dir";
+    private static final String FELIX_LOG_LEVEL = "felix.log.level";
     private static final String UTF_8 = "utf-8";
     private static final String PROPERTY_OSGI_PACKAGES_EXTRA = "org.osgi.framework.system.packages.extra";
     private final Framework felixFramework;
@@ -91,7 +92,8 @@ public class OSGISystem {
         felixProps.put("felix.fileinstall.log.level", "3");
         felixProps.put("org.osgi.framework.startlevel.beginning", "2");
         felixProps.put("org.osgi.framework.storage.clean", "onFirstInit");
-        felixProps.put("felix.log.level", "3");
+        // felix.log.level: 1=ERROR, 2=WARNING, 3=INFO, 4=DEBUG.
+        felixProps.put(FELIX_LOG_LEVEL, Config.getStringProperty("system." + FELIX_LOG_LEVEL, "3"));
         felixProps.put("felix.fileinstall.disableNio2", "true");
         felixProps.put("gosh.args", "--noi");
 

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -13,6 +13,7 @@ import com.dotcms.dotpubsub.DotPubSubProvider;
 import com.dotcms.dotpubsub.DotPubSubProviderLocator;
 import com.dotcms.rest.ErrorEntity;
 import com.dotcms.util.ReturnableDelegate;
+import com.dotcms.util.VoidDelegate;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.osgi.HostActivator;
@@ -220,14 +221,39 @@ public class OSGIUtil {
         if(UtilMethods.isEmpty(extraPackages)) {
             return ;
         }
-        
-        if("RESET".equals(extraPackages)) {
-            new File(OSGIUtil.getInstance().getOsgiExtraConfigPath()).delete();
-            debouncer.debounce("restartOsgi", this::restartOsgi, delay, TimeUnit.MILLISECONDS);
-            return;
+
+        final boolean reset = "RESET".equals(extraPackages);
+
+        // Validate before locking: the dry-run is a pure validation with no side effects, so it stays
+        // outside the cluster lock (keeps the lock hold short and preserves the OsgiException the REST
+        // layer maps to a 400).
+        if (!reset && Config.getBooleanProperty("OSGI_TEST_DRY_RUN", true) && testDryRun) {
+            this.testDryRun(extraPackages);
         }
 
-        this.persistOsgiExtras(extraPackages, testDryRun);
+        // Serialize osgi-extra.conf mutations cluster-wide under the SAME lock the upload pipeline uses
+        // (checkUploadFolder), so a manual edit / RESET on one node cannot clobber an in-progress upload
+        // merge on another node (lost update). Keeping the shared file consistent with live state is
+        // exactly what this fix is about — this closes the gap for the other writer of the file (#36434).
+        final ClusterLockManager<String> lockManager =
+                DotConcurrentFactory.getInstance().getClusterLockManager(OSGI_RESTART_LOCK_KEY);
+        try {
+            lockManager.tryClusterLock((VoidDelegate) () -> {
+                if (reset) {
+                    new File(OSGIUtil.getInstance().getOsgiExtraConfigPath()).delete();
+                } else {
+                    // Dry-run already performed above; do not repeat it inside the lock.
+                    this.persistOsgiExtras(extraPackages, false);
+                }
+            });
+        } catch (final Throwable t) {
+            // Preserve the original unchecked exception type (e.g. DotRuntimeException) so the REST
+            // layer maps it to the same response as before.
+            if (t instanceof RuntimeException) {
+                throw (RuntimeException) t;
+            }
+            throw new DotRuntimeException(getExceptionMessage(t), t);
+        }
 
         //restart OSGI after delay (manual extra-packages edit path keeps the debounce)
         debouncer.debounce("restartOsgi", this::restartOsgi, delay, TimeUnit.MILLISECONDS);
@@ -524,10 +550,14 @@ public class OSGIUtil {
                                 // admin (system event + error toast) in addition to logging full context.
                                 // This also covers failure modes restartOsgiOnlyLocal does not handle
                                 // itself (e.g. a pub/sub publish failure inside restartOsgiClusterWide).
-                                final String errorMsg = "Cluster-wide OSGI restart failed after bundle "
-                                        + "upload [" + uploadedJarNames + "]: " + getExceptionMessage(re);
-                                Logger.error(this, errorMsg, re);
-                                pushBundleUploadError(errorMsg);
+                                // Log the full detail (jar names + exception) to the server log only...
+                                Logger.error(this, "Cluster-wide OSGI restart failed after bundle upload ["
+                                        + uploadedJarNames + "]: " + getExceptionMessage(re), re);
+                                // ...but keep the broadcast generic: pushBundleUploadError notifies every
+                                // logged-in backend user (GLOBAL visibility), so jar names and exception
+                                // text must not be exposed there (#36434).
+                                pushBundleUploadError("Cluster-wide OSGI restart failed after a bundle "
+                                        + "upload. Check the dotCMS server logs for details.");
                             }
                         });
                     }

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -482,6 +482,12 @@ public class OSGIUtil {
 
                 Logger.debug(this, ()-> "****** Has found jars on upload, folder, acquiring the lock and reloading the OSGI restart *****");
 
+                // Capture the jar names now, before the reload moves them out of the upload folder, so
+                // an async restart failure can be correlated back to the upload that triggered it.
+                final String[] uploadedJars = uploadFolderFile.list(new SuffixFileFilter(".jar"));
+                final String uploadedJarNames = UtilMethods.isSet(uploadedJars)
+                        ? String.join(", ", uploadedJars) : "unknown";
+
                 try {
 
                     Logger.debug(this, () -> "Trying to lock to start the reload");
@@ -511,7 +517,7 @@ public class OSGIUtil {
                                 // This also covers failure modes restartOsgiOnlyLocal does not handle
                                 // itself (e.g. a pub/sub publish failure inside restartOsgiClusterWide).
                                 final String errorMsg = "Cluster-wide OSGI restart failed after bundle "
-                                        + "upload: " + getExceptionMessage(re);
+                                        + "upload [" + uploadedJarNames + "]: " + getExceptionMessage(re);
                                 Logger.error(this, errorMsg, re);
                                 pushBundleUploadError(errorMsg);
                             }

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -489,8 +489,11 @@ public class OSGIUtil {
                     // Under the cluster lock: read plugin(s), (re)write exports, move jars to load,
                     // and decide whether THIS node must restart. The lock is held only for that
                     // decision + move; the restart is submitted off-thread after the lock is released.
-                    final Boolean needsRestart = lockManager.tryClusterLock(
-                            (ReturnableDelegate<Boolean>) () -> this.fireReload(uploadFolderFile, testDryRun));
+                    // Bind to a typed local so the ReturnableDelegate<Boolean> overload of
+                    // tryClusterLock is selected without an inline cast.
+                    final ReturnableDelegate<Boolean> reloadTask =
+                            () -> this.fireReload(uploadFolderFile, testDryRun);
+                    final Boolean needsRestart = lockManager.tryClusterLock(reloadTask);
                     Logger.debug(this, () -> "File Reload Done");
 
                     if (Boolean.TRUE.equals(needsRestart)) {
@@ -503,9 +506,14 @@ public class OSGIUtil {
                             try {
                                 this.restartOsgiClusterWide();
                             } catch (final Exception re) {
-                                // log the full context here (the POST has already returned 200).
-                                Logger.error(this, "Cluster-wide OSGI restart failed after bundle upload: "
-                                        + getExceptionMessage(re), re);
+                                // The POST has already returned 200, so surface the async failure to the
+                                // admin (system event + error toast) in addition to logging full context.
+                                // This also covers failure modes restartOsgiOnlyLocal does not handle
+                                // itself (e.g. a pub/sub publish failure inside restartOsgiClusterWide).
+                                final String errorMsg = "Cluster-wide OSGI restart failed after bundle "
+                                        + "upload: " + getExceptionMessage(re);
+                                Logger.error(this, errorMsg, re);
+                                pushBundleUploadError(errorMsg);
                             }
                         });
                     }
@@ -583,6 +591,17 @@ public class OSGIUtil {
             this.writeExtraPackagesFiles(exportedPackagesSet, testDryRun);
             // Move the jars to the load folder while still holding the cluster lock, so the restart
             // decision returned to the caller cannot be raced away by another node emptying upload.
+            //
+            // KNOWN LIMITATION (deferred to Stage 2 — issue #36504): the jars land in the
+            // fileinstall-watched `load` folder BEFORE the async restart (see checkUploadFolder)
+            // has republished the new exports. Because `load` is shared across the cluster and
+            // fileinstall polls it continuously, there is a brief window in which a still-stale
+            // framework can auto-start a just-moved bundle before the new package is exported,
+            // producing a TRANSIENT, self-healing "osgi.wiring.package=...(version>=0.0.0)" error
+            // that clears on the pending restart. This window exists on BOTH this (origin) node and
+            // remote nodes; it is NOT the persistent "Mode A" failure this change fixes. The full
+            // remedy (node-local `load` + verify-exports-before-start / version-gated apply) is
+            // intentionally deferred to Stage 2 (#36504).
             this.moveNewBundlesToFelixLoadFolder(uploadFolderFile, pathnames);
             return true;
 

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -506,6 +506,14 @@ public class OSGIUtil {
                         Logger.info(this, () -> "Exported packages changed; scheduling cluster-wide OSGI restart");
                         // Restart off-thread so the caller (e.g. the upload POST) returns immediately.
                         DotConcurrentFactory.getInstance().getSingleSubmitter("OSGIRestart").submit(() -> {
+                            // Push the "restarting" event BEFORE the (blocking) restart so the UI shows
+                            // the spinner while it is happening. This intentionally differs from the
+                            // synchronous restartOsgi() / _restart endpoint paths, which push after the
+                            // restart returns: here the restart runs off-thread, so pushing after would
+                            // only flip the UI to "restarting" once the work is already done. A restart
+                            // FAILURE is not signalled as success — it is surfaced via
+                            // OSGI_BUNDLES_UPLOAD_FAILED (pushBundleUploadError) in the catch below, which
+                            // resets the UI state.
                             Try.run(() -> APILocator.getSystemEventsAPI()
                                     .push(SystemEventType.OSGI_FRAMEWORK_RESTART, new Payload()))
                                     .onFailure(ev -> Logger.error(OSGIUtil.this, ev.getMessage()));

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -12,6 +12,7 @@ import com.dotcms.dotpubsub.DotPubSubEvent;
 import com.dotcms.dotpubsub.DotPubSubProvider;
 import com.dotcms.dotpubsub.DotPubSubProviderLocator;
 import com.dotcms.rest.ErrorEntity;
+import com.dotcms.util.ReturnableDelegate;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.osgi.HostActivator;
@@ -93,6 +94,7 @@ public class OSGIUtil {
     private static final String FELIX_UPLOAD_DIR = "felix.upload.dir";
     private static final String FELIX_FILEINSTALL_DIR = "felix.fileinstall.dir";
     private static final String FELIX_UNDEPLOYED_DIR = "felix.undeployed.dir";
+    private static final String FELIX_LOG_LEVEL = "felix.log.level";
     private static final String FELIX_FRAMEWORK_STORAGE = org.osgi.framework.Constants.FRAMEWORK_STORAGE;
     private static final String AUTO_DEPLOY_DIR_PROPERTY =  AutoProcessor.AUTO_DEPLOY_DIR_PROPERTY;
     private static final String PROPERTY_OSGI_PACKAGES_EXTRA = "org.osgi.framework.system.packages.extra";
@@ -136,6 +138,9 @@ public class OSGIUtil {
     private Framework felixFramework;
     private String felixExtraPackagesFile;
     private WorkflowAPIOsgiService workflowOsgiService;
+
+    // Snapshot of the packages the running framework was actually started with (system.packages.extra).
+    private volatile Set<String> liveExportedPackages = new LinkedHashSet<>();
 
     //List of jar prefixes of the jars to be included in the osgi-extra.conf file
     public final List<String> portletIDsStopped = Collections.synchronizedList(new ArrayList<>());
@@ -192,7 +197,8 @@ public class OSGIUtil {
         felixProps.put("felix.fileinstall.log.level", "3");
         felixProps.put("org.osgi.framework.startlevel.beginning", "2");
         felixProps.put("org.osgi.framework.storage.clean", "onFirstInit");
-        felixProps.put("felix.log.level", "3");
+        // felix.log.level: 1=ERROR, 2=WARNING, 3=INFO, 4=DEBUG.
+        felixProps.put(FELIX_LOG_LEVEL, Config.getStringProperty(FELIX_LOG_LEVEL, "3"));
         felixProps.put("felix.fileinstall.disableNio2", "true");
         felixProps.put("gosh.args", "--noi");
 
@@ -221,6 +227,20 @@ public class OSGIUtil {
             return;
         }
 
+        this.persistOsgiExtras(extraPackages, testDryRun);
+
+        //restart OSGI after delay (manual extra-packages edit path keeps the debounce)
+        debouncer.debounce("restartOsgi", this::restartOsgi, delay, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Validates (optional dry-run) and atomically writes the given packages to the
+     * <strong>osgi-extra.conf</strong> file. Does NOT trigger a restart — callers decide how the
+     * change is applied (the upload pipeline restarts asynchronously right after; the manual REST
+     * edit path debounces).
+     */
+    private void persistOsgiExtras(final String extraPackages, final boolean testDryRun) {
+
         if (Config.getBooleanProperty("OSGI_TEST_DRY_RUN", true) && testDryRun) {
             this.testDryRun(extraPackages);
         }
@@ -238,9 +258,6 @@ public class OSGIUtil {
             throw new DotRuntimeException( e.getMessage(), e );
         }
         new File(osgiExtraFileTmp).renameTo(new File(osgiExtraFile));
-
-        //restart OSGI after delay
-        debouncer.debounce("restartOsgi", this::restartOsgi, delay, TimeUnit.MILLISECONDS);
     }
 
     public String getOsgiExtraConfigPath () {
@@ -354,13 +371,6 @@ public class OSGIUtil {
         // Verify the bundles are in the right place
         verifyBundles(felixProps);
 
-        // Set all OSGI Packages
-        final String extraPackages = getExtraOSGIPackages();
-
-
-        // Setting the OSGI extra packages property
-        felixProps.setProperty(PROPERTY_OSGI_PACKAGES_EXTRA, extraPackages);
-
         /*
         // The following is commented out since it is not affecting any OSGI functionality
         // Nevertheless the following code allows the system to include additional Felix and OSGI properties by using a
@@ -376,9 +386,19 @@ public class OSGIUtil {
         try {
 
             final String fileUploadDirectory = felixProps.getProperty(FELIX_UPLOAD_DIR);
-            // before init we have to check if any new bundle has been upload
+            // before init we check for newly uploaded bundles; this may update osgi-extra.conf,
+            // so we read the extra packages AFTER the reload to start with the complete set
+            // (avoids a boot-time package being written to the file but not exported).
             final boolean testDryRun = false; // we do not want to do test dry run when starting the osgi
             this.fireReload(new File(fileUploadDirectory), testDryRun);
+
+            // Set all OSGI Packages (read after the reload) and set the extra packages property
+            final String extraPackages = getExtraOSGIPackages();
+            felixProps.setProperty(PROPERTY_OSGI_PACKAGES_EXTRA, extraPackages);
+            // Snapshot what this node's framework is actually starting with, so the restart
+            // decision is based on live state rather than the shared osgi-extra.conf file.
+            this.liveExportedPackages = parseExportedPackages(extraPackages);
+
             // Create an instance and initialize the framework.
             FrameworkFactory factory = getFrameworkFactory();
             felixFramework = factory.newFramework(felixProps);
@@ -466,8 +486,29 @@ public class OSGIUtil {
 
                     Logger.debug(this, () -> "Trying to lock to start the reload");
                     final boolean testDryRun = true;
-                    lockManager.tryClusterLock(() -> this.fireReload(uploadFolderFile, testDryRun));
+                    // Under the cluster lock: read plugin(s), (re)write exports, move jars to load,
+                    // and decide whether THIS node must restart. The lock is held only for that
+                    // decision + move; the restart is submitted off-thread after the lock is released.
+                    final Boolean needsRestart = lockManager.tryClusterLock(
+                            (ReturnableDelegate<Boolean>) () -> this.fireReload(uploadFolderFile, testDryRun));
                     Logger.debug(this, () -> "File Reload Done");
+
+                    if (Boolean.TRUE.equals(needsRestart)) {
+                        Logger.info(this, () -> "Exported packages changed; scheduling cluster-wide OSGI restart");
+                        // Restart off-thread so the caller (e.g. the upload POST) returns immediately.
+                        DotConcurrentFactory.getInstance().getSingleSubmitter("OSGIRestart").submit(() -> {
+                            Try.run(() -> APILocator.getSystemEventsAPI()
+                                    .push(SystemEventType.OSGI_FRAMEWORK_RESTART, new Payload()))
+                                    .onFailure(ev -> Logger.error(OSGIUtil.this, ev.getMessage()));
+                            try {
+                                this.restartOsgiClusterWide();
+                            } catch (final Exception re) {
+                                // log the full context here (the POST has already returned 200).
+                                Logger.error(this, "Cluster-wide OSGI restart failed after bundle upload: "
+                                        + getExceptionMessage(re), re);
+                            }
+                        });
+                    }
                 } catch (Throwable e) {
 
                     Logger.error(this, "Error try to acquire the lock, uploadFolder: " + uploadFolderFile +
@@ -489,7 +530,7 @@ public class OSGIUtil {
         return UtilMethods.isSet(pathnames) && pathnames.length > 0;
     }
 
-    private void fireReload(final File uploadFolderFile, final boolean testDryRun) {
+    private boolean fireReload(final File uploadFolderFile, final boolean testDryRun) {
 
         Logger.info(this, ()-> "Starting the osgi reload on folder: " + uploadFolderFile);
 
@@ -514,58 +555,73 @@ public class OSGIUtil {
                 osgiUserPackages.addAll(packages);
             }
 
-            processOsgiPackages(uploadFolderFile, pathnames, osgiUserPackages, testDryRun);
+            return processOsgiPackages(uploadFolderFile, pathnames, osgiUserPackages, testDryRun);
         }
+
+        return false;
     }
-    
-    private void processOsgiPackages(final File uploadFolderFile,
+
+    private boolean processOsgiPackages(final File uploadFolderFile,
                                      final String[] pathnames,
                                      final Set<String> osgiUserPackages,
                                      final boolean testDryRun) {
         try {
 
-            final LinkedHashSet<String> exportedPackagesSet = this.getExportedPackagesAsSet();
-            
-            if (exportedPackagesSet.containsAll(osgiUserPackages)) {
+            // Compare against what THIS node's framework actually exposes right now (captured at
+            // startup), NOT the shared osgi-extra.conf file. On a cluster a peer may have already
+            // written the package to the file; that must not stop this node from restarting.
+            if (this.liveExportedPackages.containsAll(osgiUserPackages)) {
                 this.moveNewBundlesToFelixLoadFolder(uploadFolderFile, pathnames);
-                return; 
+                return false;
             }
-                
+
             Logger.info(this, "There are a new changes into the exported packages");
+            // Persist the union of the current file and the plugin packages so we never clobber a
+            // concurrent peer's additions.
+            final LinkedHashSet<String> exportedPackagesSet = this.getExportedPackagesAsSet();
             exportedPackagesSet.addAll(osgiUserPackages);
             this.writeExtraPackagesFiles(exportedPackagesSet, testDryRun);
+            // Move the jars to the load folder while still holding the cluster lock, so the restart
+            // decision returned to the caller cannot be raced away by another node emptying upload.
+            this.moveNewBundlesToFelixLoadFolder(uploadFolderFile, pathnames);
+            return true;
 
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);
             pushBundleUploadError("Failed to process OSGI bundle packages for ["
                     + String.join(", ", pathnames) + "]: " + getExceptionMessage(e));
+            return false;
         }
     }
 
     LinkedHashSet<String> getExportedPackagesAsSet() {
+        return parseExportedPackages(getExtraOSGIPackages());
+    }
 
+    private static LinkedHashSet<String> parseExportedPackages(final String extraPackages) {
         return new LinkedHashSet<>(
-                StringUtils.splitOnCommasWithQuotes(getExtraOSGIPackages()).stream()
+                StringUtils.splitOnCommasWithQuotes(extraPackages).stream()
                         .map(org.apache.commons.lang3.StringUtils::normalizeSpace)
                         .collect(Collectors.toSet()));
     }
 
-    // move all on upload folder to load, and restarts osgi.
+    // Debounced restart entry used by the manual extra-packages edit / RESET path. Moves any pending
+    // upload jars to load (there may be none for a manual edit) and then restarts unconditionally
     private void restartOsgi() {
         Logger.info(this, ()-> "Restarting OSGI");
         final File uploadPath    = new File(this.getFelixUploadPath());
         final String[] pathnames = uploadPath.list(new SuffixFileFilter(".jar"));
 
         if (UtilMethods.isSet(pathnames)) {
-
             this.moveNewBundlesToFelixLoadFolder(uploadPath, pathnames);
-
-            this.restartOsgiClusterWide();
-
-            Try.run(()->APILocator.getSystemEventsAPI()
-                    .push(SystemEventType.OSGI_FRAMEWORK_RESTART, new Payload(pathnames)))
-                    .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
         }
+
+        this.restartOsgiClusterWide();
+
+        Try.run(()->APILocator.getSystemEventsAPI()
+                .push(SystemEventType.OSGI_FRAMEWORK_RESTART,
+                        new Payload(UtilMethods.isSet(pathnames) ? pathnames : new String[0])))
+                .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
     }
 
     /**
@@ -610,7 +666,8 @@ public class OSGIUtil {
             this.stopFramework();
             this.initializeFramework();
         } catch (final RuntimeException e) {
-            final String errorMsg = "Failed to restart OSGI framework: " + getExceptionMessage(e);
+            final String errorMsg = "Failed to restart OSGI framework: " + getExceptionMessage(e)
+                    + ". Check the dotCMS server logs for the full stack trace and context.";
             Logger.error(this, errorMsg, e);
             Try.run(() -> SystemMessageEventUtil.getInstance().pushSimpleErrorEvent(
                     new ErrorEntity("osgi-framework-restart-failed", errorMsg)))
@@ -972,8 +1029,8 @@ public class OSGIUtil {
     }
 
     private void writeExtraPackagesFiles(final Set<String> packages, final boolean testDryRun) {
-
-        this.writeOsgiExtras(packagesToOrderedString(packages), testDryRun);
+        // Persist only; the upload pipeline (checkUploadFolder) submits the restart asynchronously.
+        this.persistOsgiExtras(packagesToOrderedString(packages), testDryRun);
     }
 
     /**

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -12389,7 +12389,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityStringView"
+                $ref: "#/components/schemas/ResponseEntitySetStringView"
           description: Bundle upload accepted and scheduled. Any required OSGi restart
             happens asynchronously; watch the OSGI_FRAMEWORK_RESTART / OSGI_BUNDLES_LOADED
             / OSGI_BUNDLES_UPLOAD_FAILED system events for the outcome.
@@ -33110,6 +33110,32 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SessionView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntitySetStringView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
         errors:
           type: array
           items:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -12369,6 +12369,15 @@ paths:
       tags:
       - OSGi Plugins
     post:
+      description: "Uploads one or more plugin JARs to the OSGi upload folder and\
+        \ schedules their processing. A 200 confirms the upload was accepted, NOT\
+        \ that the plugin is live: if new packages must be exported the OSGi framework\
+        \ is restarted cluster-wide asynchronously, after this response returns. Restart\
+        \ completion is signalled by the OSGI_FRAMEWORK_RESTART system event and successful\
+        \ deployment by the OSGI_BUNDLES_LOADED event; an asynchronous failure is\
+        \ reported via the OSGI_BUNDLES_UPLOAD_FAILED event and an error notification\
+        \ (check the server logs for the full stack trace). Clients should react to\
+        \ these events rather than assume the plugin is active once the 200 is received."
       operationId: uploadBundles
       requestBody:
         content:
@@ -12381,6 +12390,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Bundle upload accepted and scheduled. Any required OSGi restart
+            happens asynchronously; watch the OSGI_FRAMEWORK_RESTART / OSGI_BUNDLES_LOADED
+            / OSGI_BUNDLES_UPLOAD_FAILED system events for the outcome.
         "403":
           description: Can not access the upload folder or invalid OSGI Upload request
       summary: Upload bundles to the OSGI framework

--- a/dotcms-integration/src/test/java/org/apache/felix/framework/OSGIUtilTest.java
+++ b/dotcms-integration/src/test/java/org/apache/felix/framework/OSGIUtilTest.java
@@ -1,15 +1,28 @@
 package org.apache.felix.framework;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.osgi.HostActivator;
 import com.dotmarketing.util.Config;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 
 import com.dotmarketing.util.ResourceCollectorUtil;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -17,6 +30,9 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
 
 /**
  * OSGIUtilTest
@@ -29,7 +45,18 @@ public class OSGIUtilTest {
     private static final String FELIX_FILEINSTALL_DIR = "felix.felix.fileinstall.dir";
     private static final String FELIX_UNDEPLOYED_DIR = "felix.felix.undeployed.dir";
 
+    // Config key OSGIUtil uses to locate osgi-extra.conf; overriding it lets us control the
+    // exact set of packages the system bundle exports for a given framework (re)start.
+    private static final String OSGI_EXTRA_CONFIG_FILE_PATH_KEY = "OSGI_EXTRA_CONFIG_FILE_PATH_KEY";
+
+    // The package from Freshdesk #37894. It is NOT in the shipped osgi-extra.conf defaults
+    // (dotCMS adds it dynamically on plugin upload), so it is absent unless we export it ourselves.
+    private static final String TARGET_PACKAGE = "com.dotcms.content.index.domain";
+
     private static String felixDirectory;
+
+    // Pristine osgi-extra.conf path, captured before any test overrides it, so we can restore it.
+    private static String originalOsgiExtraPath;
 
     @BeforeClass
     public static void prepare() throws Exception {
@@ -45,6 +72,8 @@ public class OSGIUtilTest {
                 .getStringProperty(FELIX_BASE_DIR,
                         Config.CONTEXT.getRealPath(WEB_INF_FOLDER) + File.separator + "felix"))
                 .getAbsolutePath();
+
+        originalOsgiExtraPath = OSGIUtil.getInstance().getOsgiExtraConfigPath();
     }
 
     @AfterClass
@@ -238,5 +267,171 @@ public class OSGIUtilTest {
 
         final String packageString ="com.liferay.portal.model;version=0.1.0#(*%&#(*%&#(*$&#$,com.liferay.portal.util,io.vavr;version=\"0.10\",javax.servlet.http;version=\"3.1,4\"";
         OSGIUtil.getInstance().testDryRun(packageString);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Freshdesk #37894 — a plugin importing an exported package fails to resolve with
+    // "osgi.wiring.package=...;(version>=0.0.0)" even though the package IS exported as version=0.
+    // These tests prove the version value is NOT the cause: a bare version=0 export satisfies the
+    // (version>=0.0.0) requirement identically to version="0.0.0"; the failure only happens when the
+    // export is ABSENT from the running framework at resolve time. Named test_zzz_* so they run last
+    // (FixMethodOrder = NAME_ASCENDING) and never disturb the assumptions of the tests above.
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Method to test: OSGi resolution of a bundle whose imported package is not exported by the
+     * system bundle at resolve time.
+     * Given Scenario: The framework is (re)started with an osgi-extra.conf that does NOT export
+     * {@link #TARGET_PACKAGE}, then a bundle importing {@code TARGET_PACKAGE;version=0} is started.
+     * ExpectedResult: start() throws a BundleException whose message is exactly the customer's error
+     * — {@code (&(osgi.wiring.package=com.dotcms.content.index.domain)(version>=0.0.0))} — and the
+     * bundle stays INSTALLED (unresolved). This isolates the symptom to "export not live at resolve
+     * time", independent of the version string.
+     */
+    @Test
+    public void test_zzz_01_import_fails_when_package_not_exported() throws Exception {
+
+        restartWithExtraPackages(pristineExports()); // TARGET_PACKAGE deliberately absent
+        final BundleContext context = HostActivator.instance().getBundleContext();
+        assertNotNull(context);
+
+        final byte[] jar = buildBundleImporting(
+                "com.dotcms.osgitest.absent", TARGET_PACKAGE + ";version=0");
+        final Bundle bundle = context.installBundle(
+                "osgitest:absent", new ByteArrayInputStream(jar));
+        try {
+            bundle.start();
+            fail("Expected BundleException: " + TARGET_PACKAGE + " should be unresolvable");
+        } catch (final BundleException e) {
+            final String msg = e.getMessage();
+            assertTrue("Message should name the unresolved package. Was: " + msg,
+                    msg.contains(TARGET_PACKAGE));
+            assertTrue("Import version=0 should compile to a (version>=0.0.0) requirement. Was: " + msg,
+                    msg.contains("version>=0.0.0"));
+            assertEquals("Bundle must remain unresolved (INSTALLED)",
+                    Bundle.INSTALLED, bundle.getState());
+        } finally {
+            uninstallQuietly(bundle);
+            restoreOsgiExtras();
+        }
+    }
+
+    /**
+     * Method to test: OSGi resolution when the imported package IS exported as a bare {@code version=0}.
+     * Given Scenario: The framework is (re)started with an osgi-extra.conf that exports
+     * {@code TARGET_PACKAGE;version=0}, then a bundle importing {@code TARGET_PACKAGE;version=0} starts.
+     * ExpectedResult: the bundle resolves and reaches ACTIVE — proving a bare version=0 export DOES
+     * satisfy (version>=0.0.0). This is the exact scenario support could not reproduce as a failure.
+     */
+    @Test
+    public void test_zzz_02_version0_export_satisfies_requirement() throws Exception {
+
+        restartWithExtraPackages(pristineExports() + ",\n" + TARGET_PACKAGE + ";version=0");
+        final BundleContext context = HostActivator.instance().getBundleContext();
+
+        final byte[] jar = buildBundleImporting(
+                "com.dotcms.osgitest.v0", TARGET_PACKAGE + ";version=0");
+        final Bundle bundle = context.installBundle(
+                "osgitest:v0", new ByteArrayInputStream(jar));
+        try {
+            bundle.start();
+            assertEquals("version=0 export should satisfy the import and go ACTIVE",
+                    Bundle.ACTIVE, bundle.getState());
+        } finally {
+            uninstallQuietly(bundle);
+            restoreOsgiExtras();
+        }
+    }
+
+    /**
+     * Method to test: OSGi resolution when the imported package is exported as {@code version="0.0.0"}.
+     * Given Scenario: Same as the previous test but the export is written as {@code version="0.0.0"}
+     * (the customer's manual workaround value).
+     * ExpectedResult: the bundle resolves and reaches ACTIVE — behaving IDENTICALLY to the bare
+     * version=0 case, proving {@code 0} and {@code 0.0.0} are equivalent and the workaround's real
+     * effect is the framework restart it triggers, not the version string.
+     */
+    @Test
+    public void test_zzz_03_version_0_0_0_export_is_equivalent() throws Exception {
+
+        restartWithExtraPackages(pristineExports() + ",\n" + TARGET_PACKAGE + ";version=\"0.0.0\"");
+        final BundleContext context = HostActivator.instance().getBundleContext();
+
+        final byte[] jar = buildBundleImporting(
+                "com.dotcms.osgitest.v000", TARGET_PACKAGE + ";version=0");
+        final Bundle bundle = context.installBundle(
+                "osgitest:v000", new ByteArrayInputStream(jar));
+        try {
+            bundle.start();
+            assertEquals("version=\"0.0.0\" export should behave identically to version=0",
+                    Bundle.ACTIVE, bundle.getState());
+        } finally {
+            uninstallQuietly(bundle);
+            restoreOsgiExtras();
+        }
+    }
+
+    /**
+     * Reads the pristine, shipped osgi-extra.conf defaults from the classpath, independent of any
+     * override a test may have left in place. {@link #TARGET_PACKAGE} is not present in this list.
+     */
+    private static String pristineExports() throws Exception {
+        try (InputStream in = OSGIUtil.class.getResourceAsStream("/osgi/osgi-extra.conf")) {
+            assertNotNull("Default osgi-extra.conf resource must exist", in);
+            return IOUtils.toString(in, StandardCharsets.UTF_8).trim();
+        }
+    }
+
+    /**
+     * Writes the given exported-packages content to a temp osgi-extra.conf, points OSGIUtil at it via
+     * config, and restarts the framework so the system bundle re-publishes exactly these exports.
+     */
+    private static void restartWithExtraPackages(final String extraPackages) throws Exception {
+        final File confFile = File.createTempFile("osgi-extra-37894", ".conf");
+        confFile.deleteOnExit();
+        Files.write(confFile.toPath(), extraPackages.getBytes(StandardCharsets.UTF_8));
+        Config.setProperty(OSGI_EXTRA_CONFIG_FILE_PATH_KEY, confFile.getAbsolutePath());
+        restartOSGi();
+    }
+
+    /**
+     * Restores the original osgi-extra.conf path and restarts, leaving the framework in its default
+     * state for any subsequent test / teardown.
+     */
+    private static void restoreOsgiExtras() {
+        Config.setProperty(OSGI_EXTRA_CONFIG_FILE_PATH_KEY, originalOsgiExtraPath);
+        restartOSGi();
+    }
+
+    /**
+     * Builds an in-memory OSGi bundle jar (manifest only, no classes, no activator) that imports the
+     * given package header. Starting such a bundle forces OSGi to resolve the import, so an absent
+     * export surfaces as a BundleException.
+     */
+    private static byte[] buildBundleImporting(final String symbolicName, final String importPackage)
+            throws Exception {
+        final Manifest manifest = new Manifest();
+        final Attributes attrs = manifest.getMainAttributes();
+        attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attrs.putValue("Bundle-ManifestVersion", "2");
+        attrs.putValue("Bundle-SymbolicName", symbolicName);
+        attrs.putValue("Bundle-Name", symbolicName);
+        attrs.putValue("Bundle-Version", "1.0.0");
+        attrs.putValue("Import-Package", importPackage);
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (JarOutputStream jos = new JarOutputStream(bos, manifest)) {
+            // manifest-only bundle: nothing else to write
+        }
+        return bos.toByteArray();
+    }
+
+    private static void uninstallQuietly(final Bundle bundle) {
+        try {
+            if (bundle != null && bundle.getState() != Bundle.UNINSTALLED) {
+                bundle.uninstall();
+            }
+        } catch (final Exception e) {
+            //Do nothing...
+        }
     }
 }

--- a/dotcms-integration/src/test/java/org/apache/felix/framework/OSGIUtilTest.java
+++ b/dotcms-integration/src/test/java/org/apache/felix/framework/OSGIUtilTest.java
@@ -1,6 +1,7 @@
 package org.apache.felix.framework;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -12,9 +13,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
@@ -368,6 +372,112 @@ public class OSGIUtilTest {
         } finally {
             uninstallQuietly(bundle);
             restoreOsgiExtras();
+        }
+    }
+
+    /**
+     * Method to test: {@link OSGIUtil} upload-processing restart decision ({@code processOsgiPackages}).
+     * Given Scenario: a PEER cluster node has already merged {@link #TARGET_PACKAGE} into the shared
+     * {@code osgi-extra.conf}, but THIS node's framework was started without it, so its live export
+     * snapshot ({@code liveExportedPackages}) still lacks it — the exact #36434 "Mode A" cluster race.
+     * ExpectedResult: {@code processOsgiPackages} returns {@code true} (this node must restart) even
+     * though the on-disk {@code osgi-extra.conf} already lists the package. The pre-fix code compared
+     * the plugin packages against the shared FILE and would have returned {@code false} (skipping the
+     * restart, so the package was never published on this node). A control case with the package
+     * already present in the live snapshot must return {@code false} (no restart needed).
+     */
+    @Test
+    public void test_zzz_04_restart_decision_uses_live_snapshot_not_shared_file() throws Exception {
+
+        final String targetClause = TARGET_PACKAGE + ";version=0";
+
+        // Clean baseline: TARGET_PACKAGE absent from both the running framework and the conf file.
+        restartWithExtraPackages(pristineExports());
+        final File uploadDir = Files.createTempDirectory("osgi-upload-37894").toFile();
+        uploadDir.deleteOnExit();
+        try {
+            // Simulate a PEER node's write: the shared osgi-extra.conf now lists TARGET_PACKAGE, but we
+            // deliberately do NOT restart, so this node's live snapshot stays stale (without it).
+            final String confPath = OSGIUtil.getInstance().getOsgiExtraConfigPath();
+            Files.write(new File(confPath).toPath(),
+                    (pristineExports() + ",\n" + targetClause).getBytes(StandardCharsets.UTF_8));
+
+            // Precondition: the shared FILE reports the package as exported...
+            assertTrue("Precondition: shared osgi-extra.conf should now list the package",
+                    OSGIUtil.getInstance().getExportedPackagesAsSet().stream()
+                            .anyMatch(p -> p.contains(TARGET_PACKAGE)));
+            // ...while the live snapshot (what the framework actually started with) does NOT.
+            assertFalse("Precondition: live snapshot must NOT contain the package yet",
+                    liveExportedPackages().stream().anyMatch(p -> p.contains(TARGET_PACKAGE)));
+
+            // REGRESSION: live snapshot lacks the package -> this node MUST restart, even though the
+            // shared file already has it. Pre-fix (compare-against-file) returned false here => Mode A.
+            writeFragmentJar(new File(uploadDir, "peer-race-a.jar"));
+            assertTrue("Node must restart when its live framework lacks the package even though a peer "
+                            + "already wrote it to the shared osgi-extra.conf (Mode A regression)",
+                    invokeProcessOsgiPackages(uploadDir, new String[]{"peer-race-a.jar"},
+                            Set.of(targetClause)));
+
+            // CONTROL: once the live snapshot DOES export the package, no restart is needed.
+            setLiveExportedPackages(withEntry(liveExportedPackages(), targetClause));
+            writeFragmentJar(new File(uploadDir, "peer-race-b.jar"));
+            assertFalse("No restart expected when the running framework already exports the package",
+                    invokeProcessOsgiPackages(uploadDir, new String[]{"peer-race-b.jar"},
+                            Set.of(targetClause)));
+        } finally {
+            restoreOsgiExtras();
+        }
+    }
+
+    /** Reflectively reads the private {@code liveExportedPackages} snapshot for assertions. */
+    @SuppressWarnings("unchecked")
+    private static Set<String> liveExportedPackages() throws Exception {
+        final Field field = OSGIUtil.class.getDeclaredField("liveExportedPackages");
+        field.setAccessible(true);
+        return (Set<String>) field.get(OSGIUtil.getInstance());
+    }
+
+    /** Reflectively overwrites the private {@code liveExportedPackages} snapshot (control case). */
+    private static void setLiveExportedPackages(final Set<String> value) throws Exception {
+        final Field field = OSGIUtil.class.getDeclaredField("liveExportedPackages");
+        field.setAccessible(true);
+        field.set(OSGIUtil.getInstance(), value);
+    }
+
+    private static Set<String> withEntry(final Set<String> base, final String entry) {
+        final Set<String> copy = new LinkedHashSet<>(base);
+        copy.add(entry);
+        return copy;
+    }
+
+    /** Invokes the private {@code processOsgiPackages} decision method and returns its needsRestart flag. */
+    private static boolean invokeProcessOsgiPackages(final File uploadDir, final String[] pathnames,
+            final Set<String> osgiUserPackages) throws Exception {
+        final Method method = OSGIUtil.class.getDeclaredMethod(
+                "processOsgiPackages", File.class, String[].class, Set.class, boolean.class);
+        method.setAccessible(true);
+        // testDryRun=false: we assert the restart decision, not package-string validation.
+        return (boolean) method.invoke(
+                OSGIUtil.getInstance(), uploadDir, pathnames, osgiUserPackages, false);
+    }
+
+    /**
+     * Writes a minimal OSGi FRAGMENT jar to the given file. A fragment is used so the move step in
+     * {@code processOsgiPackages} deletes it (fragments are not moved to the load folder), leaving no
+     * unresolved bundle behind after the test.
+     */
+    private static void writeFragmentJar(final File dest) throws Exception {
+        final Manifest manifest = new Manifest();
+        final Attributes attrs = manifest.getMainAttributes();
+        attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attrs.putValue("Bundle-ManifestVersion", "2");
+        attrs.putValue("Bundle-SymbolicName", dest.getName().replace(".jar", ""));
+        attrs.putValue("Bundle-Version", "1.0.0");
+        // Exact value OSGIUtil/ResourceCollectorUtil.isFragmentJar recognizes, so the move step
+        // deletes this jar instead of leaving it (unresolved) in the shared load folder.
+        attrs.putValue("Fragment-Host", "system.bundle; extension:=framework");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(dest.toPath()), manifest)) {
+            // manifest-only fragment: nothing else to write
         }
     }
 


### PR DESCRIPTION
## Problem (#36434 — Stage 1 / Mode A)

On a **clustered** dotCMS (2+ nodes sharing `/data/shared`), uploading an OSGi plugin that imports a dotCMS package **not yet in the exported-packages list** could leave the plugin **permanently unresolved** on every node:

```
org.osgi.framework.BundleException: Unable to resolve <bundle>: missing requirement
  osgi.wiring.package; (&(osgi.wiring.package=<pkg>)(version>=0.0.0))
```

…even though `osgi-extra.conf` already contained `<pkg>`. This is **not** a version-string problem (`version=0` ≡ `0.0.0`); it's a **restart that was skipped on the cluster**.

### Root cause (Mode A)
Two flaws combined, both in the upload pipeline of `OSGIUtil`:
1. **The "already exported?" decision read the shared `osgi-extra.conf` file** rather than this node's running framework. When a peer node had just written the new package to that shared file, this node read it back, concluded "no restart needed," and only moved the jar.
2. **The restart trigger was gated on "is the `upload` folder still non-empty?"** The real restart ran debounced, *after* the cluster lock was released, so a peer's jar-move could empty `upload` and silently cancel it.

Net: the export was written to the shared file and the jar deployed to `load`, but **no node ever restarted** → the package was never published to any running framework → persistent resolve failure.

## Fix (Stage 1)
- **Decide against live state, not the file.** Each node snapshots the packages its framework actually started with (`liveExportedPackages`) and compares the plugin's packages against that, so a peer writing the shared file can't trick a node into skipping its restart.
- **Make the decision atomic under the cluster lock.** Writing exports + moving jars to `load` + capturing `needsRestart` all happen under `osgi_restart_lock`; the boolean can't be raced away.
- **Submit the cluster-wide restart off-thread** (single submitter) — the upload endpoint still returns immediately (matching prior behavior) and the restart starts ahead of fileinstall's next poll, so the freshly-moved jar isn't started against a still-stale framework on the origin node.
- **Remove the fragile upload-folder guard** from the debounced restart path (also fixes the manual `PUT /extra-packages` edit, which must restart even with no jar in `upload`).
- **Read exports after the boot reload** in `initializeFramework`, fixing a latent boot-with-preloaded-jars gap.

### Also included
- **`felix.log.level` is now `Config`-driven** (default `3`) so `4` can capture the Felix resolver's candidate evaluation in the field — per the issue's Diagnostics ask. dotCMS runs **two separate Felix frameworks**, so there are **two independent config keys**, one per framework (the system framework namespaces all its felix config under `system.`, matching the existing `system.felix.base.dir` pattern):

  | Framework | Class / line | Config key | Env var | Default |
  |---|---|---|---|---|
  | User / plugin | `OSGIUtil.java:201` | `felix.log.level` | `DOT_FELIX_LOG_LEVEL` | `3` |
  | System (saml, tika) | `OSGISystem.java:96` | `system.felix.log.level` | `DOT_SYSTEM_FELIX_LOG_LEVEL` | `3` |

  Levels: `1`=ERROR, `2`=WARNING, `3`=INFO, `4`=DEBUG. Set the relevant key to `4` to enable resolver DEBUG on that framework only.
- **Tier-A regression tests** in `OSGIUtilTest` proving `version=0` ≡ `0.0.0` and that the error only appears when the package is absent from the running framework.

## Verification
- `./mvnw compile -pl :dotcms-core` — BUILD SUCCESS.
- `OSGIUtilTest` — 8 run, 0 failures/errors/skipped.
- **2-node Docker cluster** sharing `/data/shared`, package absent from exports, plugin dropped into the shared `upload` folder (both pollers racing — the Mode A trigger): the origin node took the new `Restarting OSGI Cluster Wide` path, the peer restarted via pub/sub, and `com.dotcms.osgi.repro-37894d` reached **`ACTIVE` on both nodes** with **zero** `wiring.package` errors.

## Scope / follow-up
This is **Stage 1**: it eliminates the **persistent** failure (Mode A). A **transient, self-healing** window remains: because the jar is moved into the *shared*, fileinstall-watched `load` folder before the async restart republishes the new exports, a still-stale framework can briefly auto-start the bundle and log a `wiring.package=…(version>=0.0.0)` error that clears on the pending restart. This window can occur on **both the origin node and remote nodes** — it is intentionally deferred to **Stage 2** (node-local `load` + verify-exports-before-start / version-gated apply), tracked in #36504. It is documented in a code comment at the jar-move site so it isn't mistaken for an oversight. In practice the origin node's restart is submitted immediately and typically outruns fileinstall's poll (the 2-node test below saw zero errors), but the window is not formally closed until Stage 2.

Refs: #36434


This PR fixes: #36434