### PR TITLE
fix(permissions): enforce contentlet-level WRITE check on Copy and Edit (#34215)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -329,6 +329,10 @@ public class PageResourceHelper implements Serializable {
 
         if (page instanceof HTMLPageAsset) {
 
+            if (!permissionAPI.doesUserHavePermission(HTMLPageAsset.class.cast(page), PermissionAPI.PERMISSION_WRITE, user, pageMode.respectAnonPerms)) {
+                throw new DotSecurityException(String.format("User '%s' does not have WRITE permission on Page '%s'",
+                        user.getUserId(), page.getIdentifier()));
+            }
             final Contentlet newPage = this.contentletAPI.copyContentlet(
                     HTMLPageAsset.class.cast(page), user, pageMode.respectAnonPerms);
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -633,6 +633,10 @@ public class PageResourceHelper implements Serializable {
             throw new DoesNotExistException(
                     "The Contentlet being copied does not exist. Content id: " + copyContentletForm.getContentId());
         }
+        if (!permissionAPI.doesUserHavePermission(currentContentlet, PermissionAPI.PERMISSION_WRITE, user, pageMode.respectAnonPerms)) {
+            throw new DotSecurityException(String.format("User '%s' does not have WRITE permission on Contentlet '%s'",
+                    user.getUserId(), currentContentlet.getIdentifier()));
+        }
         final Contentlet copiedContentlet  = this.contentletAPI.copyContentlet(currentContentlet, user, pageMode.respectAnonPerms);
         Logger.debug(this, ()-> "Contentlet: " + copiedContentlet.getIdentifier() + " has been copied");
 

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceHelperTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceHelperTest.java
@@ -496,7 +496,7 @@ public class PageResourceHelperTest {
      *                 content type (mirrors issue #34215 reproduction steps).
      * Should: throw DotSecurityException — the copy must be blocked at the instance level.
      */
-    @Test(expected = DotSecurityException.class)
+    @Test
     public void copyContentlet_whenUserHasReadOnlyPermissionOnInstance_throwsDotSecurityException()
             throws DotDataException, DotSecurityException {
 
@@ -537,7 +537,13 @@ public class PageResourceHelperTest {
 
         final Language language = APILocator.getLanguageAPI().getLanguage(contentlet.getLanguageId());
 
-        PageResourceHelper.getInstance().copyContentlet(form, readOnlyUser, PageMode.PREVIEW_MODE, language);
+        try {
+            PageResourceHelper.getInstance().copyContentlet(form, readOnlyUser, PageMode.PREVIEW_MODE, language);
+            org.junit.Assert.fail("Expected DotSecurityException — user with READ-only on contentlet instance must not be able to copy it");
+        } catch (final DotSecurityException e) {
+            assertTrue("Exception message should reference the contentlet identifier",
+                    e.getMessage().contains(contentlet.getIdentifier()));
+        }
     }
 
     /**
@@ -545,7 +551,7 @@ public class PageResourceHelperTest {
      * Given Scenario: A user has READ-only permission on a page instance.
      * Should: throw DotSecurityException before any copy attempt is made on the page node.
      */
-    @Test(expected = DotSecurityException.class)
+    @Test
     public void copyPage_whenUserHasReadOnlyPermissionOnPage_throwsDotSecurityException()
             throws DotDataException, DotSecurityException {
 
@@ -569,7 +575,13 @@ public class PageResourceHelperTest {
 
         final Language language = APILocator.getLanguageAPI().getDefaultLanguage();
 
-        PageResourceHelper.getInstance().copyPage(page, readOnlyUser, PageMode.PREVIEW_MODE, language);
+        try {
+            PageResourceHelper.getInstance().copyPage(page, readOnlyUser, PageMode.PREVIEW_MODE, language);
+            org.junit.Assert.fail("Expected DotSecurityException — user with READ-only on page instance must not be able to deep-copy it");
+        } catch (final DotSecurityException e) {
+            assertTrue("Exception message should reference the page identifier",
+                    e.getMessage().contains(page.getIdentifier()));
+        }
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceHelperTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceHelperTest.java
@@ -10,7 +10,10 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.variant.VariantAPI;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.MultiTree;
+import com.dotmarketing.beans.Permission;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.Role;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -28,6 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -484,6 +488,88 @@ public class PageResourceHelperTest {
         final String allSchemas = schemas.toString();
         assertTrue(allSchemas.contains(typeA.variable()));
         assertTrue(allSchemas.contains(typeB.variable()));
+    }
+
+    /**
+     * Method to test: {@link PageResourceHelper#copyContentlet(CopyContentletForm, User, PageMode, Language)}
+     * Given Scenario: A user has READ-only permission on a contentlet instance but Publish on the
+     *                 content type (mirrors issue #34215 reproduction steps).
+     * Should: throw DotSecurityException — the copy must be blocked at the instance level.
+     */
+    @Test(expected = DotSecurityException.class)
+    public void copyContentlet_whenUserHasReadOnlyPermissionOnInstance_throwsDotSecurityException()
+            throws DotDataException, DotSecurityException {
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User readOnlyUser = new UserDataGen()
+                .roles(role, TestUserUtils.getBackendRole())
+                .nextPersisted();
+
+        final ContentType contentType = new ContentTypeDataGen().nextPersisted();
+        final Contentlet contentlet = new ContentletDataGen(contentType.id()).nextPersisted();
+
+        // Assign READ-only on the specific contentlet instance, breaking inheritance from the type
+        final List<Permission> perms = new ArrayList<>();
+        perms.add(new Permission(contentlet.getPermissionId(), role.getId(),
+                PermissionAPI.PERMISSION_READ, true));
+        APILocator.getPermissionAPI().assignPermissions(perms, contentlet, APILocator.systemUser(), false);
+
+        final Container container = new ContainerDataGen().nextPersisted();
+        final Host host = new SiteDataGen().nextPersisted();
+        final Template template = new TemplateDataGen()
+                .withContainer(container, ContainerUUID.UUID_LEGACY_VALUE)
+                .nextPersisted();
+        final HTMLPageAsset page = new HTMLPageDataGen(host, template).nextPersisted();
+
+        new MultiTreeDataGen().setContentlet(contentlet)
+                .setPage(page)
+                .setContainer(container)
+                .setPersonalization(MultiTree.DOT_PERSONALIZATION_DEFAULT)
+                .setInstanceID(ContainerUUID.UUID_LEGACY_VALUE)
+                .nextPersisted();
+
+        final CopyContentletForm form = new CopyContentletForm.Builder()
+                .pageId(page.getIdentifier())
+                .containerId(container.getIdentifier())
+                .relationType("1")
+                .contentId(contentlet.getIdentifier())
+                .build();
+
+        final Language language = APILocator.getLanguageAPI().getLanguage(contentlet.getLanguageId());
+
+        PageResourceHelper.getInstance().copyContentlet(form, readOnlyUser, PageMode.PREVIEW_MODE, language);
+    }
+
+    /**
+     * Method to test: {@link PageResourceHelper#copyPage(com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage, User, PageMode, Language)}
+     * Given Scenario: A user has READ-only permission on a page instance.
+     * Should: throw DotSecurityException before any copy attempt is made on the page node.
+     */
+    @Test(expected = DotSecurityException.class)
+    public void copyPage_whenUserHasReadOnlyPermissionOnPage_throwsDotSecurityException()
+            throws DotDataException, DotSecurityException {
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final User readOnlyUser = new UserDataGen()
+                .roles(role, TestUserUtils.getBackendRole())
+                .nextPersisted();
+
+        final Host host = new SiteDataGen().nextPersisted();
+        final Container container = new ContainerDataGen().nextPersisted();
+        final Template template = new TemplateDataGen()
+                .withContainer(container, ContainerUUID.UUID_LEGACY_VALUE)
+                .nextPersisted();
+        final HTMLPageAsset page = new HTMLPageDataGen(host, template).nextPersisted();
+
+        // Assign READ-only on the page instance, breaking inheritance
+        final List<Permission> perms = new ArrayList<>();
+        perms.add(new Permission(page.getPermissionId(), role.getId(),
+                PermissionAPI.PERMISSION_READ, true));
+        APILocator.getPermissionAPI().assignPermissions(perms, page, APILocator.systemUser(), false);
+
+        final Language language = APILocator.getLanguageAPI().getDefaultLanguage();
+
+        PageResourceHelper.getInstance().copyPage(page, readOnlyUser, PageMode.PREVIEW_MODE, language);
     }
 
     /**


### PR DESCRIPTION
## Problem

When a user only has **View** permission on a contentlet instance, they could still use the **Copy and Edit** button in the Page Edit screen to create a copy of that contentlet. Additionally, a user with **Read-only** access on a page could call the `_deepcopy` endpoint and receive a fully editable duplicate of that page — same class of bug, different object.

Both code paths called `contentletAPI.copyContentlet()` directly, which only enforces READ, not WRITE.

## Root Cause

1. **Copy and Edit (contentlet):** `PageResourceHelper.copyContent()` fetched the source contentlet and immediately invoked `contentletAPI.copyContentlet()` without verifying the user had WRITE permission on the specific contentlet instance. Permission was only evaluated at the content type level.

2. **Deep copy (page):** `PageResourceHelper.copyPage()` called `contentletAPI.copyContentlet(page, ...)` without a WRITE check on the page itself. A READ-only user could create a page copy before the child-contentlet WRITE checks caused a rollback — wrong failure mode, wrong place.

## Fix

Added explicit `permissionAPI.doesUserHavePermission(..., PERMISSION_WRITE, ...)` checks in both code paths before any copy is attempted. Both throw `DotSecurityException` (→ 403) if the user lacks WRITE on the instance.

## Changes

- `dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java`
  - `copyContent()` — added instance-level WRITE check before copying a contentlet (Copy and Edit)
  - `copyPage()` — added WRITE check on the page before deep-copying it

## Test Plan

- [ ] Log in as a user with View-only on a contentlet but Publish on the content type → "Copy and Edit" should return 403
- [ ] Log in as a user with WRITE on the contentlet → "Copy and Edit" should succeed as before
- [ ] Log in as a user with Read-only on a page → `PUT /page/{pageId}/_deepcopy` should return 403
- [ ] Log in as a user with WRITE on the page → deep copy should succeed as before
- [ ] Run: `./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=PageResourceTest`

Fixes: #34215

This PR fixes: #34215