### PR TITLE
fix(viewtools): keep aggregations in $json.generate() reflection JSON (#36435)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/ContentSearchResponse.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/ContentSearchResponse.java
@@ -39,22 +39,25 @@ import javax.annotation.Nullable;
  *                        sub-aggregations and {@code top_hits} preserved); Velocity resolves
  *                        {@code $results.aggregations.<name>} through this map
  */
-// {@code aggregations} is suppressed for Jackson at the CLASS level (not with a method-level
-// {@code @JsonIgnore} on {@link #getAggregations()}) on purpose: the neutral Jackson JSON must not
-// carry {@code aggregations} — the tree is already serialized as {@code aggregationTree}, and a
-// method-level {@code @JsonIgnore} would ALSO hide it from the reflection-based
+// The Velocity-only aliases {@code aggregations}, {@code tookInMillis} and {@code suggest} are
+// suppressed for Jackson at the CLASS level (not with method-level {@code @JsonIgnore} on the
+// getters) on purpose. Each is redundant on the neutral Jackson wire (the tree is serialized as
+// {@code aggregationTree}, timing as {@code tookMillis}, and suggestions are wire-omitted), but a
+// method-level {@code @JsonIgnore} would ALSO hide them from the reflection-based
 // {@code com.dotmarketing.util.json.JSONObject} bean constructor that {@code JSONTool.generate(Object)}
-// uses (it honours {@code @JsonIgnore}). That reflection path is what {@code $json.generate($response)}
-// templates walk, so hiding {@code aggregations} there is exactly the #36435 regression. A class-level
-// {@code @JsonIgnoreProperties} is read by Jackson but NOT by the vendored JSONObject, so it keeps the
-// wire shape unchanged while leaving {@code getAggregations()} visible to Velocity's json tool.
-@com.fasterxml.jackson.annotation.JsonIgnoreProperties({"aggregations"})
+// uses — it honours {@code @JsonIgnore}. That reflection path is exactly what
+// {@code $json.generate($response)} templates walk, so a method-level ignore silently drops the data
+// there (issue #36435 — originally only {@code aggregations} was reported, {@code tookInMillis} and
+// {@code suggest} shared the same latent regression). A class-level {@code @JsonIgnoreProperties} is
+// read by Jackson but NOT by the vendored JSONObject, so it keeps the wire shape unchanged while
+// leaving the {@code getX()} aliases visible to Velocity's json tool.
+@com.fasterxml.jackson.annotation.JsonIgnoreProperties({"aggregations", "tookInMillis", "suggest"})
 public record ContentSearchResponse(
         SearchHits hits,
         @Nullable String scrollId,
         long tookMillis,
         Map<String, Aggregation> aggregationTree,
-        @com.fasterxml.jackson.annotation.JsonIgnore Map<String, Object> suggest) {
+        Map<String, Object> suggest) {
 
     /**
      * Canonical constructor. {@code aggregationTree} and {@code suggest} default to an empty map when
@@ -82,8 +85,10 @@ public record ContentSearchResponse(
     // that access WITHOUT changing the JSON wire shape:
     //  - getHits()/getScrollId() return the same values as the record components, so Jackson merges
     //    them into the existing "hits"/"scrollId" fields (no new key, no duplicate).
-    //  - getTookInMillis()/getAggregations() carry @JsonIgnore so they remain Velocity-only and
-    //    never add a field to the neutral JSON.
+    //  - getTookInMillis()/getAggregations()/getSuggest() are Velocity-only and must NOT add a field
+    //    to the neutral JSON; that suppression lives in the class-level @JsonIgnoreProperties above
+    //    (Jackson-only) rather than a method-level @JsonIgnore, so they stay visible to the
+    //    reflection-based $json.generate() path (issue #36435).
 
     /** Velocity/back-compat alias for {@link #hits()}; serializes as the same {@code hits} field. */
     public SearchHits getHits() {
@@ -97,9 +102,11 @@ public record ContentSearchResponse(
 
     /**
      * Velocity/back-compat alias mirroring Elasticsearch {@code SearchResponse.getTookInMillis()}.
-     * {@code @JsonIgnore} keeps the neutral JSON unchanged (timing is serialized as {@code tookMillis}).
+     * Deliberately NOT annotated {@code @JsonIgnore}: it must stay visible to the reflection-based
+     * {@code $json.generate($response)} path (issue #36435). The neutral Jackson JSON is kept
+     * unchanged (timing is serialized only as {@code tookMillis}) by the class-level
+     * {@code @JsonIgnoreProperties("tookInMillis")}.
      */
-    @com.fasterxml.jackson.annotation.JsonIgnore
     public long getTookInMillis() {
         return tookMillis;
     }
@@ -122,11 +129,12 @@ public record ContentSearchResponse(
 
     /**
      * Velocity/back-compat alias for {@link #suggest()}, exposing search suggestions as
-     * {@code $r.suggest}. Kept {@code @JsonIgnore} (like the {@code suggest} component itself) so the
-     * neutral JSON shape of {@code /api/es/raw} is unchanged; the ES-wire {@code suggest} block is
-     * emitted only by the {@code /api/es/search} legacy adapter.
+     * {@code $r.suggest}. Deliberately NOT annotated {@code @JsonIgnore}: it must stay visible to the
+     * reflection-based {@code $json.generate($response)} path (issue #36435). The neutral JSON shape of
+     * {@code /api/es/raw} is unchanged (suggestions are wire-omitted) via the class-level
+     * {@code @JsonIgnoreProperties("suggest")}; the ES-wire {@code suggest} block is emitted only by the
+     * {@code /api/es/search} legacy adapter.
      */
-    @com.fasterxml.jackson.annotation.JsonIgnore
     public Map<String, Object> getSuggest() {
         return suggest;
     }

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/ContentSearchResponse.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/ContentSearchResponse.java
@@ -39,6 +39,16 @@ import javax.annotation.Nullable;
  *                        sub-aggregations and {@code top_hits} preserved); Velocity resolves
  *                        {@code $results.aggregations.<name>} through this map
  */
+// {@code aggregations} is suppressed for Jackson at the CLASS level (not with a method-level
+// {@code @JsonIgnore} on {@link #getAggregations()}) on purpose: the neutral Jackson JSON must not
+// carry {@code aggregations} — the tree is already serialized as {@code aggregationTree}, and a
+// method-level {@code @JsonIgnore} would ALSO hide it from the reflection-based
+// {@code com.dotmarketing.util.json.JSONObject} bean constructor that {@code JSONTool.generate(Object)}
+// uses (it honours {@code @JsonIgnore}). That reflection path is what {@code $json.generate($response)}
+// templates walk, so hiding {@code aggregations} there is exactly the #36435 regression. A class-level
+// {@code @JsonIgnoreProperties} is read by Jackson but NOT by the vendored JSONObject, so it keeps the
+// wire shape unchanged while leaving {@code getAggregations()} visible to Velocity's json tool.
+@com.fasterxml.jackson.annotation.JsonIgnoreProperties({"aggregations"})
 public record ContentSearchResponse(
         SearchHits hits,
         @Nullable String scrollId,
@@ -97,10 +107,15 @@ public record ContentSearchResponse(
     /**
      * Velocity/back-compat alias exposing the aggregation tree as {@code $r.aggregations}, matching
      * {@code ContentSearchResults#getAggregations()} so {@code $dotcontent.raw(...)} and
-     * {@code $dotcontent.search(...)} templates walk aggregations the same way. {@code @JsonIgnore}
-     * keeps the neutral JSON unchanged (the tree is serialized as {@code aggregationTree}).
+     * {@code $dotcontent.search(...)} templates walk aggregations the same way.
+     *
+     * <p>Deliberately NOT annotated {@code @JsonIgnore}: this accessor must stay visible to the
+     * reflection-based {@code com.dotmarketing.util.json.JSONObject} bean constructor behind
+     * {@code JSONTool.generate(Object)}, so {@code $json.generate($response).aggregations...} templates
+     * keep working (issue #36435). The neutral Jackson JSON is kept unchanged (the tree is serialized
+     * only as {@code aggregationTree}) by the class-level {@code @JsonIgnoreProperties("aggregations")}
+     * instead — Jackson honours it, the vendored JSONObject does not.</p>
      */
-    @com.fasterxml.jackson.annotation.JsonIgnore
     public Map<String, Aggregation> getAggregations() {
         return aggregationTree;
     }

--- a/dotCMS/src/test/java/com/dotcms/content/index/domain/AggregationDomainTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/domain/AggregationDomainTest.java
@@ -180,6 +180,7 @@ public class AggregationDomainTest {
         final ContentSearchResponse response = ContentSearchResponse.builder()
                 .hits(hits).tookMillis(42L)
                 .aggregationTree(Map.of("content_types", terms))
+                .suggest(Map.of("titleSuggest", List.of()))
                 .build();
 
         final JsonNode root = mapper.readTree(mapper.writeValueAsString(response));
@@ -188,13 +189,18 @@ public class AggregationDomainTest {
         assertTrue("aggregationTree must be present", root.has("aggregationTree"));
         assertTrue("declared aggregation must survive serialization",
                 root.path("aggregationTree").has("content_types"));
-        // The Velocity alias getAggregations() must NOT leak into the neutral Jackson JSON — the tree
-        // is single-sourced as aggregationTree. The class-level @JsonIgnoreProperties("aggregations")
-        // (not a method-level @JsonIgnore) is what suppresses it here, so it stays visible to the
-        // reflection-based $json.generate() path exercised in
+        // The Velocity-only aliases getAggregations()/getTookInMillis()/getSuggest() must NOT leak into
+        // the neutral Jackson JSON — the tree is single-sourced as aggregationTree, timing as tookMillis,
+        // and suggestions are wire-omitted. The class-level @JsonIgnoreProperties (not method-level
+        // @JsonIgnore) is what suppresses them here, so they stay visible to the reflection-based
+        // $json.generate() path exercised in
         // jsonGenerate_ofResponse_preservesAggregationsForVelocityNavigation (issue #36435).
         assertFalse("getAggregations() must not double-emit an 'aggregations' key in the neutral JSON",
                 root.has("aggregations"));
+        assertFalse("getTookInMillis() must not add a 'tookInMillis' key (timing stays as tookMillis)",
+                root.has("tookInMillis"));
+        assertFalse("getSuggest() must not add a 'suggest' key to the neutral JSON",
+                root.has("suggest"));
 
         // hits must be a nested object, not a bare array (SearchHits implements Iterable).
         final JsonNode hitsNode = root.get("hits");
@@ -401,16 +407,18 @@ public class AggregationDomainTest {
      * <p>A customer's {@code sitemap.vtl} does {@code #set($results = $json.generate($rawResults.response))}
      * and then {@code #foreach($folder in $results.aggregations.<name>.buckets)}. Before the ES→OS
      * migration the raw response was an ES {@code SearchResponse} bean and its {@code getAggregations()}
-     * reflected into the JSON, so the aggregations survived the {@code $json.generate()} hop. After the
-     * migration the raw response is {@link ContentSearchResponse}; its {@code getAggregations()} carries
-     * {@code @JsonIgnore} (to keep the neutral Jackson wire shape single-sourced from
-     * {@code aggregationTree}), and the dotCMS-vendored {@link JSONObject} bean constructor honours
-     * {@code @JsonIgnore} too — so the aggregations vanish from the generated JSON and the
-     * {@code #foreach} silently iterates zero times.</p>
+     * (and {@code getTookInMillis()}, {@code getSuggest()}) reflected into the JSON, so those survived
+     * the {@code $json.generate()} hop. After the migration the raw response is
+     * {@link ContentSearchResponse}; those Velocity aliases carried a method-level {@code @JsonIgnore}
+     * (to keep the neutral Jackson wire single-sourced), and the dotCMS-vendored {@link JSONObject} bean
+     * constructor honours {@code @JsonIgnore} too — so they vanished from the generated JSON and the
+     * {@code #foreach} silently iterated zero times.</p>
      *
      * <p>Contract this pins: running the response through the same reflection constructor
-     * {@code JSONTool.generate(Object)} uses must still expose the aggregations, navigable as
-     * {@code aggregations.<name>.buckets} down to each bucket's {@code key}/{@code docCount}.</p>
+     * {@code JSONTool.generate(Object)} uses must expose the Velocity-alias family — the aggregations
+     * navigable as {@code aggregations.<name>.buckets} down to each bucket's {@code key}/{@code docCount},
+     * plus {@code tookInMillis} and {@code suggest}. All three moved from a method-level
+     * {@code @JsonIgnore} to a class-level {@code @JsonIgnoreProperties} that only Jackson honours.</p>
      */
     @Test
     public void jsonGenerate_ofResponse_preservesAggregationsForVelocityNavigation() {
@@ -422,6 +430,7 @@ public class AggregationDomainTest {
         final ContentSearchResponse response = ContentSearchResponse.builder()
                 .hits(SearchHits.empty()).tookMillis(5L)
                 .aggregationTree(Map.of("folders", folders))
+                .suggest(Map.of("titleSuggest", List.of()))
                 .build();
 
         // Exactly what JSONTool.generate(Object o) does: new JSONObject(o).
@@ -439,6 +448,12 @@ public class AggregationDomainTest {
         assertEquals("/about-us/", buckets.getJSONObject(0).getString("key"));
         assertEquals(12L, buckets.getJSONObject(0).getLong("docCount"));
         assertEquals("/products/", buckets.getJSONObject(1).getString("key"));
+
+        // The sibling Velocity aliases that shared the same latent regression (issue #36435) must also
+        // survive the reflection hop: getTookInMillis() and getSuggest().
+        assertEquals("tookInMillis must survive the $json.generate() reflection hop", 5L,
+                json.getLong("tookInMillis"));
+        assertTrue("suggest must survive the $json.generate() reflection hop", json.has("suggest"));
     }
 
     /** An empty (but non-null) Elasticsearch aggregation set whose buckets carry no sub-aggs. */

--- a/dotCMS/src/test/java/com/dotcms/content/index/domain/AggregationDomainTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/domain/AggregationDomainTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
+import com.dotmarketing.util.json.JSONArray;
+import com.dotmarketing.util.json.JSONObject;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
@@ -186,6 +188,13 @@ public class AggregationDomainTest {
         assertTrue("aggregationTree must be present", root.has("aggregationTree"));
         assertTrue("declared aggregation must survive serialization",
                 root.path("aggregationTree").has("content_types"));
+        // The Velocity alias getAggregations() must NOT leak into the neutral Jackson JSON — the tree
+        // is single-sourced as aggregationTree. The class-level @JsonIgnoreProperties("aggregations")
+        // (not a method-level @JsonIgnore) is what suppresses it here, so it stays visible to the
+        // reflection-based $json.generate() path exercised in
+        // jsonGenerate_ofResponse_preservesAggregationsForVelocityNavigation (issue #36435).
+        assertFalse("getAggregations() must not double-emit an 'aggregations' key in the neutral JSON",
+                root.has("aggregations"));
 
         // hits must be a nested object, not a bare array (SearchHits implements Iterable).
         final JsonNode hitsNode = root.get("hits");
@@ -371,6 +380,65 @@ public class AggregationDomainTest {
         final Aggregation agg = Aggregation.builder().name("x").type("sterms").build();
         assertNotNull("metadata must never be null", agg.getMetadata());
         assertTrue("metadata defaults to empty when unset", agg.getMetadata().isEmpty());
+    }
+
+    // =========================================================================
+    // $json.generate($rawResults.response) reflection navigation — issue #36435
+    // =========================================================================
+    //
+    // Some templates do NOT navigate the Velocity object directly (the path #36026/#36027
+    // restored); they first round-trip the raw response through JSONTool.generate(Object), i.e.
+    // `#set($results = $json.generate($rawResults.response))`, and then walk the resulting
+    // JSONObject: `$results.aggregations.<name>.buckets`. JSONTool.generate(Object) is literally
+    // `new com.dotmarketing.util.json.JSONObject(bean)` — a reflection/bean constructor that only
+    // picks up public zero-arg `getX()`/`isX()` accessors and (crucially) SKIPS any accessor
+    // annotated with Jackson's @JsonIgnore. This test exercises that exact reflection path against
+    // the neutral ContentSearchResponse so the regression is pinned as a fast unit test.
+
+    /**
+     * Reproduction / regression for <a href="https://github.com/dotCMS/core/issues/36435">#36435</a>.
+     *
+     * <p>A customer's {@code sitemap.vtl} does {@code #set($results = $json.generate($rawResults.response))}
+     * and then {@code #foreach($folder in $results.aggregations.<name>.buckets)}. Before the ES→OS
+     * migration the raw response was an ES {@code SearchResponse} bean and its {@code getAggregations()}
+     * reflected into the JSON, so the aggregations survived the {@code $json.generate()} hop. After the
+     * migration the raw response is {@link ContentSearchResponse}; its {@code getAggregations()} carries
+     * {@code @JsonIgnore} (to keep the neutral Jackson wire shape single-sourced from
+     * {@code aggregationTree}), and the dotCMS-vendored {@link JSONObject} bean constructor honours
+     * {@code @JsonIgnore} too — so the aggregations vanish from the generated JSON and the
+     * {@code #foreach} silently iterates zero times.</p>
+     *
+     * <p>Contract this pins: running the response through the same reflection constructor
+     * {@code JSONTool.generate(Object)} uses must still expose the aggregations, navigable as
+     * {@code aggregations.<name>.buckets} down to each bucket's {@code key}/{@code docCount}.</p>
+     */
+    @Test
+    public void jsonGenerate_ofResponse_preservesAggregationsForVelocityNavigation() {
+        final AggregationBucket about = AggregationBucket.builder().key("/about-us/").docCount(12).build();
+        final AggregationBucket products = AggregationBucket.builder().key("/products/").docCount(7).build();
+        final Aggregation folders = Aggregation.builder()
+                .name("folders").type("sterms").buckets(List.of(about, products)).build();
+
+        final ContentSearchResponse response = ContentSearchResponse.builder()
+                .hits(SearchHits.empty()).tookMillis(5L)
+                .aggregationTree(Map.of("folders", folders))
+                .build();
+
+        // Exactly what JSONTool.generate(Object o) does: new JSONObject(o).
+        final JSONObject json = new JSONObject(response);
+
+        assertTrue("aggregations must survive the $json.generate() reflection hop (issue #36435)",
+                json.has("aggregations"));
+
+        final JSONObject aggs = json.getJSONObject("aggregations");
+        assertTrue("the declared 'folders' aggregation must be present after JSON generation",
+                aggs.has("folders"));
+
+        final JSONArray buckets = aggs.getJSONObject("folders").getJSONArray("buckets");
+        assertEquals("both folder buckets must survive", 2, buckets.length());
+        assertEquals("/about-us/", buckets.getJSONObject(0).getString("key"));
+        assertEquals(12L, buckets.getJSONObject(0).getLong("docCount"));
+        assertEquals("/products/", buckets.getJSONObject(1).getString("key"));
     }
 
     /** An empty (but non-null) Elasticsearch aggregation set whose buckets carry no sub-aggs. */

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/ContentSearchToolTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/ContentSearchToolTest.java
@@ -326,6 +326,50 @@ public class ContentSearchToolTest extends IntegrationTestBase {
             #end
             """;
 
+    /**
+     * The customer's <b>other</b> idiom (issue #36435): instead of navigating the Velocity object
+     * directly (the path {@link #verbatimCustomerVtl_rendersAfterFix()} covers), the template first
+     * round-trips the raw response through {@code $json.generate($rawResults.response)} and then walks
+     * the resulting {@code JSONObject}: {@code $results.aggregations.<name>.buckets}.
+     *
+     * <p>{@code $rawResults.response} is the {@link ContentSearchResponse} exposed by
+     * {@link ContentSearchResults#getResponse()}. {@code $json.generate(Object)} is literally
+     * {@code new com.dotmarketing.util.json.JSONObject(response)} — a reflection/bean serializer that
+     * only sees {@code getX()} accessors and honours {@code @JsonIgnore}. Before the fix,
+     * {@code getAggregations()} carried {@code @JsonIgnore}, so the aggregations vanished from the
+     * generated JSON and this loop iterated zero times (silent empty sitemap). The fix moves that
+     * suppression to a class-level {@code @JsonIgnoreProperties} that only Jackson honours, so the
+     * reflection serializer keeps {@code aggregations} — this loop must now emit buckets.</p>
+     *
+     * <p>Note: the legacy {@code .get("asMap")} hop the customer used only ever existed because the
+     * pre-migration object was an ES {@code Aggregations} (which had {@code getAsMap()}); the neutral
+     * tree is flatter, so the correct navigation is {@code aggregations.<name>.buckets} directly.</p>
+     */
+    private static final String JSON_GENERATE_VTL = """
+            #set($esQuery = '{
+                "aggs": {
+                    "content_types": {
+                        "terms": { "field": "contentType", "size": 5 }
+                    }
+                },
+                "size": 0,
+                "query": {
+                    "bool": {
+                        "filter": [ { "term": { "live": true } } ]
+                    }
+                }
+            }')
+
+            ## The #36435 idiom: JSON-ify the raw response FIRST, then navigate the JSONObject.
+            #set($rawResults = $estool.search($esQuery))
+            #set($results = $json.generate($rawResults.response))
+            aggregations: $!{results.aggregations}
+            #foreach($group in $results.aggregations.content_types.buckets)
+              json key: $!{group.key}
+              json docCount: $!{group.docCount}
+            #end
+            """;
+
     @BeforeClass
     public static void prepare() throws Exception {
         IntegrationTestInitService.getInstance().init();
@@ -378,11 +422,17 @@ public class ContentSearchToolTest extends IntegrationTestBase {
         return tool;
     }
 
-    /** Builds a Velocity context with the live {@code $estool} and a mock {@code $response} bound. */
+    /**
+     * Builds a Velocity context with the live {@code $estool}, a mock {@code $response} and the
+     * {@code $json} tool bound. {@link JSONTool} needs no real init ({@code init(Object)} is a no-op
+     * and {@code generate(Object)} is stateless), so a plain instance mirrors what the Velocity
+     * toolbox binds as {@code $json}.
+     */
     private Context velocityContext() {
         final Context ctx = new VelocityContext();
         ctx.put("estool", liveContentTool());
         ctx.put("response", mock(HttpServletResponse.class));
+        ctx.put("json", new JSONTool());
         return ctx;
     }
 
@@ -405,6 +455,25 @@ public class ContentSearchToolTest extends IntegrationTestBase {
                 Pattern.compile("docCount:\\s*\\d+").matcher(output).find());
         assertTrue("FIX (#36026): nested top_hits must be reachable, emitting 'hit id:' lines",
                 output.contains("hit id:"));
+    }
+
+    /**
+     * End-to-end regression for <a href="https://github.com/dotCMS/core/issues/36435">#36435</a>:
+     * drives the customer's {@code $json.generate($rawResults.response)}-then-navigate idiom through
+     * the real dotCMS Velocity engine and asserts the aggregation buckets survive the JSON round-trip
+     * (the {@code json key:} / {@code json docCount:} loop must execute). This is the path #36026/#36027
+     * did NOT cover — those navigate the Velocity object directly; this one serializes first.
+     */
+    @Test
+    public void jsonGenerateThenNavigateVtl_emitsBuckets() throws Exception {
+        final String output = VelocityUtil.eval(JSON_GENERATE_VTL, velocityContext());
+        Logger.info(this, "\n===== $json.generate VTL output =====\n" + output + "\n================================");
+
+        assertTrue("FIX (#36435): $json.generate($rawResults.response) must keep the aggregations, so "
+                        + "the bucket loop executes and emits 'json key:' lines",
+                output.contains("json key:"));
+        assertTrue("FIX (#36435): bucket doc counts must render with real numbers after the JSON round-trip",
+                Pattern.compile("json docCount:\\s*\\d+").matcher(output).find());
     }
 
     /**


### PR DESCRIPTION
## Summary

**The problem:** When a VTL template does `$json.generate($rawResults.response)` to turn search results into JSON and then reads the aggregations, **the JSON came out without the aggregations**. The `#foreach` printed nothing — no error, no log. A customer hit this because their `sitemap.vtl` rendered only the base URL (Freshdesk 38225).

**The cause:** During the ES→OpenSearch migration, `getAggregations()` was annotated `@JsonIgnore` (so Jackson wouldn't duplicate the tree in the API JSON). But the serializer behind `$json.generate()` **also honours that annotation** → it skipped the aggregations → they vanished from the generated JSON.

**The fix:** Move that suppression from a method-level `@JsonIgnore` to a class-level `@JsonIgnoreProperties`. Jackson still honours it → the API JSON is unchanged. The `$json.generate()` serializer does **not** honour it → the aggregations show up again. Extended to `tookInMillis` and `suggest`, which shared the same latent bug.

**The breaking change:** The legacy `.get("asMap")` hop no longer works (it was an Elasticsearch artifact). The correct navigation is now direct: `aggregations.<name>.buckets`.

**Verification:** unit tests 14/14 ✅, end-to-end integration 10/10 ✅ (real Velocity engine + Elasticsearch).

---

## Problem

Templates that round-trip a raw search response through `$json.generate($rawResults.response)` and then navigate the resulting `JSONObject` (e.g. `$results.aggregations.<name>.buckets`) silently got **no aggregations** after the ES→OpenSearch migration. A customer's `sitemap.vtl` rendered only the base URL — every aggregation-driven loop (folders, pages, urlmaps) iterated zero times, with no exception and no log line (Freshdesk 38225).

This is a distinct path from #36026/#36027, which restored **direct** Velocity object navigation (`$rawResults.aggregations...`). This bug shows up only when the template serializes the response through `$json.generate()` **first**.

## Root cause

`JSONTool.generate(Object)` is literally `new com.dotmarketing.util.json.JSONObject(bean)` — a reflection/bean serializer that:
1. only reads public zero-arg `getX()`/`isX()` accessors, and
2. **honours Jackson's `@JsonIgnore`** (`JSONObject.isIgnorable()`).

`ContentSearchResponse.getAggregations()` carried a method-level `@JsonIgnore` (added so the neutral Jackson wire is single-sourced from `aggregationTree` and not double-emitted). Because the vendored `JSONObject` also honours `@JsonIgnore`, it skipped the getter too — so the aggregations vanished from the generated JSON and the customer's `#foreach` iterated nothing.

An audit of the object graph found **two more Velocity back-compat aliases with the exact same latent regression**: `getTookInMillis()` and `getSuggest()` also carried a method-level `@JsonIgnore`. Pre-migration the raw ES `SearchResponse` exposed both via getters, so `$json.generate()` templates reading timing/suggestions regressed the same way (lower blast radius — no ticket yet).

## Fix

Move the Jackson suppression from **method-level** `@JsonIgnore` on the getters to a **class-level** `@JsonIgnoreProperties({"aggregations", "tookInMillis", "suggest"})`:

| Serializer | Reads method-level `@JsonIgnore`? | Reads class-level `@JsonIgnoreProperties`? |
|---|---|---|
| Jackson (API wire) | yes | **yes** → still suppresses all three; wire shape unchanged (tree=`aggregationTree`, timing=`tookMillis`, suggest omitted) |
| vendored `JSONObject` (`$json.generate()`) | yes | **no** → the `getX()` aliases are visible again → data restored |

Net: `$json.generate()` templates work again, and the neutral Jackson JSON gains **no** duplicate `aggregations` / `tookInMillis` / `suggest` key.

Rest of the graph audited clean: `SearchHits`, `SearchHit`, `Aggregation`, `AggregationBucket`, `TotalHits` and `ContentSearchResults` carry no `@JsonIgnore` getters, so no other attribute is affected.

## Test plan

**Automated**
- `AggregationDomainTest` (unit, no search engine): drives the exact `new JSONObject(response)` reflection path and asserts `aggregations` (down to each bucket's `key`/`docCount`), `tookInMillis` and `suggest` all survive; the Jackson-shape test asserts none of the three leak a duplicate wire key (`tookMillis`/`aggregationTree` stay; `tookInMillis`/`suggest`/`aggregations` absent). 14/14 green. Verified failing on the pre-fix source (1 failure) and passing with the fix.
- `ContentSearchToolTest` (integration): drives the customer's `$json.generate($rawResults.response)`-then-navigate idiom through the real dotCMS Velocity engine — the path #36026/#36027 did not cover.

**Manual (QA)**

_TC1 — aggregations (the reported bug):_
1. On a site with published content, create a VTL page/widget:
   ```velocity
   #set($esQuery = '{"aggs":{"folders":{"terms":{"field":"contentType","size":20}}},"size":0,"query":{"bool":{"filter":[{"term":{"live":true}}]}}}')
   #set($rawResults = $estool.search($esQuery))
   #set($results = $json.generate($rawResults.response))
   RAW JSON: $results
   #foreach($group in $results.aggregations.folders.buckets)
     key: $!{group.key} — docCount: $!{group.docCount}
   #end
   ```
2. **Expected:** `RAW JSON` contains an `"aggregations"` block, and the loop prints one `key: … docCount: …` line per bucket.
3. **Before the fix:** `RAW JSON` has no `aggregations` block and the loop prints nothing.

_TC2 — tookInMillis & suggest (the two siblings fixed in the same PR):_
1. On any site, create a VTL page/widget:
   ```velocity
   #set($esQuery = '{"size":1,"query":{"match_all":{}}}')
   #set($rawResults = $estool.search($esQuery))
   #set($results = $json.generate($rawResults.response))
   RAW JSON: $results
   tookInMillis: $!{results.tookInMillis}
   suggest key present: $!{results.suggest}
   ```
2. **Expected:** `RAW JSON` contains both a `"tookInMillis"` number and a `"suggest"` key (an object, `{}` when the query has no suggester); `tookInMillis:` renders a number and `suggest key present:` renders (not blank).
3. **Before the fix:** `RAW JSON` has neither `tookInMillis` nor `suggest`; both output lines render blank.
4. _(Optional, to see `suggest` populated)_ add a suggester to the query, e.g. `"suggest":{"my-suggestion":{"text":"lorem","term":{"field":"title"}}}`, and confirm the `suggest` block carries the suggester's entries.

## QA Note

- **Breaking-detail for affected templates:** the legacy `.get("asMap")` hop (e.g. `$results.aggregations.get("asMap").folders.buckets`) only ever worked because the pre-migration object was an ES `Aggregations` (which had `getAsMap()`). The neutral tree is flatter, so the correct navigation is now `aggregations.<name>.buckets` **directly** — drop the `asMap` hop. Worth a docs/KB note for customers using the `json.generate()`-then-navigate idiom.
- No REST/wire contract changes: the `/api/es/raw` and `/api/es/search` neutral JSON shape is unchanged (verified by the Jackson no-duplicate assertions).

Closes #36435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
### Rollback safety (H-8 — reviewed)

The rollback-safety bot flags this as a VTL viewtool contract change (H-8, HIGH): the PR **restores** the `$json.generate($rawResults.response).aggregations` (and `.tookInMillis` / `.suggest`) contract, so rolling back to N-1 would silently re-break any template that relies on it. This is inherent to the forward-fix and is expected:

- Templates already using this idiom (e.g. Freshdesk 38225) are **already broken on the current release**; rollback leaves them no worse off.
- The only new exposure is templates *authored/updated to adopt the idiom during this cycle*, which would silently regress on rollback (zero-iteration `#foreach`, no error/log).
- **No REST/wire contract change** — the neutral `/api/es/raw` & `/api/es/search` JSON is unchanged (pinned by the Jackson no-duplicate assertions).

**Release-notes action for ops:** rolling back this release silently reintroduces the `$json.generate(...).aggregations` regression (Freshdesk 38225) for any template adopting the restored idiom this cycle. Weigh that in any rollback decision.

