### PR TITLE
test(index): make createContentIndexAndDelete index-count assertion phase-aware (#36501)

### DIFF
--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -343,8 +343,12 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
         assertTrue(foundWorking);
         assertTrue(foundLive);
 
-        //Verify we just added two more indices
-        assertEquals((long) oldIndices + 2, newIndices);
+        // Under a dual-write migration phase, createContentIndex fans out to both the ES and OS
+        // stores, so listDotCMSIndices() reports two physical entries per logical index. Assert the
+        // two indices we created are present (checked above) and that the total grew by at least
+        // two, rather than asserting a single-store exact delta of +2.
+        assertTrue("expected at least two new indices, delta was " + (newIndices - oldIndices),
+                newIndices >= oldIndices + 2);
 
         //***************************************************
         //Now lets delete the created indices

--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.content.index.IndexAPI;
+import com.dotcms.content.index.IndexTag;
 import com.dotcms.content.index.domain.IndexBulkRequest;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
@@ -333,9 +334,12 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
         boolean foundWorking = false;
         boolean foundLive = false;
         for (String index : indices) {
-            if (index.equals(liveIndex)) {
+            // Tolerate the .os tag added to OS-backed indices under migration phases 1/2/3
+            // (in OS-only phase 3 listDotCMSIndices() returns only the .os-tagged names).
+            final String logical = IndexTag.strip(index);
+            if (logical.equals(liveIndex)) {
                 foundLive = true;
-            } else if (index.equals(workingIndex)) {
+            } else if (logical.equals(workingIndex)) {
                 foundWorking = true;
             }
         }
@@ -369,9 +373,12 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
         foundWorking = false;
         foundLive = false;
         for (String index : indices) {
-            if (index.equals(liveIndex)) {
+            // Tolerate the .os tag added to OS-backed indices under migration phases 1/2/3
+            // (in OS-only phase 3 listDotCMSIndices() returns only the .os-tagged names).
+            final String logical = IndexTag.strip(index);
+            if (logical.equals(liveIndex)) {
                 foundLive = true;
-            } else if (index.equals(workingIndex)) {
+            } else if (logical.equals(workingIndex)) {
                 foundWorking = true;
             }
         }


### PR DESCRIPTION
## Proposed Changes

Fixes one of the phase-induced test failures tracked in #36501 (found while running the MainSuite battery under an ES→OS migration phase — see #36320).

`ContentletIndexAPIImplTest.createContentIndexAndDelete` asserted an exact **single-store** delta after creating a working + live index:

```java
assertEquals((long) oldIndices + 2, newIndices);
```

Under a dual-write migration phase (`-Dopensearch.phase=1/2`), `createContentIndex` fans out to **both** the ES and OS stores, so `listDotCMSIndices()` reports two physical entries per logical index and the delta is +4 — failing with `expected:<158> but was:<160>`.

### Fix
Assert the two created indices are present (already checked via `foundWorking`/`foundLive`) and that the total grew by **at least** two, instead of a single-store exact delta:

```java
assertTrue("expected at least two new indices, delta was " + (newIndices - oldIndices),
        newIndices >= oldIndices + 2);
```

Phase-agnostic: passes in phase 0 (ES only) and under dual-write.

## Verification
Ran under phase 1 locally (`-Dopensearch.phase=1 -Dit.test=ContentletIndexAPIImplTest`): **`Tests run: 16, Failures: 0, Errors: 0`** ✅ (was 1 failure before).

Refs #36501 (tracking), #36320 (ContentletIndexAPIImplTest phase-aware decoupling — this assertion is item #4 there).

This PR fixes: #36501