### PR TITLE
test(import): use unique content-type variables in ImportUtilTest relationship tests (#36501)

### DIFF
--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -1549,7 +1549,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             throws DotSecurityException, DotDataException, IOException {
 
         //Creates content type
-        final ContentType type = createTestContentType("selfRelatedType", "selfRelatedType");
+        final ContentType type = createTestContentType("selfRelatedType", "selfRelatedType" + new Date().getTime());
         final Structure structure = new StructureTransformer(type).asStructure();
 
         try {
@@ -1610,8 +1610,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
         try {
             final Relationship relationship;
-            parentContentType = createTestContentType("parentContentType", "parentContentType");
-            childContentType = createTestContentType("childContentType", "childContentType");
+            parentContentType = createTestContentType("parentContentType", "parentContentType" + new Date().getTime());
+            childContentType = createTestContentType("childContentType", "childContentType" + new Date().getTime());
             final Structure parentStructure = new StructureTransformer(parentContentType).asStructure();
             final Structure childStructure = new StructureTransformer(childContentType).asStructure();
 
@@ -1693,8 +1693,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
         final int cardinality = RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal();
 
         try {
-            parentContentType = createTestContentType("parentContentType", "parentContentType");
-            childContentType = createTestContentType("childContentType", "childContentType");
+            parentContentType = createTestContentType("parentContentType", "parentContentType" + new Date().getTime());
+            childContentType = createTestContentType("childContentType", "childContentType" + new Date().getTime());
 
             com.dotcms.contenttype.model.field.Field field = FieldBuilder
                     .builder(RelationshipField.class).name("testRelationship")
@@ -1753,8 +1753,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
         try {
             final Relationship relationship;
-            parentContentType = createTestContentType("parentContentType", "parentContentType");
-            childContentType = createTestContentType("childContentType", "childContentType");
+            parentContentType = createTestContentType("parentContentType", "parentContentType" + new Date().getTime());
+            childContentType = createTestContentType("childContentType", "childContentType" + new Date().getTime());
 
             com.dotcms.contenttype.model.field.Field field = FieldBuilder.builder(RelationshipField.class).name("testRelationship")
                     .variable("testRelationship")
@@ -1825,8 +1825,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
         try {
             final Relationship relationship;
-            parentContentType = createTestContentType("parentContentType", "parentContentType");
-            childContentType = createTestContentType("childContentType", "childContentType");
+            parentContentType = createTestContentType("parentContentType", "parentContentType" + new Date().getTime());
+            childContentType = createTestContentType("childContentType", "childContentType" + new Date().getTime());
 
             com.dotcms.contenttype.model.field.Field field = FieldBuilder.builder(RelationshipField.class).name("testRelationship")
                     .variable("testRelationship")
@@ -1897,8 +1897,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
         try {
             final Relationship relationship;
-            parentContentType = createTestContentType("parentContentType", "parentContentType");
-            childContentType = createTestContentType("childContentType", "childContentType");
+            parentContentType = createTestContentType("parentContentType", "parentContentType" + new Date().getTime());
+            childContentType = createTestContentType("childContentType", "childContentType" + new Date().getTime());
 
             com.dotcms.contenttype.model.field.Field field = FieldBuilder.builder(RelationshipField.class).name("testRelationship")
                     .variable("testRelationship")
@@ -1971,7 +1971,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
         try {
 
-            parentContentType = createTestContentType("parentContentType", "parentContentType");
+            parentContentType = createTestContentType("parentContentType", "parentContentType" + new Date().getTime());
 
             field = FieldBuilder.builder(RelationshipField.class).name("testRelationship")
                     .variable("testRelationship")
@@ -2029,7 +2029,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
         final int cardinality = RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal();
 
         try {
-            parentContentType = createTestContentType("parentContentType", "parentContentType");
+            parentContentType = createTestContentType("parentContentType", "parentContentType" + new Date().getTime());
 
             //child field
             field = FieldBuilder.builder(RelationshipField.class).name("testRelationship")


### PR DESCRIPTION
## Proposed Changes

Fixes the phase-induced `ImportUtilTest` failures tracked in #36501 (found while running MainSuite1a under an ES→OS migration phase — see #36320).

### Root cause
The relationship / self-related import tests hardcoded **shared** content-type variables (`"parentContentType"`, `"childContentType"`, `"selfRelatedType"`) and deleted them in a `finally` block. Content-type deletion disposes the variable **asynchronously**; under a dual-write phase (`-Dopensearch.phase=1`) that disposal lags, so the next test creating the same fixed variable hits `doesTypeWithVariableExist() == true` and fails with:

```
IllegalArgumentException: Invalid content type variable: parentContentType
```

cascading across ~7 relationship tests in MainSuite1a. The baseline (phase 0) passes because disposal completes promptly.

### Fix
Append a per-call timestamp to the variable so each test is isolated regardless of async cleanup timing — mirroring sibling tests in the same file that already use `"parentContentType" + new Date().getTime()`. Test-isolation robustness only; **no product change**.

## Verification
Ran under phase 1 locally: the `Invalid content type variable: parentContentType` errors are **eliminated** (0 remaining, was 7).

## ⚠️ Note — separate pre-existing issue surfaced (not addressed here)
With the cascade removed, `ImportUtilTest` now runs far enough to reveal **11 unrelated failures** in the unique-field tests (`testingImportWithUniqueFields`, `importFile_fails_when_twoLinesHaveSameUniqueKeys`, …). These are **i18n message-resolution** failures — `LanguageUtil.get(user, "were-created" / "contains-duplicate-values-for-structure-unique-field")` returns the raw key instead of the resolved text, even though the keys exist in `Language.properties`. This is **phase-agnostic** (no ES/OS involvement) and independent of this change; it was previously masked by the `parentContentType` setup errors. Filing/investigating separately under #36501. It may be a local-env artifact (the import message code merged to main through green CI).

Refs #36501.

This PR fixes: #36501