### PR TITLE
feat(dev-tools): add /qa skill — recorded video verification for GitHub issues

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: qa
+description: QA a dotCMS GitHub issue or PR end-to-end against a local dotCMS instance, producing a recorded video as proof of verification. Use when the user asks to QA, verify, or validate an issue/PR fix (e.g. "/qa 36369", "qa this issue", "verify #36369 with video"). Handles UI issues (browser video) and API issues (recorded evidence harness).
+---
+
+# /qa — QA a GitHub Issue with Video Verification
+
+Verify that a merged fix actually satisfies its issue's acceptance criteria, by exercising
+the real running application — not just reading the diff — and deliver a recorded video
+as proof, plus a terse QA brief and a draft GitHub comment.
+
+## Usage
+
+```bash
+/qa 36369                                        # issue number
+/qa 36371                                        # PR number (resolves the linked issue)
+/qa https://github.com/dotCMS/core/issues/36369  # full URL
+```
+
+The run is **fully autonomous**: derive the test plan from the issue and execute it without
+asking for confirmation. Only stop for genuine blockers (no merged fix, environment cannot
+start, acceptance criteria absent AND undeducible).
+
+## Pipeline
+
+### STEP 1 — Resolve input → issue + merged PR + fix commit
+
+`$ARGUMENTS` may be an issue number, a PR number, or a URL to either.
+
+- Try as issue first: `gh issue view <n> --repo dotCMS/core --json title,body,state,labels`.
+  If it's actually a PR, `gh` errors — retry as PR and resolve its linked issue from the body
+  (`Fixes #...`).
+- Find the merged PR + merge commit via GraphQL timeline:
+
+```bash
+gh api graphql -f query='{ repository(owner:"dotCMS", name:"core") { issue(number:N) {
+  timelineItems(itemTypes:[CROSS_REFERENCED_EVENT], first:20) { nodes {
+    ... on CrossReferencedEvent { source { ... on PullRequest {
+      number state merged mergeCommit { oid } } } } } } } } }'
+```
+
+- Extract from the issue body: **acceptance criteria** (checklist items), steps to reproduce,
+  and any explicit out-of-scope statements. From the PR: changed files
+  (`gh pr view <n> --json files`) and test plan claims.
+- If there is **no merged PR**, stop: report that the issue has nothing to QA yet.
+
+### STEP 2 — Classify the issue and choose evidence mode
+
+- **UI issue** (changed files under `core-web/`, behavior visible in dotAdmin):
+  browser-driven checks recorded as video. This is the primary mode.
+- **API issue** (REST/backend behavior): drive the UI surface that reflects the behavior
+  when one exists; otherwise use the **evidence-harness page** (a generated HTML page that
+  executes the API calls via fetch and renders PASS/FAIL rows, recorded on video) — see
+  `references/api-evidence.md`.
+- **Mixed**: do both in one recording session.
+
+### STEP 3 — Provenance: prove the fix is what you're testing
+
+Never trust "the PR is merged". Follow `references/environment.md` § Provenance:
+
+1. `git merge-base --is-ancestor <fixCommit> HEAD` — fix must be in the local tree.
+2. If an instance is already running: confirm the served bundle was built from a tree
+   containing the fix (container `Created` time + bundle mtimes + `git reflog --date=iso`
+   + `merge-base --is-ancestor <fixCommit> <commit-at-build-time>`).
+3. If the bundle predates the fix: rebuild (`./mvnw install -pl :dotcms-core --am -DskipTests`)
+   and restart the environment before testing.
+
+### STEP 4 — Cheapest ground truth first: the PR's own tests
+
+Run the spec files the PR added or changed (frontend example):
+
+```bash
+cd core-web && corepack pnpm nx test <project> -- <spec-file-pattern>
+```
+
+- Suite-level failure with **0 tests run** (`Cannot find module ...`) = stale
+  `node_modules` → `corepack pnpm install` and retry. Not a product failure.
+- Backend: run the specific IT class only (`-Dit.test=Class#method`) — never the full suite.
+
+### STEP 5 — Environment: detect, else start
+
+```bash
+curl -sk -o /dev/null -w "%{http_code}" https://localhost:8443/dotAdmin/ --max-time 5
+```
+
+- `200|302` → reuse it (after the STEP 3 provenance check).
+- Otherwise: `just dev-run-fixed` (background) then `just dev-wait-ready`.
+  Login `admin@dotcms.com` / `admin`. Full recipes and gotchas: `references/environment.md`.
+
+### STEP 6 — Seed test data if the checks need it
+
+Seed via API, never by driving forms. Recipes: `references/api-seeding.md`.
+
+- **Prefix every seeded object `qa-<issue#>-<epoch>`** and **leave it in place** after the
+  run — the video references real visible names and the data stays inspectable.
+
+### STEP 7 — Execute the checks, recorded
+
+Map **each acceptance criterion to one or more concrete assertions** (DOM state, network
+request, API response). Write a throwaway Playwright script in `core-web/`
+(module resolution requires it), importing the shared helpers:
+
+```js
+import { chromium } from 'playwright-core';   // MUST be imported here, not in the helpers
+import { launchRecorded, openLogin, login, navigateMenu, gotoHash, introCard, showCursor,
+         criteriaPanel, humanClick, banner, visible, visibleArea, waitFor, makeChecker,
+         parkCursor, finalize, PACE }
+    from '../.claude/skills/qa/scripts/qa-helpers.mjs';
+const { browser, context, page } = await launchRecorded(chromium, VIDEO_DIR);
+```
+
+**Test like a human QA engineer — the full journey, on camera** (complete flow + gotchas
+in `references/browser-video.md`):
+
+- Record 1280×720 to a temp directory outside the repo (`mktemp -d` or the session
+  scratchpad — never inside the working tree).
+- Flow: `openLogin()` → `introCard()` (issue, numbered acceptance criteria, env, fix
+  commit, **seeded-data declaration**, held ~5 s) → narrated `login()` → reach the screen
+  via `navigateMenu()` clicks like a real user (`gotoHash()` only when no menu entry
+  exists, disclosed on its banner) → criteria with `humanClick()` + `banner()` →
+  `finalize(..., { criteria })` for a verdict that counts criteria, not raw assertions.
+- Live checklist (`criteriaPanel()`) shows **only the issue's acceptance criteria**;
+  each flips `✔`/`✘` strictly after its assertion returns. Extra assertions stay in the
+  log and brief, never on camera.
+- Visibility honesty: `visible()` for absence/presence; `visibleArea()` for anything the
+  viewer must SEE — an attached-but-empty container must fail, not pass.
+- Pacing: `slowMo: 150`, one `PACE.beat` after each state change (not before —
+  announcement-then-frozen-screen is dead air). `suppressToasts()` keeps system noise off
+  camera. `parkCursor()` before the verdict.
+- **One unedited take** — the delivered video is the exact run that produced the results.
+  Full integrity rules: `references/browser-video.md` § Integrity.
+- Poll with `waitFor()` for anything animation-gated — `@if` blocks leave the DOM only
+  after their leave animation.
+- **One selector per element set** — never comma-alternatives that can match the same
+  element twice. Sanity-check handle count against the expected row count before index math.
+- Delete the throwaway script when done. Never commit it.
+
+### STEP 8 — Self-verify before reporting any FAIL
+
+An automated FAIL is a claim, not a fact. Before reporting it:
+
+1. Extract frames (`ffmpeg -vf fps=1`) and **Read the PNGs** around the failing step —
+   determine whether the product misbehaved or the script did.
+2. Script artifact (wrong selector, timing, stale handle) → fix the script, re-run once.
+3. Reproducible product failure → it's a genuine FAIL. **Report only**: brief + video
+   clearly marked FAIL with the exact failing criterion. No root-cause hunt, no draft
+   comment — the human decides what happens next.
+
+### STEP 9 — Deliver
+
+1. Convert and place the video:
+   `ffmpeg -i <run>.webm -c:v libx264 -pix_fmt yuv420p -movflags +faststart out.mp4`
+   → copy to the user's Downloads folder if one exists (`$HOME/Downloads`), otherwise leave
+   it in the temp dir — either way name it `qa-<issue#>-<short-slug>.mp4` and state the
+   full path in the brief.
+2. QA brief in chat — terse one-liner bullets, exactly three sections:
+   - **Tested** — ✅/❌ per scenario, one line each, mapped to acceptance criteria
+   - **Notes** — environment, provenance, anything nonstandard
+   - **Issue** — genuine product problems found, or "none"
+3. **Draft GitHub comment** (markdown: verdict, criteria checklist with evidence, video
+   mention). Show it in chat.
+
+**Posting gate — hard rule:** never post to GitHub automatically. Ask the human to
+(a) watch the video and (b) approve the draft. Only after **explicit approval in this
+session** post it with `gh issue comment`. The video cannot be attached via `gh` — tell
+the user to drag the mp4 into the comment on github.com if they want it attached.
+On FAIL, skip the draft entirely (report only).
+
+## Hard rules
+
+- Never commit anything as part of a QA run.
+- Never run the full integration suite.
+- Seeded data: prefix `qa-<issue#>-<epoch>`, leave in place.
+- **Zero footprint beyond declared seed data.** Use Basic auth locally; never leave API
+  tokens behind (they trip the expiry warning that pollutes later recordings) — revoke
+  any minted token: `PUT /api/v1/apitoken/<tokenId>/revoke`.
+- Throwaway scripts: create in `core-web/`, delete after the run.
+- Screenshots/frames beat assumptions: when automated results and expectations disagree,
+  the frames are the tiebreaker.

--- a/.claude/skills/qa/references/api-evidence.md
+++ b/.claude/skills/qa/references/api-evidence.md
@@ -1,0 +1,32 @@
+# API issues: recorded evidence harness
+
+For an API/backend issue, prefer driving the **UI surface** where the behavior shows up —
+that's the strongest video. When no UI surface exists, don't fake one: record an
+**evidence-harness page** instead, so API verification still produces watchable,
+self-documenting proof.
+
+## Pattern
+
+1. Generate a minimal local HTML page in a temp directory (`mktemp -d` — never in the repo) that:
+   - lists each check as a row: **criterion → request → expected → actual → PASS/FAIL**,
+   - executes the calls with `fetch` against `https://localhost:8443` — Basic auth on
+     local dev (or a short-lived JWT revoked in teardown; see environment.md § API auth);
+     inject credentials at runtime, never hardcode them into the generated file,
+   - renders status and response excerpts live as each call completes,
+   - ends with a summary row: `RESULT: n/n PASSED`.
+2. Open it in the recorded Playwright context (`page.goto('file://...')`) — the standard
+   banner/pacing rules from browser-video.md apply.
+3. Assert the real outcome **in the script** (from the fetch results forwarded via
+   `page.evaluate` return values or `page.exposeFunction`), not by reading pixels.
+
+## Rules
+
+- The page runs against the same instance the provenance check validated — never demo/staging.
+- Show full request lines (method + path + relevant params) on screen; truncate response
+  bodies to the fields the criterion is about.
+- Mask anything sensitive (tokens, cookies) — show `Bearer …<last4>` at most.
+- Mutating checks follow the same seeding/naming rules as api-seeding.md
+  (`qa-<issue#>-<epoch>` prefix, leave in place).
+- Verify status codes AND response shape — a 200 with the wrong body is a FAIL.
+- Permission-sensitive endpoints: when the criterion is about authorization, run the call
+  twice — as admin and as a limited user — and show both rows.

--- a/.claude/skills/qa/references/api-seeding.md
+++ b/.claude/skills/qa/references/api-seeding.md
@@ -1,0 +1,56 @@
+# Seeding test data via API
+
+Always seed through the API — driving forms is slow and flaky. On local dev use
+**Basic auth** (`curl -u admin@dotcms.com:admin`) — do NOT mint API tokens: a 1-day token
+triggers the "API Tokens about to expire" warning that then photobombs every recording
+(see environment.md § API auth). If an endpoint truly requires a JWT, mint one and revoke
+it in teardown.
+
+**Naming rule:** prefix every seeded object `qa-<issue#>-<epoch>` and leave it in place
+after the run. The video then shows real, traceable names and the data stays inspectable.
+
+## Content type (with fields)
+
+`POST /api/v1/contenttype` — Block Editor field clazz =
+`com.dotcms.contenttype.model.field.ImmutableStoryBlockField` (dataType LONG_TEXT).
+
+## Contentlet
+
+`PUT /api/v1/workflow/actions/default/fire/NEW` with `{"contentlet": {...}}`.
+
+- **GOTCHA:** a StoryBlock/Block-Editor field value must be a **JSON string**
+  (`JSON.stringify(doc)` / `json.dumps(doc)`), NOT a nested object — otherwise it's stored
+  as a Java map `toString()` (`{type=doc, ...}`, no quotes) and the editor can't parse it.
+
+## Folders
+
+`POST /api/v1/folder/createfolders/{siteName}` with a JSON array of paths, e.g.
+`["/qa-36369-1720000000/sub-a", "/qa-36369-1720000000/sub-b"]`.
+
+## Image / file asset (real, sized, servable)
+
+1. `POST /api/v1/temp` (multipart, field `file`) → `tempFileId`.
+   - **GOTCHA:** rejects 400 "Invalid Origin or referer" unless you send
+     `-H "Origin: https://localhost:8443" -H "Referer: https://localhost:8443/dotAdmin/"`.
+2. `PUT /api/v1/workflow/actions/default/fire/PUBLISH` with
+   `{"contentlet":{"contentType":"dotAsset","asset":"<tempFileId>","hostFolder":"SYSTEM_HOST"}}`.
+3. Served at `/dA/<identifier>`. Reference in block-editor images via `attrs.src = "/dA/<id>"`
+   (data: URIs break — the UI appends `?language_id=1` → `ERR_INVALID_URL`).
+
+## Tags
+
+`POST /api/v2/tags` body `[{"name": "...", "siteId": "..."}]`.
+`siteId: "SYSTEM_HOST"` = global tag; the v2 list endpoint hides global tags unless `global=true`.
+
+## Edge datasets
+
+Seed the shapes the checks need **before** opening the browser:
+
+- Pagination behavior → bulk-create 30+ rows.
+- CSV/formula-injection → seed values starting with `=` `+` `-` `@`.
+- Selection behavior → at least 2 rows (multi-select checks need index 0 and 1).
+
+## Endpoint discovery
+
+OpenAPI spec of the running instance: `https://localhost:8443/api/openapi.json`
+(fallback `https://demo.dotcms.com/api/openapi.json`). Check it before guessing shapes.

--- a/.claude/skills/qa/references/browser-video.md
+++ b/.claude/skills/qa/references/browser-video.md
@@ -1,0 +1,162 @@
+# Browser automation + video recording (Playwright)
+
+## Setup
+
+- Only `playwright-core` is installed (no `@playwright/test`). Import from `'playwright-core'`.
+- Scripts must run **from `core-web/`** (module resolution). Create them there, delete after the run.
+- Browsers: `npx playwright install chromium` (once per machine).
+- Always `ignoreHTTPSErrors: true` (self-signed cert) on both browser and context.
+
+## Recording
+
+```js
+const context = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1280, height: 720 },
+    recordVideo: { dir: VIDEO_DIR, size: { width: 1280, height: 720 } }
+});
+```
+
+- The video file is only finalized on `context.close()`. Capture `page.video()` **before**
+  closing, then `await video.path()` **after**. (`finalize()` in qa-helpers does this.)
+
+## The human QA flow — every recording follows the full journey
+
+The video must read like a competent QA engineer's screen share. No teleporting, no
+unexplained activity, nothing on screen before the viewer knows what they're watching:
+
+1. **Context before activity** — `openLogin(page)`, then `introCard()` over the login
+   screen: issue number/title, the numbered acceptance criteria, environment, fix commit,
+   and **what data this run seeded** (`seeded: [...]` or "none" — so on-screen content
+   can't be mistaken for this run's fixtures). Hold ~5 s (`PACE.intro`).
+2. **Narrated login** — `login(page)`: banner says who is logging in, the cursor is
+   visible from the first click, credentials are typed on camera.
+3. **Navigate like a user** — `navigateMenu(page, group, item)`: click through the left
+   menu by visible labels, exactly as a human reaches the screen. `gotoHash()` is a
+   teleport — last resort for surfaces with no menu entry, and its banner must disclose
+   it on camera. (Its error lists available menu labels — use them, don't fall back
+   silently.)
+4. **Visible cursor everywhere** (`showCursor()` + `humanClick()`): every click travels
+   the pointer to the target. Menu navigation keeps overlays alive (SPA route change);
+   a `gotoHash()` full load kills them — re-apply cursor/checklist/toast-suppression after.
+5. **Live criteria checklist** (`criteriaPanel()`): every acceptance criterion on screen,
+   `○ pending` → `◐ running` when its steps begin → `✔`/`✘` **only after the assertion
+   returns**. The panel documents the run; it never predicts it.
+6. **Step banner** (`banner()`): what's happening right now, in plain words.
+7. **Park + verdict** — `parkCursor()` moves the dot to neutral space (a dot resting on a
+   checkbox reads as state), then `finalize(..., { criteria })` shows
+   `PASS — 4/4 criteria verified (8 assertions)` — the count matches what the intro
+   promised, held ~3 s (with tiny cursor moves: the paint-driven recorder truncates a
+   fully static tail).
+
+Pacing: `slowMo: 150` on launch, and one `PACE.beat` (~1.2 s) **after** each state change
+so the viewer sees the result settle. Don't also pad before the action — a banner staring
+at a static screen for seconds is dead air. Pacing changes watchability only; assertions
+stay DOM-based and unaffected.
+
+## What may go on the checklist
+
+Only the issue's acceptance criteria. Extra assertions you find useful (intermediate
+states, adjacent behavior) live in the console log and the QA brief — putting out-of-scope
+claims on camera invites "why is that there?" and dilutes trust.
+
+## Integrity rules — the video must be beyond doubt
+
+- **One unedited take.** The delivered video is a single continuous recording of the run
+  that produced the SUMMARY results. Never splice, trim failures out, or re-shoot a single
+  step; if the script needs fixing, re-run the whole session and deliver the new take.
+- **Verdicts follow assertions.** Nothing on screen may claim PASS/FAIL before the
+  corresponding DOM/network assertion has actually returned in the script.
+- **Overlays narrate, never obscure — and never intercept.** Banner top, checklist
+  bottom-right, cursor dot — none may cover the UI element under verification, and every
+  overlay MUST have `pointer-events: none`. An overlay that eats a click silently changes
+  what the run actually did (learned the hard way: the banner sat over the nav toggle and
+  swallowed its click, so raw `page.mouse.click` hit the banner while the video looked
+  like a click on the app).
+- **No staged state.** Only the declared seeded data (visible `qa-<issue#>-...` names on
+  camera) — no hidden fixtures, no pre-toggled UI, no mocked responses. The intro card
+  declares what this run seeded; leftover `qa-*` data from earlier runs must not be
+  passed off as this run's.
+- **Visually-true assertions.** `visible()` (offsetParent) is for absence/presence.
+  Any claim the viewer should SEE uses `visibleArea()` — a DOM-attached but visually
+  empty container (e.g. an actions bar with no actions for the selection) must FAIL,
+  not pass. A technically-true-but-invisible PASS is a report finding, never a video claim.
+- **System noise is suppressed, not cropped.** `suppressToasts()` keeps unrelated toasts
+  (token expiry etc.) off camera for the whole session — cosmetic cleanup, disclosed here,
+  touching nothing under verification.
+
+## Convert + deliver
+
+```bash
+ffmpeg -i run.webm -c:v libx264 -pix_fmt yuv420p -movflags +faststart out.mp4
+# ffmpeg missing? install via the machine's package manager (brew / apt / dnf)
+cp out.mp4 "$HOME/Downloads/qa-<issue#>-<short-slug>.mp4"   # or leave in temp dir if no Downloads
+```
+
+## Frame forensics — mandatory before reporting a FAIL
+
+```bash
+ffmpeg -i run.webm -vf fps=1 frames/f_%03d.png
+```
+
+Then **Read the PNGs** around the failing step. A FAIL can be the script's fault:
+on #36369 the "2 selected: Upload still hidden" check failed because the click had
+*deselected* a row — visible instantly in the frames, invisible in the logs.
+
+## Hard-won gotchas (each cost a full re-run once)
+
+### Login: the submit button stays disabled
+`page.fill` immediately after load does not enable Angular's login form. Do:
+
+```js
+await page.waitForSelector('[data-testid="userNameInput"]');
+await page.waitForTimeout(1000);                                   // let Angular wire the form
+await page.type('[data-testid="userNameInput"]', user, { delay: 20 });
+await page.type('[data-testid="password"]', pass, { delay: 20 });
+await page.waitForSelector('[data-testid="submitButton"]:not([disabled])');
+await page.click('[data-testid="submitButton"]');
+```
+
+Older `playwright-core` has **no `pressSequentially`** — `page.type` is the portable call.
+
+### Comma-selector double-match
+`page.$$('td .p-checkbox, td p-tablecheckbox')` matched every row **twice** (40 handles for
+20 rows), so `rows[1]` was row 0's checkbox again and clicking it toggled the selection OFF
+→ false FAIL. Rules:
+- One selector per element set, never comma-alternatives that can hit the same node.
+- Sanity-check `handles.length` against the expected count (paginator rows-per-page)
+  before any index math.
+
+### Animation-gated `@if`
+Elements inside `@if` leave the DOM only after their leave animation completes. Never assert
+at a fixed delay after the trigger — poll with `waitFor(fn)` (200 ms interval, ~8 s budget).
+
+### Toast overlays block clicks
+System toasts cover top-right buttons → `click` times out at 30 s. `login()`/`navigateMenu()`
+install `suppressToasts()` (MutationObserver) automatically; re-call it after a `gotoHash()`
+full load. The worst offender — "API Tokens about to expire" — is self-inflicted: QA runs
+that mint short-lived API tokens trip it for every later recording. Fix the cause, not the
+symptom: Basic auth for seeding, revoke any minted token (environment.md § API auth).
+
+### Legacy editor = iframe
+The legacy content editor renders inside an iframe (struts JSP). Find the right frame by
+iterating `page.frames()` for one where the target selector exists; interact via
+`frame.evaluate(...)`.
+
+### Which component actually rendered?
+A URL being "legacy" (`#/c/content/...`) doesn't mean the field inside is the legacy
+component — feature flags swap them. Confirm by DOM signature before hunting UI elements.
+
+## Assertion patterns stronger than screenshots
+
+- **Visibility**: `el.offsetParent !== null` by data-testid (see `visible()` helper).
+- **Focus**: `page.evaluate(() => document.activeElement === document.querySelector(sel))`.
+- **A request really left the browser**: `page.on('request', ...)` and filter the URL.
+- **Downloaded file bytes**: `newContext({ acceptDownloads: true })`, register
+  `page.waitForEvent('download')` **before** the click, then read `await dl.path()`.
+
+## Automate-vs-human boundary
+
+Deterministic state (visibility, focus, counts, network params, file bytes) → automate and
+assert. Transient CSS (a fade that must not flash) → report as the one residual manual
+check; never fake-certify it with fixed-delay screenshots.

--- a/.claude/skills/qa/references/environment.md
+++ b/.claude/skills/qa/references/environment.md
@@ -1,0 +1,104 @@
+# Environment: detect, start, provenance
+
+## Detect a running instance
+
+```bash
+curl -sk -o /dev/null -w "%{http_code}" https://localhost:8443/dotAdmin/ --max-time 5      # 200|302 = up
+CONTAINER=$(docker ps --format '{{.Names}}' | grep -E 'dotcms-core.*_dotcms$' | head -1)    # discover, never hardcode
+# (plain `grep dotcms-core` also matches the opensearch/database sidecars — anchor on the _dotcms suffix)
+```
+
+The compose project prefix varies by machine — always discover the container name as above
+and use `$CONTAINER` in every `docker exec/inspect/restart` below.
+URL `https://localhost:8443/dotAdmin` (self-signed cert). Default dev login: `admin@dotcms.com` / `admin`.
+The helpers honor `DOTCMS_URL` if the instance is elsewhere.
+
+## Start if not running
+
+```bash
+just dev-run-fixed        # fixed ports: HTTP 8080, HTTPS 8443, mgmt 8090 — designed for agentic/CI use
+just dev-wait-ready       # polls /dotmgt/readyz, ~100s budget
+```
+
+Postgres + OpenSearch come up first, the app last (~2–4 min). The Maven launcher process may
+exit 0 while the container keeps running — that's fine. Fallback readiness loop:
+
+```bash
+until curl -sk -o /dev/null -w "%{http_code}" https://localhost:8443/dotAdmin/ | grep -qE "200|302"; do sleep 5; done
+```
+
+## Provenance: prove the served build contains the fix
+
+Trust the chain, not the merge badge:
+
+```bash
+# 1. Fix is in the local tree
+git merge-base --is-ancestor <fixCommit> HEAD && echo OK
+
+# 2. When was the running container's frontend built?
+docker inspect <container> --format '{{.Created}}'
+docker exec <container> sh -c 'ls -la /srv/dotserver/tomcat/webapps/ROOT/dotAdmin/*.js | head -3'   # bundle mtimes
+
+# 3. What commit was the tree at, at that build time?
+git reflog --date=iso | grep <build-date>
+
+# 4. Was the fix an ancestor of that commit?
+git merge-base --is-ancestor <fixCommit> <commit-at-build-time> && echo "FIX IN SERVED BUNDLE"
+```
+
+Served frontend bundles live at `/srv/dotserver/tomcat/webapps/ROOT/{dotAdmin,dotcms-block-editor,...}/`.
+
+- Timeline evidence beats grepping minified bundles: template details like `animate.enter`
+  compile to Angular *instructions*, not attributes, so they don't appear in the consts
+  arrays — a structural grep can false-negative on a build that has the fix.
+- Grep the served bundle only when the fix introduced a **unique string literal** (literals
+  survive minification):
+
+```bash
+docker exec <container> sh -c 'grep -l "<unique-literal>" /srv/dotserver/tomcat/webapps/ROOT/dotAdmin/*.js'
+```
+
+If the bundle predates the fix: `./mvnw install -pl :dotcms-core --am -DskipTests` and restart.
+
+## API auth (for seeding — see api-seeding.md)
+
+**Use Basic auth on local dev — do NOT mint API tokens.**
+
+```bash
+curl -sk -u admin@dotcms.com:admin https://localhost:8443/api/v1/...
+```
+
+Why: an API token created with `expirationDays: 1` immediately trips dotCMS's
+"Some API Tokens are about to expire" admin warning (`apitoken.expiry.admin.message`),
+which then squats over the toolbar in every recording — the QA harness polluting the
+environment it films. If an endpoint genuinely requires a JWT, mint one and **revoke it
+in teardown**:
+
+```bash
+# mint:  POST /api/v1/authentication/api-token  {"user":...,"password":...,"expirationDays":1}
+# teardown (mandatory):
+curl -sk -u admin@dotcms.com:admin -X PUT https://localhost:8443/api/v1/apitoken/<tokenId>/revoke
+# audit what's lingering:  GET /api/v1/apitoken/dotcms.org.1/tokens
+```
+
+## Feature flags (many "wrong UI" mysteries are flags)
+
+`ConfigUtils.isFeatureFlagOn(name)` defaults **ON** (`Config.getBooleanProperty(name, true)`).
+Flip at runtime without a rebuild — a config-file edit survives `docker restart` (env vars don't):
+
+```bash
+docker exec <container> sh -c 'echo "FLAG_NAME=false" >> /srv/dotserver/tomcat/webapps/ROOT/WEB-INF/classes/dotmarketing-config.properties'
+docker restart <container>    # ~1–2 min
+```
+
+## Frontend unit-test environment
+
+- Package manager is **pnpm via corepack** (not yarn). Try `corepack pnpm ...` directly
+  (with `export COREPACK_ENABLE_DOWNLOAD_PROMPT=0`); if corepack/node isn't on PATH,
+  activate the repo's Node version first — `.nvmrc` declares it (e.g. `nvm use` if the
+  machine uses nvm). Don't assume a specific version-manager install path.
+- Jest pattern goes **positionally**: `corepack pnpm nx test <project> -- <pattern>`
+  (`--testPathPattern` errors on this Jest).
+- Suite-level failure `Cannot find module '@openng/spectator/jest'` with 0 tests run =
+  stale `node_modules` after a dependency swap → `corepack pnpm install`, retry. Not a product failure.
+- Portlet project names: `portlets-dot-<feature>-portlet`; content-drive is `portlets-content-drive`.

--- a/.claude/skills/qa/scripts/qa-helpers.mjs
+++ b/.claude/skills/qa/scripts/qa-helpers.mjs
@@ -1,0 +1,383 @@
+/**
+ * Shared helpers for /qa recorded verification runs.
+ *
+ * Import from a throwaway script created in core-web/ and INJECT chromium from there —
+ * bare specifiers resolve from this file's location, which has no node_modules, so the
+ * throwaway script must own the playwright-core import:
+ *
+ *   import { chromium } from 'playwright-core';
+ *   import { launchRecorded, openLogin, login, navigateMenu, introCard, showCursor,
+ *            criteriaPanel, humanClick, banner, visible, visibleArea, waitFor,
+ *            makeChecker, finalize, PACE } from '../.claude/skills/qa/scripts/qa-helpers.mjs';
+ *   const { browser, context, page } = await launchRecorded(chromium, VIDEO_DIR);
+ *
+ * Uses page.type (portable across older playwright-core versions that lack pressSequentially).
+ */
+export const BASE = process.env.DOTCMS_URL || 'https://localhost:8443';
+
+/** Pacing for a watchable, human-speed recording (ms). */
+export const PACE = { beat: 1200, intro: 5000 };
+
+/**
+ * Launch a recorded 1280x720 session. Pass in chromium from playwright-core.
+ * slowMo paces every Playwright action so the video reads like manual QA —
+ * keep it 100–200; it slows the recording, it does not change what is asserted.
+ */
+export async function launchRecorded(chromium, videoDir, { headless = true, slowMo = 150 } = {}) {
+    const browser = await chromium.launch({ headless, slowMo });
+    const context = await browser.newContext({
+        ignoreHTTPSErrors: true,
+        viewport: { width: 1280, height: 720 },
+        recordVideo: { dir: videoDir, size: { width: 1280, height: 720 } }
+    });
+    const page = await context.newPage();
+    return { browser, context, page };
+}
+
+/** Open the login screen and wait for it to render — the canvas for introCard(). */
+export async function openLogin(page) {
+    await page.goto(`${BASE}/dotAdmin/`, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-testid="userNameInput"]', { timeout: 30000 });
+}
+
+/**
+ * Log into dotAdmin the way a human does, narrated: banner + visible cursor from the very
+ * first frame, typed credentials, cursor travels to Sign In. Call openLogin() + introCard()
+ * BEFORE this (card over the login screen) so the viewer has context before any activity.
+ */
+export async function login(page, user = 'admin@dotcms.com', pass = 'admin') {
+    if (!page.url().startsWith(BASE)) {
+        await page.goto(`${BASE}/dotAdmin/`, { waitUntil: 'domcontentloaded' });
+    }
+    await page.waitForSelector('[data-testid="userNameInput"]', { timeout: 30000 });
+    await showCursor(page);
+    await banner(page, `Logging in as ${user}`);
+    await page.waitForTimeout(1000); // let Angular wire up the form
+    await humanClick(page, '[data-testid="userNameInput"]');
+    await page.type('[data-testid="userNameInput"]', user, { delay: 20 });
+    await humanClick(page, '[data-testid="password"]');
+    await page.type('[data-testid="password"]', pass, { delay: 20 });
+    await page.waitForSelector('[data-testid="submitButton"]:not([disabled])', { timeout: 15000 });
+    await humanClick(page, '[data-testid="submitButton"]');
+    await page.waitForURL(/dotAdmin\/#\//, { timeout: 30000 });
+    await suppressToasts(page);
+}
+
+/**
+ * Navigate to a portlet through the left menu, like a user: click the menu group by its
+ * visible label, then the submenu entry by its label. Labels are matched case-insensitively
+ * on trimmed text. Throws with the list of AVAILABLE labels when a label isn't found, so a
+ * failed run tells you what to call instead.
+ * The dotAdmin shell is an SPA — overlays (banner/cursor/checklist) survive this navigation.
+ */
+export async function navigateMenu(page, groupLabel, itemLabel) {
+    await banner(page, `Navigating: ${groupLabel} → ${itemLabel}`);
+    await page.waitForSelector('[data-testid="nav-item-main"]', { timeout: 30000 });
+
+    // Expand the sidebar if collapsed — a collapsed menu only shows submenus as hover
+    // flyouts that close while the cursor travels to them; humans (and this helper)
+    // work with the expanded menu and its inline submenus.
+    const collapsed = await page.evaluate(() => !!document.querySelector('nav.collapsed'));
+    if (collapsed) {
+        await humanClick(page, '[data-testid="dot-nav-header-toggle-button"]');
+        await page.waitForTimeout(500); // expand animation
+    }
+
+    // A link only counts as visible if a click at its center would actually LAND on it
+    // (elementFromPoint) — collapsed submenus keep their links in the DOM with nonzero
+    // rects (hidden by overflow), so geometry alone lies.
+    const findLink = (label) => page.evaluate((label) => {
+        const links = [...document.querySelectorAll('a.dot-nav-sub__link')].filter((a) => {
+            const r = a.getBoundingClientRect();
+            if (r.width < 2 || r.height < 2) return false;
+            const hit = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+            return !!hit && (a.contains(hit) || hit.contains(a));
+        });
+        const labels = links.map((a) => a.textContent.trim());
+        const i = labels.findIndex((l) => l.toLowerCase() === label.toLowerCase());
+        if (i === -1) return { labels };
+        const r = links[i].getBoundingClientRect();
+        return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    }, label);
+
+    // Open the group only if the target link isn't already visible (clicking an open
+    // group would close it).
+    let item = await findLink(itemLabel);
+    if (item.labels) {
+        const group = await page.evaluate((label) => {
+            const mains = [...document.querySelectorAll('[data-testid="nav-item-main"]')];
+            const labels = mains.map((m) =>
+                m.querySelector('[data-testid="nav-item-label"]')?.textContent.trim() || '');
+            const i = labels.findIndex((l) => l.toLowerCase() === label.toLowerCase());
+            if (i === -1) return { labels };
+            const r = mains[i].getBoundingClientRect();
+            return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+        }, groupLabel);
+        if (group.labels) throw new Error(
+            `navigateMenu: group "${groupLabel}" not found. Available groups: ${group.labels.join(' | ')}`);
+        await page.mouse.move(group.x, group.y, { steps: 12 });
+        await page.waitForTimeout(350);
+        await page.mouse.click(group.x, group.y, { delay: 60 });
+        const opened = await waitFor(async () => !(await findLink(itemLabel)).labels, 5000);
+        item = await findLink(itemLabel);
+        if (!opened || item.labels) throw new Error(
+            `navigateMenu: item "${itemLabel}" not visible under "${groupLabel}". Visible items: ${(item.labels || []).join(' | ')}`);
+    }
+    const urlBefore = page.url();
+    await page.mouse.move(item.x, item.y, { steps: 10 });
+    await page.waitForTimeout(350);
+    await page.mouse.click(item.x, item.y, { delay: 60 });
+    // Trust requires proof the navigation actually happened — a helper that returns after
+    // a click that landed nowhere turns every downstream assertion into noise.
+    const navigated = await waitFor(() => page.url() !== urlBefore, 10000);
+    if (!navigated) throw new Error(
+        `navigateMenu: clicked "${itemLabel}" but the route never changed (still ${urlBefore})`);
+    await suppressToasts(page);
+}
+
+/**
+ * Navigate to a dotAdmin hash route DIRECTLY — a teleport, not a human flow.
+ * Last resort for surfaces with no menu entry; the banner discloses it on camera.
+ * This is a full page load: re-apply showCursor/criteriaPanel/suppressToasts after it.
+ */
+export async function gotoHash(page, route) {
+    await banner(page, `Opening ${route} directly (no menu entry for this screen)`).catch(() => {});
+    await page.goto(`${BASE}/dotAdmin/#${route}`, { waitUntil: 'domcontentloaded' });
+}
+
+/** Close PrimeNG toasts that overlap toolbar buttons (they reappear after navigation). */
+export async function dismissToasts(page) {
+    for (let i = 0; i < 5; i++) {
+        const t = await page.$('.p-toast-icon-close, .p-toast-message-icon-close');
+        if (!t) break;
+        await t.click().catch(() => {});
+        await page.waitForTimeout(300);
+    }
+}
+
+/**
+ * Keep system toasts (e.g. "API Tokens about to expire") off camera for the whole session
+ * via a MutationObserver that closes them as they appear. Cosmetic cleanup only — it
+ * touches nothing under verification. Dies on a full page load; login()/navigateMenu()
+ * re-apply it, re-call it yourself after gotoHash().
+ */
+export async function suppressToasts(page) {
+    await page.evaluate(() => {
+        if (window.__qaToastKiller) return;
+        const kill = () => document
+            .querySelectorAll('.p-toast-icon-close, .p-toast-message-icon-close')
+            .forEach((b) => b.click());
+        kill();
+        window.__qaToastKiller = new MutationObserver(kill);
+        window.__qaToastKiller.observe(document.body, { childList: true, subtree: true });
+    });
+}
+
+/**
+ * Full-screen intro card: issue number/title, the acceptance criteria about to be
+ * verified, and provenance (env + fix commit) — so a viewer has context before any
+ * action happens. Holds PACE.intro ms, then removes itself.
+ */
+export async function introCard(page, { issue, title, criteria, commit, seeded }, hold = PACE.intro) {
+    await page.evaluate(({ issue, title, criteria, commit, seeded, base }) => {
+        const el = document.createElement('div');
+        el.id = 'qa-intro';
+        Object.assign(el.style, {
+            position: 'fixed', inset: '0', zIndex: '100000', background: '#111827',
+            color: '#f9fafb', font: '400 16px/1.6 system-ui', padding: '48px 64px',
+            display: 'flex', flexDirection: 'column', justifyContent: 'center'
+        });
+        const li = criteria.map((c, i) => `<li style="margin:4px 0">${i + 1}. ${c}</li>`).join('');
+        el.innerHTML =
+            `<div style="opacity:.7;letter-spacing:.1em;font-size:13px">dotCMS QA — RECORDED VERIFICATION</div>
+             <h1 style="font-size:26px;margin:12px 0 4px">Issue #${issue} — ${title}</h1>
+             <div style="margin:16px 0 8px;font-weight:600">Verifying ${criteria.length} acceptance criteria:</div>
+             <ol style="list-style:none;margin:0;padding:0">${li}</ol>
+             <div style="margin-top:24px;opacity:.7;font-size:13px">Environment: ${base} · Fix commit: ${commit || 'n/a'} · Single unedited take</div>
+             <div style="opacity:.7;font-size:13px">Data seeded this run: ${seeded && seeded.length ? seeded.join(', ') : 'none'}</div>`;
+        document.body.appendChild(el);
+    }, { issue, title, criteria, commit, seeded, base: BASE });
+    await page.waitForTimeout(hold);
+    await page.evaluate(() => document.getElementById('qa-intro')?.remove());
+}
+
+/**
+ * Live criteria checklist (bottom-right). Re-render with the full items array after every
+ * status change or navigation — it is idempotent. Status: 'pending' | 'running' | 'pass' | 'fail'.
+ * A criterion may only be flipped to pass/fail AFTER its DOM assertion returned — the
+ * checklist documents the run, it never predicts it.
+ */
+export async function criteriaPanel(page, items) {
+    await page.evaluate((items) => {
+        let el = document.getElementById('qa-criteria');
+        if (!el) {
+            el = document.createElement('div');
+            el.id = 'qa-criteria';
+            Object.assign(el.style, {
+                position: 'fixed', right: '12px', bottom: '12px', zIndex: '99998',
+                background: 'rgba(17,24,39,.92)', color: '#f9fafb', borderRadius: '8px',
+                font: '500 12px/1.5 system-ui', padding: '10px 14px', maxWidth: '380px',
+                pointerEvents: 'none'
+            });
+            document.body.appendChild(el);
+        }
+        const icon = { pending: '○', running: '◐', pass: '✔', fail: '✘' };
+        const color = { pending: '#9ca3af', running: '#fbbf24', pass: '#34d399', fail: '#f87171' };
+        el.innerHTML = items.map((it) =>
+            `<div style="color:${color[it.status]};white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${icon[it.status]} ${it.text}</div>`
+        ).join('');
+    }, items);
+}
+
+/**
+ * Render a cursor dot that follows the REAL mouse events (page.mouse.*) so viewers can
+ * see where each click lands. Pure visualization of genuine input — call again after
+ * any navigation (listeners don't survive a page load).
+ */
+export async function showCursor(page) {
+    await page.evaluate(() => {
+        if (document.getElementById('qa-cursor')) return;
+        const dot = document.createElement('div');
+        dot.id = 'qa-cursor';
+        Object.assign(dot.style, {
+            position: 'fixed', width: '18px', height: '18px', borderRadius: '50%',
+            background: 'rgba(251,191,36,.55)', border: '2px solid #b45309',
+            zIndex: '100001', pointerEvents: 'none', transform: 'translate(-50%,-50%)',
+            transition: 'width .15s, height .15s', left: '-100px', top: '-100px'
+        });
+        document.body.appendChild(dot);
+        document.addEventListener('mousemove', (e) => {
+            dot.style.left = e.clientX + 'px';
+            dot.style.top = e.clientY + 'px';
+        }, true);
+        document.addEventListener('mousedown', () => { dot.style.width = '28px'; dot.style.height = '28px'; }, true);
+        document.addEventListener('mouseup', () => { dot.style.width = '18px'; dot.style.height = '18px'; }, true);
+    });
+}
+
+/**
+ * Click like a human: travel the mouse to the element's center in visible steps,
+ * pause a beat, then click at those coordinates. Real input events end-to-end.
+ * Accepts an ElementHandle or a selector string.
+ */
+export async function humanClick(page, target, { pause = 350 } = {}) {
+    const handle = typeof target === 'string' ? await page.waitForSelector(target) : target;
+    const box = await handle.boundingBox();
+    if (!box) throw new Error('humanClick: target has no bounding box (not visible?)');
+    const x = box.x + box.width / 2, y = box.y + box.height / 2;
+    await page.mouse.move(x, y, { steps: 12 });
+    await page.waitForTimeout(pause);
+    await page.mouse.click(x, y, { delay: 60 });
+}
+
+/** On-screen narration banner so the video is self-documenting. */
+export async function banner(page, text) {
+    await page.evaluate((t) => {
+        let el = document.getElementById('qa-banner');
+        if (!el) {
+            el = document.createElement('div');
+            el.id = 'qa-banner';
+            Object.assign(el.style, {
+                position: 'fixed', top: '0', left: '0', right: '0', zIndex: '99999',
+                background: '#111827', color: '#f9fafb', font: '600 15px/1.4 system-ui',
+                padding: '8px 16px', textAlign: 'center', opacity: '0.92',
+                pointerEvents: 'none' // overlays must NEVER intercept clicks meant for the app
+            });
+            document.body.appendChild(el);
+        }
+        el.textContent = t;
+    }, text);
+}
+
+/**
+ * True when the element exists and is rendered (offsetParent check).
+ * Right for absence/presence claims ("button is gone"). For "the user can SEE it",
+ * use visibleArea() — an attached but EMPTY container passes this check.
+ */
+export function visible(page, testid) {
+    return page.evaluate((id) => {
+        const el = document.querySelector(`[data-testid="${id}"]`);
+        return !!el && el.offsetParent !== null;
+    }, testid);
+}
+
+/**
+ * True when the element is rendered AND occupies real pixels (≥ minPx area).
+ * Use for any claim the viewer must be able to see on camera — a DOM-attached but
+ * visually empty container (e.g. an actions bar with no actions) correctly FAILS this.
+ */
+export function visibleArea(page, testid, minPx = 100) {
+    return page.evaluate(({ id, minPx }) => {
+        const el = document.querySelector(`[data-testid="${id}"]`);
+        if (!el || el.offsetParent === null) return false;
+        const r = el.getBoundingClientRect();
+        return r.width * r.height >= minPx;
+    }, { id: testid, minPx });
+}
+
+/**
+ * Park the cursor in neutral space (breadcrumb header area) so the final frames don't
+ * show the dot hovering an interactive element that could be misread as state.
+ */
+export async function parkCursor(page) {
+    await page.mouse.move(500, 45, { steps: 8 });
+}
+
+/** Poll a predicate — required for anything gated by enter/leave animations. */
+export async function waitFor(fn, timeout = 8000, interval = 200) {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        if (await fn()) return true;
+        await new Promise((r) => setTimeout(r, interval));
+    }
+    return false;
+}
+
+/** Check collector: const { check, results, allPass } = makeChecker(); */
+export function makeChecker() {
+    const results = [];
+    return {
+        results,
+        check(name, ok) {
+            results.push({ name, ok: !!ok });
+            console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}`);
+        },
+        allPass: () => results.every((r) => r.ok),
+        summary: () =>
+            `${results.filter((r) => r.ok).length}/${results.length}`
+    };
+}
+
+/**
+ * Show the final verdict banner, print SUMMARY + VIDEO lines, and close everything.
+ * Must be called even on error (wrap the run in try/finally) or the video is lost.
+ * Pass the criteria items array so the banner counts CRITERIA (what the intro promised),
+ * with assertions as supporting detail — "4/4 criteria verified (8 assertions)".
+ */
+export async function finalize(browser, context, page, checker, { criteria } = {}) {
+    try {
+        if (checker) {
+            await parkCursor(page).catch(() => {});
+            const verdict = criteria
+                ? `${criteria.filter((c) => c.status === 'pass').length}/${criteria.length} criteria verified (${checker.summary()} assertions)`
+                : `(${checker.summary()})`;
+            await banner(
+                page,
+                `QA RESULT: ${checker.allPass() ? 'PASS ✔' : 'FAIL — see log'} — ${verdict}`
+            );
+            // The recorder is paint-driven: a fully static page stops producing frames and
+            // the trailing verdict hold gets truncated from the file. Tiny real cursor
+            // moves force frames so the verdict actually survives ~3s on screen.
+            for (let i = 0; i < 6; i++) {
+                await page.mouse.move(500 + (i % 2 ? 2 : -2), 45, { steps: 2 }).catch(() => {});
+                await page.waitForTimeout(500);
+            }
+            console.log('\nSUMMARY ' + JSON.stringify(checker.results));
+        }
+    } finally {
+        const video = page.video();
+        await context.close(); // finalizes the video file
+        if (video) console.log('VIDEO ' + (await video.path()));
+        await browser.close();
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Adds a Claude Code skill (`/qa <issue# | PR# | url>`) that QAs a merged fix end-to-end against a local dotCMS instance and delivers a **single-take video as proof of verification**, plus a terse QA brief and a draft comment for human review.

### What it does

1. Resolves issue → merged PR → fix commit, and **proves provenance**: the served bundle must have been built from a tree containing the fix (container created-time + `git reflog` + `merge-base --is-ancestor`) before any testing.
2. Runs the PR's own test files first (cheapest ground truth).
3. Detects a running instance on the fixed ports or starts one (`just dev-run-fixed` + `dev-wait-ready`).
4. Drives the real UI **like a human QA engineer, on camera**: intro card listing the acceptance criteria + seeded-data declaration, narrated login, left-menu navigation by visible labels, visible cursor travel for every click, live criteria checklist that flips ✔/✘ only after each DOM assertion returns, verdict banner counting criteria.
5. Self-verifies any FAIL via frame forensics (ffmpeg frame extraction) before reporting — distinguishes product failures from script artifacts.

### Integrity rules (codified in `references/browser-video.md`)

- One unedited take — the delivered video is the exact run that produced the results
- Overlays narrate but are pointer-transparent — they can never intercept a click meant for the app
- Visually-true assertions — an attached-but-empty container fails `visibleArea()`, never passes as "shown"
- Zero environment footprint — Basic auth for seeding (no lingering API tokens, which trip the token-expiry warning), seeded data prefixed `qa-<issue#>-<epoch>` and declared on camera
- Never posts to GitHub without explicit human approval of both the draft comment and the video

### Portability

No hardcoded paths, usernames, or container names — containers are discovered at runtime, the environment is the repo-standard fixed-port recipe, `DOTCMS_URL` overrides supported, Node/pnpm resolved per `.nvmrc`/corepack.

### Validation

Battle-tested by QAing #36369 (Content Drive: hide Upload button when items are selected): 4/4 acceptance criteria verified, 7/7 assertions, 31s recording reviewed frame-by-frame. Four failed takes during development each exposed and fixed a real generic bug (overlay click interception, hidden-link geometry false positives, hover-flyout misclicks, paint-driven recorder truncation).

### Note

No linked GitHub issue yet — branch naming deviates from the `issue-N-` convention for that reason; happy to retro-link one if we file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)