### PR TITLE
fix(edit-content): position-based right-align for relationship last column

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
@@ -26,7 +26,7 @@
             @for (column of columns; track $index) {
                 @switch (column.type) {
                     @case ('title') {
-                        <th scope="col" class="min-w-0 flex-1">
+                        <th scope="col" class="min-w-0 flex-1" [class.text-right!]="$last">
                             {{ 'dot.file.relationship.field.table.title' | dm }}
                         </th>
                     }
@@ -34,6 +34,7 @@
                         <th
                             scope="col"
                             class="w-32 max-w-32 min-w-32"
+                            [class.text-right!]="$last"
                             data-testid="relationship-locale-header">
                             {{ 'dot.file.relationship.field.table.language' | dm }}
                         </th>
@@ -41,18 +42,19 @@
                     @case ('status') {
                         <th
                             scope="col"
-                            class="w-32 max-w-32 min-w-32 text-right!"
+                            class="w-32 max-w-32 min-w-32"
+                            [class.text-right!]="$last"
                             data-testid="relationship-status-header">
                             {{ 'dot.file.relationship.field.table.status' | dm }}
                         </th>
                     }
                     @case ('image') {
-                        <th scope="col" class="w-24 max-w-24 min-w-24">
+                        <th scope="col" class="w-24 max-w-24 min-w-24" [class.text-right!]="$last">
                             <p class="truncate capitalize">{{ column.header }}</p>
                         </th>
                     }
                     @default {
-                        <th scope="col" class="w-32 max-w-32 min-w-32">
+                        <th scope="col" class="w-32 max-w-32 min-w-32" [class.text-right!]="$last">
                             <span class="capitalize">{{ column.header }}</span>
                         </th>
                     }
@@ -122,7 +124,10 @@
             @for (column of columns; track $index) {
                 @switch (column.type) {
                     @case ('title') {
-                        <td class="min-w-0 flex-1" [class.cursor-not-allowed]="isDisabled">
+                        <td
+                            class="min-w-0 flex-1"
+                            [class.cursor-not-allowed]="isDisabled"
+                            [class.text-right!]="$last">
                             <div class="flex items-center gap-3">
                                 @if (showThumbnail) {
                                     <div
@@ -138,7 +143,10 @@
                         </td>
                     }
                     @case ('language') {
-                        <td class="w-32 max-w-32 min-w-32" [class.cursor-not-allowed]="isDisabled">
+                        <td
+                            class="w-32 max-w-32 min-w-32"
+                            [class.cursor-not-allowed]="isDisabled"
+                            [class.text-right!]="$last">
                             @if (item.language | language; as localeLabel) {
                                 <p-tag
                                     class="whitespace-nowrap"
@@ -150,13 +158,17 @@
                     }
                     @case ('status') {
                         <td
-                            class="w-32 max-w-32 min-w-32 text-right!"
-                            [class.cursor-not-allowed]="isDisabled">
+                            class="w-32 max-w-32 min-w-32"
+                            [class.cursor-not-allowed]="isDisabled"
+                            [class.text-right!]="$last">
                             <dot-contentlet-status-badge [state]="item" />
                         </td>
                     }
                     @case ('image') {
-                        <td class="w-24 max-w-24 min-w-24" [class.cursor-not-allowed]="isDisabled">
+                        <td
+                            class="w-24 max-w-24 min-w-24"
+                            [class.cursor-not-allowed]="isDisabled"
+                            [class.text-right!]="$last">
                             <div class="flex items-center justify-center">
                                 <div class="h-14 w-20 shrink-0 overflow-hidden rounded-md">
                                     <dot-content-thumbnail
@@ -168,7 +180,7 @@
                         </td>
                     }
                     @default {
-                        <td class="w-32 max-w-32 min-w-32">
+                        <td class="w-32 max-w-32 min-w-32" [class.text-right!]="$last">
                             <p class="truncate">{{ item[column.nameField] }}</p>
                         </td>
                     }


### PR DESCRIPTION
## What

Fixes the `showFields` column-alignment bug in the new Edit Content **Relationship field** table.

The table hardcoded right-alignment (`text-right!`) to the `status` column *type*, assuming `status` is always the last data column (flush against the `+` action column). When the `showFields` field variable reorders columns (e.g. `Status, Locales` instead of `Locales, Status`), the status chip was pushed to the right edge of a now-middle column and collided visually with the next column.

## How

Right-alignment is now **positional** instead of type-based: it is bound to the last data column via the `@for` `$last` context (`[class.text-right!]="$last"`) on every column cell, in both the header and body templates. Whichever column renders last hugs the action column, regardless of its type.

Uses the `[class.foo!]` conditional-important syntax already established in the codebase (e.g. `[class.bg-white!]` in the locales sidebar selector).

- The default layout (`title, language, status`) is visually unchanged — `status` is still last, so it still right-aligns.
- With `showFields` reordering, the last column right-aligns and the previously-misplaced `text-right!` on a mid-table status column is gone.

## Scope

Template-only change. No TypeScript, SCSS, or store changes.

## Acceptance criteria

- [x] With `showFields` adding/reordering columns, the relationship field renders correctly — no misaligned chips
- [x] Chips/tags continue to render as specified (locale tag, status badge)
- [x] Default layout unchanged

## Testing

- `nx lint edit-content` — passing (no new warnings)
- `nx test edit-content --testPathPatterns=dot-relationship-field.component.spec` — 12/12 passing
- Manually verified in the browser

Closes #36155