### PR TITLE
fix(block-editor): register storyblock render.vtl as a velocimacro library (#35984)

### DIFF
--- a/dotCMS/src/main/resources/system.properties
+++ b/dotCMS/src/main/resources/system.properties
@@ -117,7 +117,7 @@ input.encoding=UTF-8
 output.encoding=UTF-8
 
 velocimacro.library.autoreload=false
-velocimacro.library=VM_global_library.vm,dotCMS_library.vm,dotCMS_library_ext.vm
+velocimacro.library=VM_global_library.vm,dotCMS_library.vm,dotCMS_library_ext.vm,static/storyblock/render.vtl
 velocimacro.permissions.allow.inline.to.replace.global=true
 directive.parse.max.depth=100
 directive.if.tostring.nullcheck=false

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
@@ -8,11 +8,14 @@ import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.contenttype.model.type.FileAssetContentType;
 import com.dotcms.mock.request.FakeHttpRequest;
 import com.dotcms.mock.response.BaseResponse;
+import com.dotcms.rendering.velocity.services.MacroCacheRefresherJob;
 import org.apache.commons.io.FileUtils;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.json.JSONException;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -23,8 +26,10 @@ import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.VelocityUtil;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
+import com.liferay.util.SystemProperties;
 import io.vavr.control.Try;
 import org.apache.velocity.context.Context;
+import org.apache.velocity.runtime.RuntimeConstants;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -37,6 +42,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.Arrays;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -528,6 +534,48 @@ public class StoryBlockMapTest extends IntegrationTestBase {
                 html.contains("custom-grid-video"));
         Assert.assertTrue("dotVideo override content missing. HTML: " + html,
                 html.contains("grid-video-title"));
+    }
+
+    /**
+     * Method to test: {@link StoryBlockMap#toHtml()}
+     * Given Scenario: A Story Block field is rendered, then the Velocity resource cache is flushed
+     *   (as happens on "Maintenance -> Flush Cache", a publish, or a deploy) and the field is
+     *   re-rendered. This reproduces the conditions of issue #35984, where #renderContentBlock -
+     *   registered only as a parse-time side effect of #parse("static/storyblock/render.vtl") - was
+     *   not re-primed after a flush, and Velocity emitted the literal macro call as text.
+     * ExpectedResult: (1) render.vtl is part of the velocimacro.library set that
+     *   MacroCacheRefresherJob re-primes after every flush, and (2) neither render emits the literal
+     *   string "#renderContentBlock"; both produce the real heading content.
+     */
+    @Test
+    public void test_render_after_cache_flush_does_not_emit_literal_macro() throws JSONException {
+
+        // Deterministic guard: render.vtl must be in the re-primed velocimacro.library list. This is
+        // read exactly as MacroCacheRefresherJob.refreshSystemMacros() reads it, so if the fix is
+        // reverted this assertion fails.
+        final String[] macroLibraries = Config.getStringArrayProperty(RuntimeConstants.VM_LIBRARY,
+                SystemProperties.getArray(RuntimeConstants.VM_LIBRARY));
+        Assert.assertTrue("render.vtl must be registered as a velocimacro.library so #renderContentBlock "
+                        + "is re-primed after a cache flush (issue #35984). Found: " + Arrays.toString(macroLibraries),
+                Arrays.asList(macroLibraries).contains("static/storyblock/render.vtl"));
+
+        final String htmlBefore = new StoryBlockMap(JSON).toHtml();
+        Assert.assertFalse("Story Block emitted the literal macro call before flush: " + htmlBefore,
+                htmlBefore.contains("#renderContentBlock"));
+        Assert.assertTrue("Expected real heading content before flush: " + htmlBefore,
+                htmlBefore.contains("heading 1"));
+
+        // Simulate "Maintenance -> Flush Cache" / publish / deploy: flush the Velocity resource cache,
+        // then run synchronously what clearCache() submits asynchronously so the assertion is stable.
+        CacheLocator.getVeloctyResourceCache().clearCache();
+        new MacroCacheRefresherJob().refreshSystemMacros();
+
+        final String htmlAfter = new StoryBlockMap(JSON).toHtml();
+        Assert.assertFalse("Story Block emitted the literal #renderContentBlock macro call after a cache "
+                        + "flush (issue #35984): " + htmlAfter,
+                htmlAfter.contains("#renderContentBlock"));
+        Assert.assertTrue("Expected real heading content after flush: " + htmlAfter,
+                htmlAfter.contains("heading 1"));
     }
 
 


### PR DESCRIPTION
### Proposed Changes
* Add `static/storyblock/render.vtl` to the `velocimacro.library` list in `system.properties`, so `#renderContentBlock` is registered as a global Velocity library macro at engine init and **re-primed after every cache flush** by `MacroCacheRefresherJob.refreshSystemMacros()` — the same robust mechanism `renderMarks` (in `VM_global_library.vm`) already relies on.
* Add a regression test (`StoryBlockMapTest#test_render_after_cache_flush_does_not_emit_literal_macro`) that asserts `render.vtl` is in the re-primed library list and that a Story Block field renders with **no** literal `#renderContentBlock` text after a cache flush.

Fixes #35984.

### Root cause
On live, server-rendered pages, Story Block content intermittently rendered the literal macro call `#renderContentBlock($item.content)` instead of the real heading/paragraph content — most often right after a cache flush (Flush Cache / publish / deploy).

`#renderContentBlock` was defined **only** in `static/storyblock/render.vtl` and entered Velocity's macro namespace purely as a **parse-time side effect** of `#parse("static/storyblock/render.vtl")`. When `DotResourceCache.clearCache()` runs it flushes the parsed-template AST cache and then re-primes only the `velocimacro.library` files + `dot_velocity_macros.vtl`. `render.vtl` was in neither list, so a cached `render.vtl` AST could be reused (cache hit → no re-parse → no macro re-registration) while the macro was no longer registered, and Velocity emitted the macro call verbatim as text. `renderMarks` never suffers this because it lives in a `velocimacro.library` file.

### How the fix works
Adding `render.vtl` to `velocimacro.library`:
1. Loads `renderContentBlock` as a **global library macro at engine init** (not a per-template parse-namespace macro that can be dumped).
2. **Re-primes** it after every flush via `MacroCacheRefresherJob` (identical to `renderMarks`).
3. Excludes `render.vtl` from the flushable AST cache (`DotResourceCache.ignoreGlobalVM`), so `#parse` always re-parses and re-registers it — the "cache hit → no re-parse" window can no longer open.

### Verification
* **Deterministic runtime A/B (cache inspection, same page/warm-up):** without the fix, `/static/storyblock/render.vtl` is present in the Velocity AST cache (`velocitycache`); **with the fix it is absent** (only `paragraph.vtl` / `heading*.vtl` remain) — confirming the mechanism engages.
* Regression test above (JUnit 4, added to the existing `StoryBlockMapTest`, already registered in a suite).
* Post-flush rendering of a live Blog Story Block page stayed clean across thousands of concurrent requests on the fixed build.
* **Note on live repro:** the user-visible symptom is a cache-invalidation timing race that is only realistically reproducible on a **multi-node/cluster** environment (the customer's Cloud). It could not be reproduced black-box on a single node with or without the fix, because the authoritative in-memory `VelocimacroManager` is not clearable via external cache flushes. Final live sign-off should be done on a clustered/Cloud staging env.

### Checklist
- [x] Tests
- [ ] Translations — n/a
- [x] Security Implications Contemplated — none; config-only change to Velocity macro-library loading, no user input, no output change when healthy.

### Additional Info
**Tradeoff (by design):** because `render.vtl` is excluded from the AST cache, it is re-parsed on each top-level block render. Cost is negligible (~94-line template; Story Block pages are page-cached) and buys guaranteed macro re-registration. A cleaner long-term alternative — moving `#renderContentBlock` into `VM_global_library.vm` and dropping the redundant `#parse` calls from the 13 storyblock templates — avoids the re-parse but touches many files; left as an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35984