### PR TITLE
fix(os-search): honor track_total_hits and _score sort on the OpenSearch read path (#36501)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentFactoryIndexOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentFactoryIndexOperationsOS.java
@@ -334,6 +334,10 @@ public class ContentFactoryIndexOperationsOS implements ContentFactoryIndexOpera
 
             final String finalDefaultSecondarySort = defaultSecondarySort;
             final SortOrder finalSecondaryOrder = defaultSecondaryOrder;
+            // Primary sort by relevance (_score DESC), then the secondary field — mirrors the ES path
+            // (ContentFactoryIndexOperationsES.addSorting). Without the _score sort, sortBy=score
+            // ordered only by the secondary field, so hit[0] was not the highest-scoring document.
+            searchRequestBuilder.sort(SortOptions.of(so -> so.score(sc -> sc.order(SortOrder.Desc))));
             searchRequestBuilder.sort(SortOptions.of(builder ->  builder.field(FieldSort.of(fs -> fs.field(finalDefaultSecondarySort).order(finalSecondaryOrder)))));
 
         } else if(!sortBy.startsWith("undefined") && !sortBy.startsWith("undefined_dotraw") && !sortBy.equals("random")

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexProperty.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexProperty.java
@@ -156,9 +156,10 @@ public enum OSIndexProperty {
 
     /**
      * Maximum number of hits to track accurately.
-     * No ES equivalent — OpenSearch-specific feature.
+     * Falls back to {@code ES_TRACK_TOTAL_HITS} so an existing Elasticsearch track_total_hits
+     * configuration is honored under the OpenSearch read path during migration.
      */
-    TRACK_TOTAL_HITS("OS_TRACK_TOTAL_HITS", null),
+    TRACK_TOTAL_HITS("OS_TRACK_TOTAL_HITS", "ES_TRACK_TOTAL_HITS"),
 
     /**
      * Enable in-memory caching of search query results.


### PR DESCRIPTION
## Proposed Changes
Two OpenSearch read-path gaps found running the integration suite under ES→OS migration **phase 2** (reads from OpenSearch). Both have a working ES reference implementation. Contributes to #36501.

- **track_total_hits** — `OSIndexProperty.TRACK_TOTAL_HITS` had no ES fallback key, so an existing `ES_TRACK_TOTAL_HITS` config was ignored under OS reads and OS always returned the full accurate count. Added the `ES_TRACK_TOTAL_HITS` fallback (same dual-key pattern as `USE_FILTERS_FOR_SEARCHING`).
- **_score sort** — `ContentFactoryIndexOperationsOS.addSorting`, for `sortBy=score`, added only the secondary field sort and never a primary `_score` sort, so results ordered by moddate and hit[0] was not the highest-scoring doc. Added the `_score DESC` primary sort (mirrors `ContentFactoryIndexOperationsES.addSorting`; API matches `OSContentletScrollImpl`).

## Verification
Phase 2, isolated env: `ESContentFactoryImplTest` **42/0/0** (incl. `Test_TrackHits_SearchCount` and `testScore`, previously failing). Core compiles.

Refs #36501, #36320.

This PR fixes: #36501