### PR TITLE
fix(os-index): resolve getIndexDocumentCount physical name via the read provider (.os tag) (#36501)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -3264,8 +3264,11 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
      */
     @Override
     public long getIndexDocumentCount(final String indexName) {
-        return router.readProvider().getIndexDocumentCount(
-                indexAPI.getNameWithClusterIDPrefix(indexName));
+        // Resolve the physical name through the read provider's own toPhysicalName so the OS read
+        // path (phases 2/3) receives the .os-tagged name. getNameWithClusterIDPrefix adds only the
+        // cluster prefix (no .os tag), so under OS reads the index was reported as not found.
+        final ContentletIndexOperations readProvider = router.readProvider();
+        return readProvider.getIndexDocumentCount(readProvider.toPhysicalName(indexName));
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes
`ContentletIndexAPIImpl.getIndexDocumentCount(String)` resolved the physical name with `getNameWithClusterIDPrefix` (cluster prefix but **no** `.os` tag). Under ES→OS migration phase 2/3 the read provider is OpenSearch, whose indices are `.os`-tagged, so the lookup hit a non-existent index and threw. Now resolves via the read provider's own `toPhysicalName()` (ES: prefix only; OS: prefix + `.os`), mirroring the sibling `getIndexDocumentCount(String, IndexTag)` overload. Contributes to #36501.

## Verification
Phase 2, isolated env: `ContentletIndexAPIImplTest#testGetIndexDocumentCountSuccess` **1/0/0** (previously failing).

Refs #36501, #36320.

This PR fixes: #36501