### PR TITLE
fix(os-index): idempotent delete + batched alias lookup in OSIndexAPIImpl (#36501)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexAPIImpl.java
@@ -54,6 +54,8 @@ import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
 import org.opensearch.client.opensearch.indices.ExistsRequest;
 import org.opensearch.client.opensearch.indices.ForcemergeRequest;
 import org.opensearch.client.opensearch.indices.ForcemergeResponse;
+import com.google.common.collect.Lists;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.indices.GetAliasRequest;
 import org.opensearch.client.opensearch.indices.GetAliasResponse;
 import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
@@ -271,9 +273,29 @@ public class OSIndexAPIImpl implements IndexAPI {
             final var response = clientProvider.getClient().indices().delete(request);
             return response.acknowledged();
         } catch (Exception e) {
+            if (isIndexNotFound(e)) {
+                // Deleting an already-absent index is a no-op: the desired end state (index gone)
+                // already holds. ES tolerated this; OS must too, otherwise phase-2 cleanup paths
+                // (where OS is the write primary) fail hard on a missing shadow/working index.
+                Logger.debug(this.getClass(), "Index already absent; delete is a no-op: " + indexName);
+                return true;
+            }
             Logger.error(this.getClass(), "Error deleting index: " + indexName, e);
             throw new RuntimeException("Failed to delete index: " + indexName, e);
         }
+    }
+
+    /**
+     * True when {@code e} (or its cause) is an OpenSearch "index not found" (HTTP 404) error, so
+     * callers can treat delete/lookup of an absent index idempotently.
+     */
+    private static boolean isIndexNotFound(final Throwable e) {
+        if (e instanceof OpenSearchException && ((OpenSearchException) e).status() == 404) {
+            return true;
+        }
+        final Throwable root = (e.getCause() != null) ? e.getCause() : e;
+        final String msg = String.valueOf(root.getMessage()).toLowerCase();
+        return msg.contains("index_not_found") || msg.contains("no such index");
     }
 
     @Override
@@ -751,6 +773,13 @@ public class OSIndexAPIImpl implements IndexAPI {
         }
     }
 
+    /**
+     * Max index names per {@code _alias} lookup request. Keeps the GET request line well under
+     * OpenSearch's ~4096-byte limit so a large index set never triggers
+     * {@code too_long_http_line_exception}.
+     */
+    private static final int ALIAS_LOOKUP_BATCH_SIZE = 50;
+
     @Override
     public Map<String, String> getIndexAlias(final List<String> indexNames) {
         final Map<String, String> aliases = new HashMap<>();
@@ -761,17 +790,22 @@ public class OSIndexAPIImpl implements IndexAPI {
             final List<String> physicalNames = indexNames.stream()
                     .map(this::getNameWithClusterIDPrefix)
                     .collect(Collectors.toList());
-            final GetAliasResponse response = clientProvider.getClient().indices()
-                    .getAlias(GetAliasRequest.of(b -> b.index(physicalNames)));
-            // result(): index name -> IndexAliases; IndexAliases.aliases() is keyed by alias name.
-            response.result().forEach((indexName, indexAliases) -> {
-                final Map<String, ?> aliasMap = indexAliases.aliases();
-                if (UtilMethods.isSet(aliasMap)) {
-                    final String aliasName = aliasMap.keySet().iterator().next();
-                    aliases.put(removeClusterIdFromName(indexName),
-                            removeClusterIdFromName(aliasName));
-                }
-            });
+            // Batch the lookup so a large set (100+ site-search indices) never overflows the HTTP
+            // request line — otherwise OpenSearch returns too_long_http_line_exception, the whole
+            // lookup aborts, and a valid alias is reported as missing.
+            for (final List<String> batch : Lists.partition(physicalNames, ALIAS_LOOKUP_BATCH_SIZE)) {
+                final GetAliasResponse response = clientProvider.getClient().indices()
+                        .getAlias(GetAliasRequest.of(b -> b.index(batch)));
+                // result(): index name -> IndexAliases; IndexAliases.aliases() is keyed by alias name.
+                response.result().forEach((indexName, indexAliases) -> {
+                    final Map<String, ?> aliasMap = indexAliases.aliases();
+                    if (UtilMethods.isSet(aliasMap)) {
+                        final String aliasName = aliasMap.keySet().iterator().next();
+                        aliases.put(removeClusterIdFromName(indexName),
+                                removeClusterIdFromName(aliasName));
+                    }
+                });
+            }
         } catch (Exception e) {
             // Consistent with the other OS read methods (listIndices, getClusterHealth, …):
             // log and return what was resolved rather than propagating provider errors.


### PR DESCRIPTION
## Proposed Changes
Two OpenSearch index-management robustness gaps that surface under migration phase 2, where OS is read/write primary so its errors propagate. Contributes to #36501.

- **idempotent delete** — `delete(indexName)` threw on any failure, including `index_not_found`. ES tolerated deleting an absent index; OS must too, else phase-2 cleanup paths fail hard on a missing index. Now treats `index_not_found` (HTTP 404) as an idempotent no-op; other errors still propagate.
- **batched alias lookup** — `getIndexAlias(List)` put every index name on one `_alias` GET request line; with a large set (100+ site-search indices) it exceeded OpenSearch's ~4096-byte line limit (`too_long_http_line_exception`), aborting the whole lookup and reporting a valid alias as missing. Now batches the lookup (`ALIAS_LOOKUP_BATCH_SIZE`) and merges results.

## Verification
Phase 2, isolated env: `ESSiteSearchAPITest` reindex tests **2/0/0** (delete idempotency); `SiteSearchWebAPITest#search_byAlias_resolvesIndex` passes. Note: the alias-overflow path needs 100+ indices to trigger the original bug, so the fix is exercised defensively rather than reproduced in isolation.

Refs #36501, #36320.

This PR fixes: #36501