### PR TITLE
test(hardening): fix order-dependent tests surfaced by phased (ES→OS) runs (#36501)

### DIFF
--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESSiteSearchAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESSiteSearchAPITest.java
@@ -236,29 +236,36 @@ public class ESSiteSearchAPITest {
      */
     @Test
     public void test_deleteOldSiteSearchIndices() throws IOException, DotDataException {
-        final String timestamp = String.valueOf(new Date().getTime());
-        siteSearchAPI.createSiteSearchIndex(ES_SITE_SEARCH_NAME + "_20230101000000", "Index1_deleteTest", 1);
-        siteSearchAPI.createSiteSearchIndex(ES_SITE_SEARCH_NAME + "_20230201000000", "", 1);
-        siteSearchAPI.createSiteSearchIndex(ES_SITE_SEARCH_NAME + "_20230301000000", "", 1);
-        siteSearchAPI.createSiteSearchIndex(ES_SITE_SEARCH_NAME + "_" + timestamp, "", 1);
+        // Unique, strictly increasing timestamps per run so a class retry (rerunFailingTestsCount)
+        // never collides on a leftover fixed-name index (createSiteSearchIndex is fail-hard on
+        // already-exists). Order preserved: idxOldest < idxDefault < idxMiddle < idxNewest.
+        final long base = new Date().getTime();
+        final String idxOldest  = ES_SITE_SEARCH_NAME + "_" + (base - 3000);
+        final String idxDefault = ES_SITE_SEARCH_NAME + "_" + (base - 2000);
+        final String idxMiddle  = ES_SITE_SEARCH_NAME + "_" + (base - 1000);
+        final String idxNewest  = ES_SITE_SEARCH_NAME + "_" + base;
+        siteSearchAPI.createSiteSearchIndex(idxOldest, "Index1_deleteTest", 1);
+        siteSearchAPI.createSiteSearchIndex(idxDefault, "", 1);
+        siteSearchAPI.createSiteSearchIndex(idxMiddle, "", 1);
+        siteSearchAPI.createSiteSearchIndex(idxNewest, "", 1);
 
         //set index as default
-        siteSearchAPI.activateIndex(ES_SITE_SEARCH_NAME + "_20230201000000");
+        siteSearchAPI.activateIndex(idxDefault);
 
         //load all indices and check that all 4 indices are there
         List<String> indices = siteSearchAPI.listIndices();
-        assertTrue(indices.contains(ES_SITE_SEARCH_NAME + "_20230101000000"));
-        assertTrue(indices.contains(ES_SITE_SEARCH_NAME + "_20230201000000"));
-        assertTrue(indices.contains(ES_SITE_SEARCH_NAME + "_20230301000000"));
-        assertTrue(indices.contains(ES_SITE_SEARCH_NAME + "_" + timestamp));
+        assertTrue(indices.contains(idxOldest));
+        assertTrue(indices.contains(idxDefault));
+        assertTrue(indices.contains(idxMiddle));
+        assertTrue(indices.contains(idxNewest));
         final int originalSizeOfIndices = indices.size();
 
         //Delete Old Indices
         siteSearchAPI.deleteOldSiteSearchIndices();
 
-        //load all indices and check that the index from 20230301 is not there
+        //load all indices and check that the middle (old, non-default) index is not there
         indices = siteSearchAPI.listIndices();
-        assertFalse(indices.contains(ES_SITE_SEARCH_NAME + "_20230301000000"));
+        assertFalse(indices.contains(idxMiddle));
         assertNotEquals(originalSizeOfIndices, indices.size());
 
     }

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/RelationshipFactoryImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/RelationshipFactoryImplTest.java
@@ -229,6 +229,13 @@ public class RelationshipFactoryImplTest extends ContentTypeBaseTest{
 
         parentContentlet = contentletAPI.checkin(parentContentlet, contentletRelationships, null, null, user, false);
 
+        //Ensure the relationship is fully indexed before the language-variant check-ins below.
+        //A legacy-relationship checkin with no explicit relationships auto-preserves related content
+        //by READING the index; under the OS read path (migration phase 2) that read is not
+        //read-after-write consistent mid-test, so without this an in-flight index dropped one
+        //related version and the DB query returned 3 instead of 4.
+        TestDataUtils.waitForEmptyQueue();
+
         //Adding multilingual versions of the children
         Contentlet childInGerman = contentletAPI.checkout(childInDefaultLanguage.getInode(), user, false);
         Contentlet child2InGerman = contentletAPI.checkout(childInDanish.getInode(), user, false);


### PR DESCRIPTION
## Proposed Changes
Two test-quality issues exposed by running the integration suite under a non-zero ES→OS migration phase (phase 2, reads from OpenSearch). Neither is a product bug. Contributes to #36501.

- **`RelationshipFactoryImplTest.testGetDBRelatedChildrenMultilingualContent`** — the DB-focused test's setup relied on index read-after-write consistency: a legacy-relationship checkin with no explicit relationships auto-preserves related content by *reading the index*, and under OS reads (phase 2) that read isn't read-after-write consistent mid-test, dropping one related version (3 vs 4). Added `TestDataUtils.waitForEmptyQueue()` after the relationship is established so the language-variant check-ins see a consistent index.
- **`ESSiteSearchAPITest.test_deleteOldSiteSearchIndices`** — used fixed index names with no cleanup, so a class retry (`rerunFailingTestsCount`) collided on a leftover index (`createSiteSearchIndex` is fail-hard on already-exists). Now uses unique, strictly increasing timestamps per run (relative order preserved).

## Verification
Both verified under phase 2 in an isolated worktree: `RelationshipFactoryImplTest` 1/0/0, `ESSiteSearchAPITest` 1/0/0.

## Not included
`PublisherTest.autoUnpublishContent` (initially bucketed here as flaky) is **excluded**: re-firing `IdentifierDateJob` with the correct content type on every poll still leaves the identifier's `SysExpireDate` null under phase 2 (deterministic across 4 reruns), so it is deeper than a race — a **candidate product gap in the OS auto-expire path**, being re-investigated separately under #36501.

Refs #36501.

This PR fixes: #36501