### PR TITLE
fix(permissions): return 403 not 401 for authenticated users on protected file assets (#36541)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/servlets/BinaryExporterServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/BinaryExporterServlet.java
@@ -203,6 +203,7 @@ public class BinaryExporterServlet extends HttpServlet {
 		ServletOutputStream out = null;
 		RandomAccessFile input = null;
 		InputStream is = null;
+		User user = null;
 		// Default to a no-shortyId value
 		try {
 			ShortyId shorty = shortyIdApi.noShorty(uuid);
@@ -253,7 +254,7 @@ public class BinaryExporterServlet extends HttpServlet {
 			}
 			boolean isTempBinaryImage = tempBinaryImageInodes.contains(assetInode);
 
-			final User user = ServletUtils.getUserAndAuthenticateIfRequired(
+			user = ServletUtils.getUserAndAuthenticateIfRequired(
 						this.webResource, req, resp);
 			final PageMode mode = PageMode.get(req);
 
@@ -675,7 +676,9 @@ public class BinaryExporterServlet extends HttpServlet {
 		} catch (DotSecurityException e) {
 			try {
 			  if(req.getSession()!=null){
-				if(WebAPILocator.getUserWebAPI().isLoggedToBackend(req)){
+				// any authenticated (non-anonymous) user lacking READ gets a clean 403.
+				// Only anonymous/not-logged-in users are redirected to login with a 401.
+				if(user != null && !user.isAnonymousUser()){
 				    req.getSession().removeAttribute(com.dotmarketing.util.WebKeys.REDIRECT_AFTER_LOGIN);
 					resp.sendError(HttpServletResponse.SC_FORBIDDEN);
 				}else{

--- a/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
@@ -21,6 +21,7 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;
 import static com.dotmarketing.business.Role.DOTCMS_BACK_END_USER;
+import static com.dotmarketing.business.Role.DOTCMS_FRONT_END_USER;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -56,6 +57,7 @@ import java.util.Base64;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -326,6 +328,45 @@ public class BinaryExporterServletTest {
 
         }
 
+    }
+
+    /**
+     * Method to test: {@link BinaryExporterServlet#doGet(HttpServletRequest, HttpServletResponse)}
+     * Given scenario: An authenticated front-end user (logged in, non-anonymous) requests a
+     * protected file asset they do NOT have READ permission on.
+     * Expected result: A clean 403 Forbidden is returned (matching VelocityServlet page behavior),
+     * and REDIRECT_AFTER_LOGIN is NOT set, so SAML sites do not enter an infinite redirect loop.
+     * See issue #36541.
+     */
+    @Test
+    public void requestBinaryFile_authenticatedUserWithoutPermission_returns403()
+            throws DotDataException, DotSecurityException, ServletException, IOException {
+
+        // Front-end user WITHOUT the role that grants READ on sharedFileAssetWithPerms
+        final User frontEndUser = new UserDataGen()
+                .roles(APILocator.getRoleAPI().loadRoleByKey(DOTCMS_FRONT_END_USER))
+                .nextPersisted();
+
+        try (TmpBinaryFile tmpTargetFile = new TmpBinaryFile(false)) {
+
+            final String fileURI = "/contentAsset/raw-data/"
+                    + sharedFileAssetWithPerms.getIdentifier() + "/fileAsset/";
+            final MockHeaderRequest request = new MockHeaderRequest(mockServletRequest(fileURI));
+
+            // Simulate an authenticated front-end user on the request (as a session login would)
+            request.setAttribute(WebKeys.USER, frontEndUser);
+
+            final HttpServletResponse response = mockServletResponse(tmpTargetFile);
+
+            sendRequest(request, response);
+
+            // Authenticated-but-unauthorized user must get a clean 403, not a 401 redirect-to-login
+            assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+            assertNull(request.getSession().getAttribute(
+                    com.dotmarketing.util.WebKeys.REDIRECT_AFTER_LOGIN));
+        } finally {
+            UserDataGen.remove(frontEndUser);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

`BinaryExporterServlet` returned **HTTP 401 Unauthorized** (and set `REDIRECT_AFTER_LOGIN`) for an authenticated **front-end** user who lacks READ permission on a protected file asset, instead of a clean **403 Forbidden**. Page assets already behave correctly via `VelocityServlet`.

On SAML-protected sites the erroneous 401 re-triggers IdP authentication on every request, producing an infinite redirect loop (`ERR_TOO_MANY_REDIRECTS`), leaving the protected file inaccessible.

Fixes #36541.

## Root cause

The `catch (DotSecurityException)` block branched only on `isLoggedToBackend(req)`, distinguishing "backend logged in" vs. "everything else." An authenticated front-end user fell into the `else` branch and was treated as needing to log in (401 + redirect), when they should get a 403 — they *are* logged in, they just lack READ on the asset.

## Fix

Mirror `VelocityServlet`'s handler exactly: keep the user resolved by `getUserAndAuthenticateIfRequired(...)` in scope and branch on `user != null && !user.isAnonymousUser()`.

- **Authenticated (front-end or backend) user** → **403**, and `REDIRECT_AFTER_LOGIN` is cleared.
- **Anonymous / not-logged-in** → **401** + `REDIRECT_AFTER_LOGIN` (login flow preserved).
- **Backend/admin** users → **403** (no change from prior behavior).

Using the already-resolved user (rather than re-deriving it) matches `VelocityServlet` semantics and avoids an extra role lookup in the error path.

## Acceptance criteria

- [x] Authenticated front-end user without READ on a protected file asset receives **403**.
- [x] `REDIRECT_AFTER_LOGIN` is **not** set for an already-authenticated user.
- [x] File-asset behavior matches page-asset behavior (`VelocityServlet`).
- [x] **Anonymous** users are still redirected to login (401 + `REDIRECT_AFTER_LOGIN`).
- [x] **Backend/admin** users continue to receive 403 (no regression).
- [ ] Verify on a SAML-protected site (no more infinite redirect loop) — requires live IdP; covered indirectly by eliminating the 401.

## Testing

Added integration test `BinaryExporterServletTest#requestBinaryFile_authenticatedUserWithoutPermission_returns403` covering the authenticated-front-end-user → 403 case and asserting `REDIRECT_AFTER_LOGIN` is not set. The existing data-provider scenarios (including anonymous → 401) guard against regression.

```
./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=BinaryExporterServletTest
# Tests run: 27, Failures: 0, Errors: 0, Skipped: 1 (pre-existing @Ignore)
```

> ⚠️ Touches authorization status-code behavior — reviewers should confirm the anonymous→401 and backend→403 paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36541