### PR TITLE
feat(content-drive): relationship field filtering via DB tree (v1.1) (#36384)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/browser/BrowserAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/browser/BrowserAPIImpl.java
@@ -8,6 +8,7 @@ import com.dotcms.content.business.json.ContentletJsonAPI;
 import com.dotcms.contenttype.model.field.CheckboxField;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.MultiSelectField;
+import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
@@ -39,6 +40,7 @@ import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
 import com.dotmarketing.portlets.fileassets.business.FileAsset;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI.RenderMode;
@@ -1936,8 +1938,8 @@ public class BrowserAPIImpl implements BrowserAPI {
     /**
      * Appends the DB-routed per-field predicates (Content Drive field filters) to the select query.
      * Per the ADR-0018 routing contract these criteria are resolved in the database to preserve
-     * read-your-writes. Only Tag fields are supported in v1 (Relationship is deferred to v1.1 and is
-     * rejected at request parsing time). Index-routed criteria are intentionally ignored here.
+     * read-your-writes: Tag (via {@code tag}/{@code tag_inode}) and Relationship (via {@code tree}).
+     * Index-routed criteria are intentionally ignored here — they are handled by the ES path.
      * <p>
      * Multiple criteria combine with AND (each adds an {@code and ... in (...)} sub-select), matching
      * the additive filtering model.
@@ -1958,8 +1960,64 @@ public class BrowserAPIImpl implements BrowserAPI {
             }
             if (criteria.getField() instanceof TagField) {
                 appendTagQuery(sqlQuery, workingLiveInode, criteria.getValues(), parameters);
+            } else if (criteria.getField() instanceof RelationshipField) {
+                appendRelationshipQuery(sqlQuery, browserQuery.user, criteria.getField(),
+                        criteria.getValues(), parameters);
             }
         }
+    }
+
+    /**
+     * Appends a Relationship-field predicate resolved against the {@code tree} table (never the
+     * index), so newly related content is filterable immediately (read-your-writes). The values are
+     * the child/parent contentlet <strong>identifiers</strong> selected on the FE.
+     * <p>
+     * The direction is resolved from the field: if it is the parent-side field the browsed content
+     * is the parent and the values are its children ({@code select parent ... where child in (...)});
+     * if it is the child-side field the direction is reversed. Multiple identifiers combine with OR
+     * (related to any); the enclosing sub-select ANDs with the rest of the query. Permission checks
+     * on the related content are intentionally not applied here — the browsed (parent) content still
+     * runs through the permission filter downstream.
+     *
+     * @param sqlQuery    The StringBuilder representing the SQL query being built.
+     * @param user        The {@link User} performing the search (to resolve the relationship).
+     * @param field       The Relationship {@link Field}.
+     * @param identifiers The related contentlet identifiers to match.
+     * @param parameters  The list of SQL parameters to append bind values to.
+     */
+    private void appendRelationshipQuery(final StringBuilder sqlQuery, final User user,
+            final Field field, final List<String> identifiers, final List<Object> parameters) {
+
+        if (identifiers.isEmpty()) {
+            return;
+        }
+        final Relationship relationship = Try.of(
+                        () -> APILocator.getRelationshipAPI().getRelationshipFromField(field, user))
+                .getOrNull();
+        if (null == relationship) {
+            throw new DotRuntimeException(String.format(
+                    "Unable to resolve the relationship for field '%s'.", field.variable()));
+        }
+        // isChildField(rel, field) is true when the field lives on the parent structure and holds
+        // the *children* (dotCMS names a relationship field after its target). In that case the
+        // browsed content is the parent and the FE-sent values are child identifiers, so we select
+        // parents whose tree 'child' column matches. When the field holds parents, reverse it.
+        final boolean fieldHoldsChildren =
+                APILocator.getRelationshipAPI().isChildField(relationship, field);
+        final String selectColumn = fieldHoldsChildren ? "parent" : "child";
+        final String matchColumn = fieldHoldsChildren ? "child" : "parent";
+
+        sqlQuery.append(" and id.id in ( select ").append(selectColumn)
+                .append(" from tree where ").append(matchColumn).append(" in (");
+        for (int i = 0; i < identifiers.size(); i++) {
+            if (i > 0) {
+                sqlQuery.append(", ");
+            }
+            sqlQuery.append("?");
+            parameters.add(identifiers.get(i).trim());
+        }
+        sqlQuery.append(") and relation_type = ? ) ");
+        parameters.add(relationship.getRelationTypeValue());
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/drive/ContentDriveFieldFilterResolver.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/drive/ContentDriveFieldFilterResolver.java
@@ -97,13 +97,6 @@ public class ContentDriveFieldFilterResolver {
                     fieldVariable));
         }
 
-        if (field instanceof RelationshipField) {
-            // Distinct from the generic "unsupported type" below so the FE can tell "not yet"
-            // (deferred to v1.1) from "never".
-            throw new BadRequestException(String.format(
-                    "Field '%s' is a Relationship field; relationship filtering is not available yet "
-                            + "(planned for v1.1).", fieldVariable));
-        }
         final RoutingBucket bucket = routingBucketFor(field);
         if (null == bucket) {
             throw new BadRequestException(String.format(
@@ -212,15 +205,12 @@ public class ContentDriveFieldFilterResolver {
 
     /**
      * Maps a field type to its routing bucket per the ADR-0018 contract, or {@code null} when the
-     * field type is out of scope (Relationship is deferred to v1.1; dividers, Binary, JSON,
-     * Key/Value, Block Editor, Constant, Hidden, Custom, File/Image, Host/Folder are excluded).
+     * field type is out of scope (dividers, Binary, JSON, Key/Value, Block Editor, Constant, Hidden,
+     * Custom, File/Image, Host/Folder are excluded). Tag and Relationship resolve in the DB to
+     * preserve read-your-writes; everything else in scope resolves against the index.
      */
     private RoutingBucket routingBucketFor(final Field field) {
-        if (field instanceof RelationshipField) {
-            // v1.1 — DB path against the tree tables, not part of this deliverable.
-            return null;
-        }
-        if (field instanceof TagField) {
+        if (field instanceof TagField || field instanceof RelationshipField) {
             return RoutingBucket.DB;
         }
         if (isIndexRouted(field)) {
@@ -259,7 +249,8 @@ public class ContentDriveFieldFilterResolver {
                 return field instanceof MultiSelectField
                         || field instanceof CheckboxField
                         || field instanceof TagField
-                        || field instanceof CategoryField;
+                        || field instanceof CategoryField
+                        || field instanceof RelationshipField;
             case SCALAR:
                 return field instanceof TextField
                         || field instanceof TextAreaField

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/drive/ContentDriveFieldFilterResolverTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/drive/ContentDriveFieldFilterResolverTest.java
@@ -176,14 +176,12 @@ public class ContentDriveFieldFilterResolverTest {
     }
 
     @Test
-    public void relationshipGetsDistinctNotYetMessage() {
+    public void relationshipListRoutesToDatabase() {
         final ContentType ct = contentTypeWithAllFields();
-        final BadRequestException ex = assertThrows(BadRequestException.class,
-                () -> resolver.parse(Map.of("relationshipF", List.of("id1")), ct));
-        // The client-facing detail is carried in the JAX-RS response entity, not getMessage().
-        final String detail = String.valueOf(ex.getResponse().getEntity()).toLowerCase();
-        assertTrue("relationship rejection should mention it is not available yet: " + detail,
-                detail.contains("not available yet") || detail.contains("v1.1"));
+        final FieldSearchCriteria c = single(ct, "relationshipF", List.of("id1", "id2"));
+        assertEquals(FilterKind.MULTI, c.getKind());
+        assertEquals(RoutingBucket.DB, c.getBucket());
+        assertEquals(List.of("id1", "id2"), c.getValues());
     }
 
     @Test

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/drive/ContentDriveFieldFilterTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/drive/ContentDriveFieldFilterTest.java
@@ -5,7 +5,10 @@ import com.dotcms.IntegrationTestBase;
 import com.dotcms.browser.BrowserAPIImpl.PaginatedContents;
 import com.dotcms.contenttype.model.field.CheckboxField;
 import com.dotcms.contenttype.model.field.DateTimeField;
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.FieldBuilder;
 import com.dotcms.contenttype.model.field.MultiSelectField;
+import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.BaseContentType;
@@ -23,7 +26,9 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -74,6 +79,10 @@ public class ContentDriveFieldFilterTest extends IntegrationTestBase {
 
     private static ContentType typeWithFields;
     private static ContentType otherType;
+    private static ContentType relatedType;
+    private static String relationshipVar;
+    private static Contentlet childNews;
+    private static Contentlet childPress;
 
     private static final String TEXT_VAR = "topic";
     private static final String TAG_VAR = "labels";
@@ -160,8 +169,53 @@ public class ContentDriveFieldFilterTest extends IntegrationTestBase {
                 .folder(testFolder)
                 .nextPersisted();
 
+        // Relationship setup: typeWithFields (parent) references relatedType (child) via a field.
+        relatedType = new ContentTypeDataGen()
+                .name("DriveFfRelated_" + uniqueId)
+                .velocityVarName("driveFfRelated_" + uniqueId)
+                .baseContentType(BaseContentType.CONTENT)
+                .host(testSite)
+                .nextPersisted();
+
+        relationshipVar = "related";
+        final Field relationshipField = FieldBuilder.builder(RelationshipField.class)
+                .name(relationshipVar)
+                .variable(relationshipVar)
+                .contentTypeId(typeWithFields.id())
+                .values(String.valueOf(WebKeys.Relationship.RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal()))
+                .relationType(relatedType.variable())
+                .required(false)
+                .indexed(true)
+                .searchable(true)
+                .build();
+        final Field savedRelationshipField =
+                APILocator.getContentTypeFieldAPI().save(relationshipField, systemUser);
+        final Relationship relationship =
+                APILocator.getRelationshipAPI().getRelationshipFromField(savedRelationshipField, systemUser);
+
+        childNews = new ContentletDataGen(relatedType.id())
+                .setProperty("title", "Child news " + uniqueId).folder(testFolder).nextPersisted();
+        childPress = new ContentletDataGen(relatedType.id())
+                .setProperty("title", "Child press " + uniqueId).folder(testFolder).nextPersisted();
+
+        // Re-checkin creates a new working version (new inode); reassign so inode-based assertions
+        // keep pointing at the current version.
+        angularWithTags = relate(angularWithTags, relationship, childNews);
+        reactWithVue = relate(reactWithVue, relationship, childPress);
+
         Logger.info(ContentDriveFieldFilterTest.class,
                 "Field-filter test data ready under " + testAssetPath);
+    }
+
+    /**
+     * Relates a child under the given relationship on a (re-checked-out) parent contentlet and
+     * returns the resulting working version.
+     */
+    private static Contentlet relate(final Contentlet parent, final Relationship relationship,
+            final Contentlet child) {
+        final Contentlet checkedOut = ContentletDataGen.checkout(parent);
+        checkedOut.setProperty(relationship.getChildRelationName(), List.of(child));
+        return ContentletDataGen.checkin(checkedOut);
     }
 
     private static Date date(final int year) {
@@ -323,6 +377,37 @@ public class ContentDriveFieldFilterTest extends IntegrationTestBase {
         assertTrue("2024 item is after 2023", inodes.contains(angularWithTags.getInode()));
         assertTrue("2026 item is after 2023", inodes.contains(angularNoTags.getInode()));
         assertFalse("2020 item is before 2023", inodes.contains(reactWithVue.getInode()));
+    }
+
+    /**
+     * Relationship field routes to the DB ({@code tree}): filtering the parent by a child identifier
+     * returns only the parent that references it (read-your-writes, no index involved).
+     */
+    @Test
+    public void testRelationshipFiltersViaDatabase() throws DotDataException, DotSecurityException {
+        final Set<String> inodes = driveInodes(baseRequest()
+                .userSearchable(Map.of(relationshipVar, List.of(childNews.getIdentifier())))
+                .build());
+        assertTrue("parent related to 'news' child must match",
+                inodes.contains(angularWithTags.getInode()));
+        assertFalse("parent related to 'press' child must not match",
+                inodes.contains(reactWithVue.getInode()));
+        assertFalse("unrelated parent must not match",
+                inodes.contains(angularNoTags.getInode()));
+    }
+
+    /**
+     * Multiple related identifiers combine with OR (related to any).
+     */
+    @Test
+    public void testRelationshipOrsValues() throws DotDataException, DotSecurityException {
+        final Set<String> inodes = driveInodes(baseRequest()
+                .userSearchable(Map.of(relationshipVar,
+                        List.of(childNews.getIdentifier(), childPress.getIdentifier())))
+                .build());
+        assertTrue(inodes.contains(angularWithTags.getInode()));
+        assertTrue(inodes.contains(reactWithVue.getInode()));
+        assertFalse(inodes.contains(angularNoTags.getInode()));
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

Final slice (PR 3 of 3) of the Content Drive field-based search backend — issue #36384. Adds **Relationship** field filtering (v1.1), resolved in the DB against the `tree` table per the ADR-0018 routing contract.

> **Stacked on [#36474](https://github.com/dotCMS/core/pull/36474).** Base branch is `36384-content-drive-field-search-resolver`; review that one first. Once it merges, this can be retargeted to `main`.

* **Resolver** (`ContentDriveFieldFilterResolver`): Relationship fields are now accepted (the previous 400 is gone), routed to the **DB** bucket (alongside Tag), and accept a `MULTI` value (array of child/parent identifiers).
* **DB predicate** (`BrowserAPIImpl.appendRelationshipQuery`): resolves the relationship from the field (`RelationshipAPI.getRelationshipFromField`) and adds a `tree` sub-select on the identifier column (`id.id`), never the index:
  * Field holds children (`isChildField` → browsed content is the parent, values are child ids): `id.id in (select parent from tree where child in (?,…) and relation_type = ?)`.
  * Field holds parents: the columns are reversed.
  * Multiple identifiers combine with **OR** (related to any); the sub-select ANDs with the rest of the query.
* Direction is resolved from the field via `RelationshipAPI.isChildField`, which covers one-sided, two-sided and self-relationships and every cardinality.

**Contract:** the FE sends contentlet **identifiers** (confirmed with FE — the `tree` table is identifier-keyed; inode is per-version and would break on publish). Read-your-writes holds because the predicate is DB-resolved.

**Permissions:** child-content permissions are intentionally not checked in the predicate; the browsed (parent) content still runs through the permission filter downstream (agreed scope).

### Checklist
- [x] Tests — extended `ContentDriveFieldFilterTest` (IT): relationship → DB, OR across identifiers. Extended `ContentDriveFieldFilterResolverTest` (unit): relationship routes to DB as MULTI. **IT 14/14, unit 20/20** passing locally (Postgres + OpenSearch).
- [ ] Translations
- [x] Security Implications Contemplated — tree values are bound as SQL parameters (no injection); relationship resolution respects the querying user.

### Additional Info

* `/v1/drive/search` is `@Hidden` → no `openapi.yaml` change.
* Completes the v1 + v1.1 field set: Text/Textarea/WYSIWYG, Select/Radio, Multi-Select/Checkbox (OR), Boolean, Date/Time/Date-Time, Tag (DB), Category (index), **Relationship (DB)**.
* Only `RelationshipField`s flagged `searchable && indexed` are filterable (same rule as every other field) — the field must be marked User Searchable.

### Screenshots

N/A — backend only.

This PR fixes: #36384