### PR TITLE
fix(edit-content): date picker panel clipped by dialog overflow (#36156 QA)

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/components/calendar-field/calendar-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/components/calendar-field/calendar-field.component.html
@@ -10,6 +10,7 @@
     [timeOnly]="fieldTypeConfig.timeOnly"
     [showTime]="fieldTypeConfig.showTime"
     [hideOnDateTimeSelect]="false"
+    [appendTo]="'body'"
     (onSelect)="onCalendarChange($event)"
     (onClearClick)="onCalendarChange(null)"
     (onClear)="onCalendarChange(null)"


### PR DESCRIPTION
### Proposed Changes

QA feedback on #36156: the Date / Date-Time / Time picker panel was partially obscured when opened inside the Edit Content dialog or in full screen — the overlay was being clipped by the dialog's `overflow` boundary.

https://github.com/user-attachments/assets/9394b40b-d9ea-4847-832c-51225c4d2a66


**Fix:** add `[appendTo]="'body'"` to the `<p-datepicker>` in `calendar-field.component`. PrimeNG renders the panel inline by default, so any ancestor with `overflow: hidden/auto` (the dialog / full-screen container) clips it. Teleporting the overlay to `<body>` takes it out of the clipping context. This is the same pattern already used by the other overlays in `libs/edit-content` (menus, dialogs, file-field).

Single-line change; applies to all three field types (Date, Date/Time, Time) since they share `dot-calendar-field`. No API/backend changes.

### Checklist
- [ ] Tests
- [ ] Translations
- [x] Security Implications Contemplated (none — frontend presentation/UX only)

Relates to #36156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36156