### PR TITLE
test(index): decouple ContentletIndexAPIImplTest from ElasticSearch internals (#36320)

### DIFF
--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -1,6 +1,5 @@
 package com.dotcms.content.elasticsearch.business;
 
-import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -11,7 +10,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.dotcms.IntegrationTestBase;
-import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.content.index.IndexAPI;
 import com.dotcms.content.index.domain.IndexBulkRequest;
 import com.dotcms.contenttype.business.ContentTypeAPI;
@@ -69,7 +67,6 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
-import com.rainerhahnekamp.sneakythrow.Sneaky;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -80,14 +77,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.jetbrains.annotations.Nullable;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1168,11 +1157,13 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
             Logger.warn(this, "Requested Inode is not indexed because Inode is not set");
         }
         try {
+            // Vendor-neutral, phase-aware read: SiteSearchAPI.search routes to ES or OS per the
+            // active migration phase, replacing the former ES-direct RestHighLevelClient search so
+            // this test works under any phase.
             Awaitility.await().atMost(10, TimeUnit.SECONDS)
-                    .until(() ->
-                                    Objects.requireNonNull(
-                                                    indexSearch(indexName, String.format(ID_QUERY, id)))
-                                            .getTotalHits().value,
+                    .until(() -> APILocator.getSiteSearchAPI()
+                                    .search(indexName, String.format(ID_QUERY, id), 0, 10)
+                                    .getTotalResults(),
                             greaterThan(0L)
                     );
             return true;
@@ -1180,33 +1171,6 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
             Logger.error(this.getClass(), e.getMessage(), e);
             return false;
         }
-    }
-
-    private SearchHits indexSearch(String indexName, String query) throws Exception {
-
-        String qq = ESContentFactoryImpl.translateQuery(query,
-                ContentletIndexAPIImplTest.MOD_DATA_SORT).getQuery();
-
-        if (indexName == null) {
-            indexName = SiteSearchAPI.ES_SITE_SEARCH_NAME + "_"
-                    + ContentletIndexAPIImpl.timestampFormatter.format(new Date());
-            APILocator.getSiteSearchAPI().createSiteSearchIndex(indexName, null, 1);
-            APILocator.getSiteSearchAPI().activateIndex(indexName);
-        }
-
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.query(QueryBuilders.queryStringQuery(qq));
-        searchSourceBuilder.timeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
-        searchSourceBuilder.fetchSource(new String[]{"inode"}, null);
-        searchSourceBuilder.storedField("id");
-        SearchRequest searchRequest = new SearchRequest();
-        searchRequest.indices(esIndexAPI.getNameWithClusterIDPrefix(indexName));
-        searchRequest.source(searchSourceBuilder);
-
-        final SearchResponse response = Sneaky.sneak(() ->
-                RestHighLevelClientProvider
-                        .getInstance().getClient().search(searchRequest, RequestOptions.DEFAULT));
-        return response.getHits();
     }
 
     @Nullable
@@ -1349,10 +1313,14 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
     /**
      * Method to test: {@link ContentletIndexAPI#getIndexDocumentCount(String)} Test Case: Tries to
      * get the document count of an index that does not exist Expected Results: Throws
-     * ElasticsearchStatusException
+     * a runtime exception, without coupling to a vendor-specific type.
      */
-    @Test(expected = ElasticsearchStatusException.class)
+    @Test
     public void testGetIndexDocumentCountWithInvalidIndexNameFails() {
-        indexAPI.getIndexDocumentCount("invalidIndexName");
+        // Vendor/phase-neutral: an invalid index name must fail. The concrete type differs by
+        // backend (ES throws ElasticsearchStatusException, the OS read path wraps as
+        // DotRuntimeException), so assert the common RuntimeException rather than a vendor type.
+        assertThrows(RuntimeException.class,
+                () -> indexAPI.getIndexDocumentCount("invalidIndexName"));
     }
 }


### PR DESCRIPTION
## Proposed Changes
Decouples `ContentletIndexAPIImplTest` from ElasticSearch internals so it is vendor/phase-agnostic — the in-scope work of #36320.

- **Neutralize the ES-direct search helper**: `isDocIndexed()` now uses the phase-aware `SiteSearchAPI.search(index, query, start, rows)` (routes to ES or OS per the active migration phase) instead of the private `indexSearch()` that used `RestHighLevelClientProvider` + `SearchRequest`/`SearchSourceBuilder`/`QueryBuilders`/`SearchHits`. The `indexSearch()` helper is deleted.
- **Vendor-neutral exception assertion**: `testGetIndexDocumentCountWithInvalidIndexNameFails` now `assertThrows(RuntimeException.class, ...)` instead of `@Test(expected = ElasticsearchStatusException.class)`. The concrete type differs by backend (ES → `ElasticsearchStatusException`, OS read path → `DotRuntimeException`); asserting the common `RuntimeException` passes under every phase without coupling to a vendor type.
- **Removed all 8 `org.elasticsearch.*` imports** + `RestHighLevelClientProvider` + the now-unused `INDEX_OPERATIONS_TIMEOUT_IN_MS` / `Sneaky` imports. **Zero `org.elasticsearch` imports remain.**

## Verification
`ContentletIndexAPIImplTest` under **phase 0** (ES): **16/0/0** ✅. `testSearch`'s doc-indexed check now passes via the neutral path.

## Out of scope / note
`testSearch`'s highlight assertions still depend on OpenSearch site-search highlights, which are not implemented yet (**#36576 / #34609**) — so full phase-2/3 green for that one method is gated on that separate product gap, not on this decoupling.

Refs #36320, #36501.

This PR fixes: #36320