### PR TITLE
fix(uve): prevent duplicate document.write re-executing inline scripts on VTL pages

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-iframe/dot-uve-iframe.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-iframe/dot-uve-iframe.component.spec.ts
@@ -225,53 +225,31 @@ describe('DotUveIframeComponent', () => {
             expect(setSeoSpy).toHaveBeenCalledTimes(1);
         });
 
-        it('should write content to iframe document', () => {
-            const openSpy = jest.spyOn(mockDoc, 'open');
-            const writeSpy = jest.spyOn(mockDoc, 'write');
-            const closeSpy = jest.spyOn(mockDoc, 'close');
-
+        it('should set srcdoc to page content on iframe load', () => {
             component.onIframeLoad();
-
-            expect(openSpy).toHaveBeenCalledTimes(1);
-            expect(writeSpy).toHaveBeenCalledTimes(1);
-            expect(closeSpy).toHaveBeenCalledTimes(1);
+            expect(mockIframe.srcdoc).toBe(mockPageRender);
         });
 
-        it('should not insert content if iframe element is not available', () => {
+        it('should not set srcdoc if iframe element is not available', () => {
             component.iframe = undefined as any;
-            const openSpy = jest.spyOn(mockDoc, 'open');
             component.onIframeLoad();
-            expect(openSpy).not.toHaveBeenCalled();
-        });
-
-        it('should not insert content if contentDocument is not available', () => {
-            Object.defineProperty(mockIframe, 'contentDocument', {
-                value: null,
-                writable: true
-            });
-            const openSpy = jest.spyOn(mockDoc, 'open');
-            component.onIframeLoad();
-            expect(openSpy).not.toHaveBeenCalled();
+            expect(mockIframe.srcdoc).toBe('');
         });
 
         describe('legacy script injection (FEATURE_FLAG_UVE_LEGACY_SCRIPT_INJECTION)', () => {
             it('should inject the UVE script when the flag is enabled', () => {
                 legacyScriptInjectionEnabledSignal.set(true);
-                const writeSpy = jest.spyOn(mockDoc, 'write');
                 component.onIframeLoad();
-                expect(writeSpy).toHaveBeenCalledWith(
-                    expect.stringContaining(`<script src="${SDK_EDITOR_SCRIPT_SOURCE}"></script>`)
+                expect(mockIframe.srcdoc).toContain(
+                    `<script src="${SDK_EDITOR_SCRIPT_SOURCE}"></script>`
                 );
             });
 
             it('should NOT inject the UVE script when the flag is disabled', () => {
                 legacyScriptInjectionEnabledSignal.set(false);
-                const writeSpy = jest.spyOn(mockDoc, 'write');
                 component.onIframeLoad();
-                expect(writeSpy).toHaveBeenCalledWith(
-                    expect.not.stringContaining(
-                        `<script src="${SDK_EDITOR_SCRIPT_SOURCE}"></script>`
-                    )
+                expect(mockIframe.srcdoc).not.toContain(
+                    `<script src="${SDK_EDITOR_SCRIPT_SOURCE}"></script>`
                 );
             });
         });
@@ -565,6 +543,68 @@ describe('DotUveIframeComponent', () => {
             });
             (component as any).setSeoData();
             expect(mockDotSeoMetaTagsService.getMetaTagsResults).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('insertPageContent – de-duplicate writes', () => {
+        let mockIframe: HTMLIFrameElement;
+        let mockWindow: Window;
+
+        beforeEach(() => {
+            pageTypeSignal.set(PageType.TRADITIONAL);
+
+            mockIframe = document.createElement('iframe');
+            mockWindow = {
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn()
+            } as unknown as Window;
+
+            Object.defineProperty(mockIframe, 'contentWindow', {
+                value: mockWindow,
+                writable: true
+            });
+
+            component.iframe = { nativeElement: mockIframe } as any;
+        });
+
+        it('should set srcdoc to content on the first call', () => {
+            component.onIframeLoad();
+            expect(mockIframe.srcdoc).toBe(mockPageRender);
+        });
+
+        it('should skip srcdoc assignment on re-entrant calls with the same src and content', () => {
+            component.onIframeLoad(); // first write — srcdoc = mockPageRender
+            mockIframe.srcdoc = 'SENTINEL'; // manually change to detect re-assignment
+            component.onIframeLoad(); // same key — should not overwrite
+
+            expect(mockIframe.srcdoc).toBe('SENTINEL');
+        });
+
+        it('should re-write srcdoc when content changes (real-time canvas update)', () => {
+            const updatedRender = '<html><body>Updated Content</body></html>';
+            component.onIframeLoad();
+            pageRenderSignal.set(updatedRender);
+            component.onIframeLoad();
+
+            expect(mockIframe.srcdoc).toBe(updatedRender);
+        });
+
+        it('should re-write srcdoc when src changes (page navigation)', () => {
+            component.onIframeLoad();
+            spectator.setInput('src', 'https://example.com/new-page');
+            component.onIframeLoad();
+
+            // Content is the same but the key changed (different src) — re-write
+            expect(mockIframe.srcdoc).toBe(mockPageRender);
+        });
+
+        it('should still call handleInlineScripts on de-duplicated calls', () => {
+            const handleSpy = jest.spyOn(component as any, 'handleInlineScripts');
+            component.onIframeLoad();
+            component.onIframeLoad();
+
+            // handleInlineScripts must run on every call, not just srcdoc writes
+            expect(handleSpy).toHaveBeenCalledTimes(2);
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-iframe/dot-uve-iframe.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-iframe/dot-uve-iframe.component.ts
@@ -75,6 +75,15 @@ export class DotUveIframeComponent {
     private readonly iframeClickListener$ = new Subject<void>();
 
     /**
+     * Tracks the last content written into the iframe, keyed by `src + content`.
+     * Prevents destructive re-writes when the reactive effect, the (load) handler,
+     * and the synthetic load fired by doc.close() all converge on insertPageContent
+     * for the same render — which re-executes customer top-level const/let and throws
+     * "Identifier '…' has already been declared".
+     */
+    private lastWrittenKey: string | null = null;
+
+    /**
      * Rendered HTML for traditional pages.
      * @type {Signal<string>}
      */
@@ -149,19 +158,24 @@ export class DotUveIframeComponent {
             return;
         }
 
-        const doc = iframeElement.contentDocument;
-
-        if (!doc) {
-            return;
-        }
-
         const content = this.$isEmaLegacyScriptInjectionEnabled()
             ? addEditorPageScript(pageRender)
             : pageRender;
 
-        doc.open();
-        doc.write(content);
-        doc.close();
+        const writeKey = `${this.src()}::${content}`;
+
+        if (writeKey !== this.lastWrittenKey) {
+            this.lastWrittenKey = writeKey;
+            // srcdoc navigates the iframe to a fresh browsing context on every
+            // unique render, clearing the window's global lexical scope.
+            // document.open()/write()/close() reuses the same window object, so
+            // top-level let/const from any prior render remain in scope and throw
+            // "Identifier '…' has already been declared" when the same scripts
+            // run again — even across legitimate re-renders (e.g. preview → edit
+            // mode returns different server-rendered HTML that still contains the
+            // same let/const declarations).
+            iframeElement.srcdoc = content;
+        }
 
         this.handleInlineScripts(enableInlineEdit);
     }


### PR DESCRIPTION
## Summary

- **Root cause:** `insertPageContent` called `document.open()/write()/close()` to inject server-rendered HTML into the UVE iframe. `document.open()` replaces the `Document` object but keeps the same `window` — so `let`/`const` declarations from any prior render remain in the window's global lexical scope. Any subsequent write throws `"Identifier '…' has already been declared"` when the same scripts run again. This affects two scenarios:
  - **Re-entrant writes:** `doc.close()` fires a synthetic `load` event that routes back into `insertPageContent`, calling `doc.write()` a second time on a scope that already has those declarations.
  - **Legitimate re-renders:** switching from preview to edit mode causes the store to update `pageRender` with new server-rendered HTML that still contains the same `let`/`const` declarations — `doc.open()` does not clear the scope, so the write throws.

- **Fix:** Replaces `document.open()/write()/close()` with `iframeElement.srcdoc`. Setting `srcdoc` navigates the iframe to a fresh browsing context on each unique render, clearing the global lexical scope so inline scripts with top-level `let`/`const` declarations always start clean.

- **Re-entrancy guard:** A `lastWrittenKey` field (keyed on `src + content`) prevents redundant `srcdoc` assignments. Without it, the synthetic `load` event fired after each `srcdoc` navigation would route back into `insertPageContent` and reset `srcdoc` again, causing an infinite reload loop. `handleInlineScripts` remains unconditional so the inline-edit toggle responds to `enableInlineEdit` changes independently of whether a write was skipped.

## What this fixes

On traditional (VTL) pages whose inline scripts declare top-level `let` or `const` (e.g. `let resizeTimer;`, `const urlParams`), opening the page in UVE Edit mode no longer throws:

```
Uncaught SyntaxError: Failed to execute 'write' on 'Document': Identifier '…' has already been declared
```

## Re-render scenarios that still work correctly

| Trigger | Behavior |
|---|---|
| Re-entrant `load` from `doc.close()` synthetic event | `srcdoc` assignment skipped — no reload loop |
| Reactive effect re-runs with unchanged signals | `srcdoc` assignment skipped |
| Real content change (`pageRender` changes) | New key → fresh `srcdoc` write in a clean scope ✅ |
| Navigation to a different page (`src` changes) | New key → fresh `srcdoc` write in a clean scope ✅ |
| Preview → Edit mode switch | New key → fresh `srcdoc` write in a clean scope ✅ |

## Test plan

- [ ] Open a traditional (VTL) page in UVE Edit mode where an inline `<script>` declares a top-level `let` or `const` — confirm no `"Identifier '…' has already been declared"` errors in the browser console.
- [ ] Switch between preview and edit mode on the same page — confirm no console errors on re-render.
- [ ] Navigate between pages in the editor — confirm each page renders correctly.
- [ ] Run unit tests: `pnpm nx test portlets-edit-ema-portlet --testPathPattern=dot-uve-iframe`



https://github.com/user-attachments/assets/c88a53f6-b8ae-46f7-a003-8aa0bb0fc34a





Fixes #36141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36141