### PR TITLE
fix(permissions): access-denied 403 page + auth/authz split + SAML loop-guard (#32365)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/DotSamlResource.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/DotSamlResource.java
@@ -430,6 +430,9 @@ public class DotSamlResource implements Serializable {
 							SamlName.DOT_SAML_LOGOUT_SERVICE_ENDPOINT_URL,
 							()-> "/dotAdmin/#/public/logout");
 					RedirectUtil.sendRedirectHTML(httpServletResponse, logoutPath);
+					// The redirect commits the response; return so we don't fall through to the
+					// unconditional DoesNotExistException throw below (which would write a second response).
+					return;
 
 
 				}
@@ -485,6 +488,9 @@ public class DotSamlResource implements Serializable {
 					
 					
 					RedirectUtil.sendRedirectHTML(httpServletResponse, logoutPath);
+					// The redirect commits the response; return so we don't fall through to the
+					// unconditional DoesNotExistException throw below (which would write a second response).
+					return;
 
 				}
 			} finally {

--- a/dotCMS/src/main/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptor.java
@@ -162,6 +162,24 @@ public class SamlWebInterceptor implements WebInterceptor {
                             // if the auto login couldn't log in the user, then send it to the IdP login page (if it is not already logged in).
                             if (null == session || !autoLoginResult.isAutoLogin() || this.samlWebUtils.isNotLogged(request)) {
 
+                                // Loop-guard: if auto-login actually resolved a SAML user (isAutoLogin)
+                                // yet the request is STILL not logged in for this destination, re-authenticating
+                                // will resolve the very same user and produce the same result — that is
+                                // an infinite IdP redirect loop (e.g. a front-end-only SAML user sent
+                                // to a back-end URL like /dotAdmin). Break it
+                                // with a clean 403 instead of bouncing to the IdP again.
+                                if (autoLoginResult.isAutoLogin() && this.samlWebUtils.isNotLogged(request)) {
+
+                                    Logger.warn(this, ()-> "SAML auth redirect loop detected for URI '"
+                                            + request.getRequestURI() + "': the user is authenticated but not "
+                                            + "authorized for this destination. Returning 403 instead of "
+                                            + "redirecting to the IdP again.");
+                                    SecurityLogger.logInfo(this.getClass(), "SAML auth redirect loop broken for URI: "
+                                            + request.getRequestURI());
+                                    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                                    return Result.SKIP_NO_CHAIN;
+                                }
+
                                 Logger.debug(this, ()-> "User is not log in, doing SAML Authentication request");
                                 this.doAuthentication(request, response, session, identityProviderConfiguration, host.getIdentifier());
                                 return Result.SKIP_NO_CHAIN;

--- a/dotCMS/src/main/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptor.java
@@ -183,8 +183,18 @@ public class SamlWebInterceptor implements WebInterceptor {
                                             + "redirecting to the IdP again.");
                                     SecurityLogger.logInfo(this.getClass(), "SAML auth redirect loop broken for URI: "
                                             + request.getRequestURI());
-                                    // Match the isCommitted() guard used by SecurityUtils.sendPermissionDenied,
-                                    // to avoid IllegalStateException / a double response if already committed.
+                                    // Mirror SecurityUtils.sendPermissionDenied's authenticated-403 path: clear any
+                                    // stale REDIRECT_AFTER_LOGIN so it cannot resurface as an unwanted redirect on the
+                                    // next login. We clear it HERE (not by relying on the JSP 403 branch) because for
+                                    // /api/* destinations custom-error-page.jsp returns early before that branch runs.
+                                    // Cleared inline rather than via sendPermissionDenied because the resolved User is
+                                    // not in scope here and this path must never fall to the 401 branch (which would
+                                    // re-set REDIRECT_AFTER_LOGIN and re-enter the loop).
+                                    final HttpSession loopSession = request.getSession(false);
+                                    if (null != loopSession) {
+                                        loopSession.removeAttribute(WebKeys.REDIRECT_AFTER_LOGIN);
+                                    }
+                                    // isCommitted() guard avoids IllegalStateException / a double response.
                                     if (!response.isCommitted()) {
                                         response.sendError(HttpServletResponse.SC_FORBIDDEN);
                                     }

--- a/dotCMS/src/main/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptor.java
@@ -168,6 +168,13 @@ public class SamlWebInterceptor implements WebInterceptor {
                                 // an infinite IdP redirect loop (e.g. a front-end-only SAML user sent
                                 // to a back-end URL like /dotAdmin). Break it
                                 // with a clean 403 instead of bouncing to the IdP again.
+                                //
+                                // Note: this is self-healing for a transient auto-login failure (e.g. a
+                                // one-off doCookieLogin error rather than a genuine realm mismatch). getUser()
+                                // consumes (removes) the SAML_USER_ID from the session, so isAutoLogin can only
+                                // be true for the single request following an IdP round-trip: a transient failure
+                                // yields one 403, and the next request has no SAML_USER_ID (isAutoLogin=false) and
+                                // re-runs a full IdP authentication. So a temporary glitch cannot lock the user out.
                                 if (autoLoginResult.isAutoLogin() && this.samlWebUtils.isNotLogged(request)) {
 
                                     Logger.warn(this, ()-> "SAML auth redirect loop detected for URI '"
@@ -176,7 +183,11 @@ public class SamlWebInterceptor implements WebInterceptor {
                                             + "redirecting to the IdP again.");
                                     SecurityLogger.logInfo(this.getClass(), "SAML auth redirect loop broken for URI: "
                                             + request.getRequestURI());
-                                    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                                    // Match the isCommitted() guard used by SecurityUtils.sendPermissionDenied,
+                                    // to avoid IllegalStateException / a double response if already committed.
+                                    if (!response.isCommitted()) {
+                                        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                                    }
                                     return Result.SKIP_NO_CHAIN;
                                 }
 

--- a/dotCMS/src/main/java/com/dotcms/util/SecurityUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/SecurityUtils.java
@@ -1,11 +1,14 @@
 package com.dotcms.util;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import com.dotcms.security.multipart.IllegalFileExtensionsValidator;
 import com.dotcms.security.multipart.IllegalTraversalFilePathValidator;
@@ -16,8 +19,10 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.SecurityLogger;
 import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.WebKeys;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.liferay.portal.model.User;
 import com.liferay.util.Xss;
 
 import io.vavr.control.Try;
@@ -81,6 +86,56 @@ public class SecurityUtils {
       ref = "/";
 
     return ref;
+  }
+
+  /**
+   * Centralizes the front-end "permission denied" HTTP response so authentication and
+   * authorization are cleanly separated across every servlet/filter that handles a
+   * {@code DotSecurityException}. This mirrors the Spring Security split between an
+   * {@code AuthenticationEntryPoint} (401, "who are you?") and an {@code AccessDeniedHandler}
+   * (403, "I know who you are, but you cannot have this"):
+   * <ul>
+   *   <li><b>Authenticated (non-anonymous) user</b> &rarr; {@code 403 Forbidden}. The
+   *   {@link WebKeys#REDIRECT_AFTER_LOGIN} intent is cleared so the container error page does
+   *   <b>not</b> bounce the browser back through the login/SSO flow &mdash; re-authenticating
+   *   can never grant a missing permission, which is exactly what produces the infinite SAML
+   *   redirect loop (see issue #36541).</li>
+   *   <li><b>Anonymous / not-logged-in user</b> &rarr; {@code 401 Unauthorized} and
+   *   {@link WebKeys#REDIRECT_AFTER_LOGIN} is set to {@code originalUri} so the legitimate
+   *   login flow can return the user to the resource afterwards.</li>
+   * </ul>
+   * The user is considered anonymous when it is {@code null} or {@link User#isAnonymousUser()}
+   * is {@code true}.
+   *
+   * @param user        the resolved user (may be {@code null} or the anonymous user)
+   * @param originalUri  the URI to return to after login (used only for the anonymous 401 path)
+   * @param request     the current request
+   * @param response    the current response
+   * @throws IOException if the error response cannot be written
+   */
+  public static void sendPermissionDenied(final User user, final String originalUri,
+      final HttpServletRequest request, final HttpServletResponse response) throws IOException {
+
+    if (response.isCommitted()) {
+      return;
+    }
+
+    if (user != null && !user.isAnonymousUser()) {
+      // Authenticated but not authorized: clean 403, never re-trigger authentication.
+      final HttpSession session = request.getSession(false);
+      if (session != null) {
+        session.removeAttribute(WebKeys.REDIRECT_AFTER_LOGIN);
+      }
+      response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    } else {
+      // Anonymous: remember where the user was headed and require login.
+      final HttpSession session = request.getSession();
+      if (session != null && UtilMethods.isSet(originalUri)) {
+        Logger.debug(SecurityUtils.class, () -> "Setting redirect after login to requested uri: " + originalUri);
+        session.setAttribute(WebKeys.REDIRECT_AFTER_LOGIN, originalUri);
+      }
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
   }
 
   /**

--- a/dotCMS/src/main/java/com/dotmarketing/filters/CMSUrlUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/filters/CMSUrlUtil.java
@@ -561,15 +561,15 @@ public class CMSUrlUtil {
         // Check if the page is visible by a CMS Anonymous role
         if (!permissionAPI.doesUserHavePermission(permissionable, PERMISSION_READ, user, mode.respectAnonPerms)) {
 
-            if (null == user) {// Not logged in user
+            if (null == user || user.isAnonymousUser()) {// Not logged in / anonymous user
 
                 Logger.debug(this.getClass(),
                         "CHECKING PERMISSION: Page doesn't have anonymous access [" + requestedURIForLogging + "]");
                 Logger.debug(this.getClass(), "401 URI = " + requestedURIForLogging);
                 Logger.debug(this.getClass(), "Unauthorized URI = " + requestedURIForLogging);
 
-                request.getSession().setAttribute(com.dotmarketing.util.WebKeys.REDIRECT_AFTER_LOGIN, requestedURIForLogging);
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "The requested page/file is unauthorized");
+                // Centralized auth/authz split: anonymous -> 401 + REDIRECT_AFTER_LOGIN.
+                com.dotcms.util.SecurityUtils.sendPermissionDenied(user, requestedURIForLogging, request, response);
                 return true;
             } else if (!permissionAPI.getRolesWithPermission(permissionable, PERMISSION_READ)
                 .contains(APILocator.getRoleAPI().loadLoggedinSiteRole())) {
@@ -579,7 +579,8 @@ public class CMSUrlUtil {
                     // go to unauthorized page
                     Logger.warn(this.getClass(),
                             "CHECKING PERMISSION: Page doesn't have any access for this user [" + requestedURIForLogging + "]");
-                    response.sendError(HttpServletResponse.SC_FORBIDDEN, "The requested page/file is forbidden");
+                    // Centralized auth/authz split: authenticated -> clean 403, no login redirect.
+                    com.dotcms.util.SecurityUtils.sendPermissionDenied(user, requestedURIForLogging, request, response);
                     return true;
                 }
             }

--- a/dotCMS/src/main/java/com/dotmarketing/filters/CMSUrlUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/filters/CMSUrlUtil.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.filters;
 
 import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.util.SecurityUtils;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
@@ -569,7 +570,7 @@ public class CMSUrlUtil {
                 Logger.debug(this.getClass(), "Unauthorized URI = " + requestedURIForLogging);
 
                 // Centralized auth/authz split: anonymous -> 401 + REDIRECT_AFTER_LOGIN.
-                com.dotcms.util.SecurityUtils.sendPermissionDenied(user, requestedURIForLogging, request, response);
+                SecurityUtils.sendPermissionDenied(user, requestedURIForLogging, request, response);
                 return true;
             } else if (!permissionAPI.getRolesWithPermission(permissionable, PERMISSION_READ)
                 .contains(APILocator.getRoleAPI().loadLoggedinSiteRole())) {
@@ -580,7 +581,7 @@ public class CMSUrlUtil {
                     Logger.warn(this.getClass(),
                             "CHECKING PERMISSION: Page doesn't have any access for this user [" + requestedURIForLogging + "]");
                     // Centralized auth/authz split: authenticated -> clean 403, no login redirect.
-                    com.dotcms.util.SecurityUtils.sendPermissionDenied(user, requestedURIForLogging, request, response);
+                    SecurityUtils.sendPermissionDenied(user, requestedURIForLogging, request, response);
                     return true;
                 }
             }

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/BinaryExporterServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/BinaryExporterServlet.java
@@ -675,19 +675,10 @@ public class BinaryExporterServlet extends HttpServlet {
 	         }
 		} catch (DotSecurityException e) {
 			try {
-			  if(req.getSession()!=null){
-				// any authenticated (non-anonymous) user lacking READ gets a clean 403.
-				// Only anonymous/not-logged-in users are redirected to login with a 401.
-				if(user != null && !user.isAnonymousUser()){
-				    req.getSession().removeAttribute(com.dotmarketing.util.WebKeys.REDIRECT_AFTER_LOGIN);
-					resp.sendError(HttpServletResponse.SC_FORBIDDEN);
-				}else{
-					final String requestUri = (String) req.getAttribute("javax.servlet.forward.request_uri");
-					Logger.debug(this, "Setting redirect after login to requested uri: " + requestUri);
-				    req.getSession().setAttribute(com.dotmarketing.util.WebKeys.REDIRECT_AFTER_LOGIN, requestUri);
-					resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-				}
-			  }
+				// Centralized auth/authz split: authenticated (non-anonymous) user lacking READ
+				// gets a clean 403; only anonymous/not-logged-in users are redirected to login with a 401.
+				final String requestUri = (String) req.getAttribute("javax.servlet.forward.request_uri");
+				SecurityUtils.sendPermissionDenied(user, requestUri, req, resp);
 			} catch (Exception e1) {
 				Logger.error(BinaryExporterServlet.class, "An error occurred when accessing '" + uri + "': " + e1.getMessage(), e1);
 	            if(!resp.isCommitted()){

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -60,12 +60,8 @@ public class SpeedyAssetServlet extends HttpServlet {
                     webResource, request, response);
             Logger.debug(ShortyServlet.class, () -> "User: " + user);
         } catch (SecurityException e) {
-            // Authentication (not authorization) failed here: no valid user could be resolved,
-            // so treat as anonymous and require login. Authorization on the asset itself is
-            // enforced downstream by BinaryExporterServlet (the /contentAsset forward below),
-            // which uses the same centralized auth/authz split.
             Logger.debug(SpeedyAssetServlet.class, e,  () -> "Error getting user and authenticating");
-            com.dotcms.util.SecurityUtils.sendPermissionDenied(null, request.getRequestURI(), request, response);
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -60,8 +60,12 @@ public class SpeedyAssetServlet extends HttpServlet {
                     webResource, request, response);
             Logger.debug(ShortyServlet.class, () -> "User: " + user);
         } catch (SecurityException e) {
+            // Authentication (not authorization) failed here: no valid user could be resolved,
+            // so treat as anonymous and require login. Authorization on the asset itself is
+            // enforced downstream by BinaryExporterServlet (the /contentAsset forward below),
+            // which uses the same centralized auth/authz split.
             Logger.debug(SpeedyAssetServlet.class, e,  () -> "Error getting user and authenticating");
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            com.dotcms.util.SecurityUtils.sendPermissionDenied(null, request.getRequestURI(), request, response);
             return;
         }
 

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -22,6 +22,7 @@
 402-title=Payment Required (402 error)
 403-body1=You do not have permissions to view the Page or file you were looking for.<br/>(If you are logged in, please contact your administrator for access).
 403-body2=If the problem persists, please return to the <a href="/">Home Page</a>.
+403-logout-sso=Sign out of your identity provider and sign in with a different account
 403-copywright=dotCMS LLC
 403-image-title=dotCMS Content Management System
 403-page-title=dotCMS: 403 Forbidden

--- a/dotCMS/src/main/webapp/html/error/custom-error-page.jsp
+++ b/dotCMS/src/main/webapp/html/error/custom-error-page.jsp
@@ -31,6 +31,8 @@ if(PageMode.get(request).isAdmin && Config.getBooleanProperty("SIMPLE_ERROR_PAGE
   final int status = response.getStatus();
   final String title = LanguageUtil.get(pageContext, status + "-page-title");
   final String body = LanguageUtil.get(pageContext, status + "-body1");
+  // Extra HTML rendered below the body (e.g. the Access Denied sign-out link on a 403).
+  String accessDeniedExtraHtml = "";
   try {
     final long languageId = WebAPILocator.getLanguageWebAPI().getLanguage(request).getId();
     final boolean isAPICall = pageContext.getErrorData().getRequestURI().startsWith("/api/");
@@ -91,6 +93,30 @@ if(PageMode.get(request).isAdmin && Config.getBooleanProperty("SIMPLE_ERROR_PAGE
         }
       request.getRequestDispatcher("/dotCMS/login").forward(request, response);
       }
+    } else if (status == 403) {
+      // Access Denied: the user is authenticated but not authorized for this resource.
+      // Clear any stale redirect intent and offer a sign-out
+      // link so the user can terminate the SSO session and retry with a different account.
+      session.removeAttribute(WebKeys.REDIRECT_AFTER_LOGIN);
+
+      String logoutUrl = "/dotCMS/logout";
+      String logoutLabel = LanguageUtil.get(pageContext, "Logout");
+      try {
+        final com.dotcms.saml.DotSamlProxyFactory samlProxy = com.dotcms.saml.DotSamlProxyFactory.getInstance();
+        if (null != site && samlProxy.isAnyHostConfiguredAsSAML()) {
+          final com.dotcms.saml.IdentityProviderConfiguration idpConfig =
+              samlProxy.identityProviderConfigurationFactory().findIdentityProviderConfigurationById(site.getIdentifier());
+          if (null != idpConfig && idpConfig.isEnabled()) {
+            // dotCMS performs SLO against whichever IdP the host is configured for (Entra ID, Okta, ...).
+            logoutUrl = "/api/v1/dotsaml/logout/" + site.getIdentifier();
+            logoutLabel = LanguageUtil.get(pageContext, "403-logout-sso");
+          }
+        }
+      } catch (Exception e) {
+        Logger.debug(this.getClass(), "Unable to resolve SAML logout link for 403 page: " + e.getMessage());
+      }
+
+      accessDeniedExtraHtml = "<p><a href=\"" + logoutUrl + "\">" + logoutLabel + "</a></p>";
     } else if (status == 404) {
       ClickstreamFactory.add404Request(request, response, site);
     } else if (status == 500) {
@@ -148,6 +174,8 @@ h1 {
       <h1><%= title %></h1>
 
       <p><%= body %></p>
+
+      <%= accessDeniedExtraHtml %>
 
     </div>
   </div>

--- a/dotCMS/src/test/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptorLoopGuardTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptorLoopGuardTest.java
@@ -1,0 +1,126 @@
+package com.dotcms.filters.interceptor.saml;
+
+import com.dotcms.cms.login.LoginServiceAPI;
+import com.dotcms.filters.interceptor.Result;
+import com.dotcms.saml.IdentityProviderConfiguration;
+import com.dotcms.saml.IdentityProviderConfigurationFactory;
+import com.dotcms.saml.SamlConfigurationService;
+import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.util.security.Encryptor;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.UserAPI;
+import com.dotmarketing.business.web.HostWebAPI;
+import com.dotmarketing.filters.CMSUrlUtil;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the deterministic SAML auth-redirect loop-guard in
+ * {@link SamlWebInterceptor#intercept(HttpServletRequest, HttpServletResponse)} (issue #32365).
+ *
+ * The guard breaks the infinite IdP redirect loop that occurs when an authenticated-but-unauthorized
+ * user (e.g. a front-end-only SAML user sent to a back-end URL like {@code /dotAdmin}) would otherwise
+ * be bounced to the IdP forever: when auto-login resolved a SAML user ({@code isAutoLogin}) yet the
+ * request is still not logged in for its destination ({@code isNotLogged}), it returns a clean 403
+ * instead of redirecting again.
+ */
+public class SamlWebInterceptorLoopGuardTest {
+
+    /**
+     * Builds a spy interceptor with the protected gate methods stubbed so {@code intercept()} reaches
+     * the loop-guard branch: SAML is configured, the URL is include-path filtered (not access-filtered),
+     * the user is not logged in for this destination, and auto-login resolves (or not) a SAML user.
+     */
+    private SamlWebInterceptor interceptorReachingGuard(final HttpServletRequest request,
+                                                        final HttpServletResponse response,
+                                                        final HttpSession session,
+                                                        final boolean autoLoginResolvedUser) {
+
+        final SamlWebUtils samlWebUtils      = mock(SamlWebUtils.class);
+        final HostWebAPI hostWebAPI          = mock(HostWebAPI.class);
+        final SamlConfigurationService samlConfigurationService = mock(SamlConfigurationService.class);
+        final IdentityProviderConfigurationFactory idpFactory   = mock(IdentityProviderConfigurationFactory.class);
+        final IdentityProviderConfiguration idpConfig           = mock(IdentityProviderConfiguration.class);
+        final Host host                      = mock(Host.class);
+
+        final SamlWebInterceptor interceptor = spy(new SamlWebInterceptor(
+                mock(Encryptor.class), mock(LoginServiceAPI.class), mock(UserAPI.class), hostWebAPI,
+                mock(AppsAPI.class), samlWebUtils, mock(CMSUrlUtil.class), idpFactory));
+        interceptor.setSamlConfig(samlConfigurationService);
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getRequestURI()).thenReturn("/dotAdmin/");
+        when(hostWebAPI.getCurrentHostNoThrow(request)).thenReturn(host);
+        when(host.getIdentifier()).thenReturn("123");
+        when(idpFactory.findIdentityProviderConfigurationById("123")).thenReturn(idpConfig);
+        when(idpConfig.isEnabled()).thenReturn(true);
+        when(samlWebUtils.isNotLogged(request)).thenReturn(true);
+
+        doReturn(true).when(interceptor).isAnySamlConfigurated();
+        doReturn(false).when(interceptor).checkAccessFilters(anyString(), any(), any(), any());
+        doReturn(true).when(interceptor).checkIncludePath(anyString(), any());
+        doReturn(new AutoLoginResult(session, autoLoginResolvedUser)).when(interceptor)
+                .autoLogin(any(), any(), any(), any());
+
+        return interceptor;
+    }
+
+    /**
+     * Method to test: {@link SamlWebInterceptor#intercept(HttpServletRequest, HttpServletResponse)}
+     * Given Scenario: auto-login resolved a SAML user ({@code isAutoLogin=true}) but the request is
+     * still not logged in for the destination (front-end-only user hitting a back-end URL).
+     * Expected Result: the loop-guard returns HTTP 403 and {@code Result.SKIP_NO_CHAIN} instead of
+     * redirecting to the IdP again.
+     */
+    @Test
+    public void test_authenticated_but_unauthorized_breaks_loop_with_403() throws IOException {
+
+        final HttpServletRequest request   = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final HttpSession session          = mock(HttpSession.class);
+        when(response.isCommitted()).thenReturn(false);
+
+        final SamlWebInterceptor interceptor = this.interceptorReachingGuard(request, response, session, true);
+
+        final Result result = interceptor.intercept(request, response);
+
+        assertEquals(Result.SKIP_NO_CHAIN, result);
+        verify(response).sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    /**
+     * Method to test: {@link SamlWebInterceptor#intercept(HttpServletRequest, HttpServletResponse)}
+     * Given Scenario: the response is already committed when the loop-guard fires.
+     * Expected Result: no {@code sendError} is written (avoids IllegalStateException / double response),
+     * and the interceptor still returns {@code Result.SKIP_NO_CHAIN}.
+     */
+    @Test
+    public void test_loop_guard_does_not_write_when_response_committed() throws IOException {
+
+        final HttpServletRequest request   = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final HttpSession session          = mock(HttpSession.class);
+        when(response.isCommitted()).thenReturn(true);
+
+        final SamlWebInterceptor interceptor = this.interceptorReachingGuard(request, response, session, true);
+
+        final Result result = interceptor.intercept(request, response);
+
+        assertEquals(Result.SKIP_NO_CHAIN, result);
+        verify(response, never()).sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptorLoopGuardTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/interceptor/saml/SamlWebInterceptorLoopGuardTest.java
@@ -11,6 +11,7 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.UserAPI;
 import com.dotmarketing.business.web.HostWebAPI;
 import com.dotmarketing.filters.CMSUrlUtil;
+import com.dotmarketing.util.WebKeys;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
@@ -100,6 +101,10 @@ public class SamlWebInterceptorLoopGuardTest {
 
         assertEquals(Result.SKIP_NO_CHAIN, result);
         verify(response).sendError(HttpServletResponse.SC_FORBIDDEN);
+        // The authenticated-403 path must clear any stale REDIRECT_AFTER_LOGIN (issue #36541/#32365),
+        // so it can't resurface as an unwanted redirect on the next login — including for /api/* URLs
+        // where the error page returns before its 403 branch would otherwise clear it.
+        verify(session).removeAttribute(WebKeys.REDIRECT_AFTER_LOGIN);
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/util/SecurityUtilsTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/SecurityUtilsTest.java
@@ -3,6 +3,8 @@ package com.dotcms.util;
 import java.net.URL;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -11,10 +13,16 @@ import com.dotcms.mock.request.MockAttributeRequest;
 import com.dotcms.mock.request.MockHeaderRequest;
 import com.dotcms.mock.request.MockHttpRequestUnitTest;
 import com.dotcms.mock.request.MockSessionRequest;
+import com.dotmarketing.util.WebKeys;
 import com.google.common.collect.ImmutableList;
+import com.liferay.portal.model.User;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SecurityUtilsTest {
 
@@ -104,6 +112,92 @@ public class SecurityUtilsTest {
 
 
     return new MockHeaderRequest(new MockAttributeRequest(new MockSessionRequest(new MockHttpRequestUnitTest(host, uri).request()).request()).request(), "referer", referer);
+  }
+
+  /**
+   * Method to test: {@link SecurityUtils#sendPermissionDenied(User, String, HttpServletRequest, HttpServletResponse)}
+   * Given Scenario: An authenticated (non-anonymous) user lacks permission on a resource.
+   * Expected Result: A clean 403 is sent, the REDIRECT_AFTER_LOGIN intent is cleared, and it is
+   * never set (so the container error page does not bounce the user back through the SSO flow).
+   */
+  @Test
+  public void test_sendPermissionDenied_authenticatedUser_returns403_andClearsRedirect() throws Exception {
+
+    final User authenticated = mock(User.class);
+    when(authenticated.isAnonymousUser()).thenReturn(false);
+
+    final HttpSession session = mock(HttpSession.class);
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    final HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.isCommitted()).thenReturn(false);
+    when(request.getSession(false)).thenReturn(session);
+
+    SecurityUtils.sendPermissionDenied(authenticated, "/protected/file.pdf", request, response);
+
+    verify(response).sendError(HttpServletResponse.SC_FORBIDDEN);
+    verify(session).removeAttribute(WebKeys.REDIRECT_AFTER_LOGIN);
+    verify(session, never()).setAttribute(Mockito.eq(WebKeys.REDIRECT_AFTER_LOGIN), Mockito.any());
+  }
+
+  /**
+   * Method to test: {@link SecurityUtils#sendPermissionDenied(User, String, HttpServletRequest, HttpServletResponse)}
+   * Given Scenario: The anonymous user requests a protected resource.
+   * Expected Result: A 401 is sent and REDIRECT_AFTER_LOGIN is set so login can return the user.
+   */
+  @Test
+  public void test_sendPermissionDenied_anonymousUser_returns401_andSetsRedirect() throws Exception {
+
+    final User anonymous = mock(User.class);
+    when(anonymous.isAnonymousUser()).thenReturn(true);
+
+    final HttpSession session = mock(HttpSession.class);
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    final HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.isCommitted()).thenReturn(false);
+    when(request.getSession()).thenReturn(session);
+
+    SecurityUtils.sendPermissionDenied(anonymous, "/protected/file.pdf", request, response);
+
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(session).setAttribute(WebKeys.REDIRECT_AFTER_LOGIN, "/protected/file.pdf");
+  }
+
+  /**
+   * Method to test: {@link SecurityUtils#sendPermissionDenied(User, String, HttpServletRequest, HttpServletResponse)}
+   * Given Scenario: A null user (not resolved / not logged in) requests a protected resource.
+   * Expected Result: Treated as anonymous -> 401 with the redirect intent set.
+   */
+  @Test
+  public void test_sendPermissionDenied_nullUser_returns401() throws Exception {
+
+    final HttpSession session = mock(HttpSession.class);
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    final HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.isCommitted()).thenReturn(false);
+    when(request.getSession()).thenReturn(session);
+
+    SecurityUtils.sendPermissionDenied(null, "/protected/file.pdf", request, response);
+
+    verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(session).setAttribute(WebKeys.REDIRECT_AFTER_LOGIN, "/protected/file.pdf");
+  }
+
+  /**
+   * Method to test: {@link SecurityUtils#sendPermissionDenied(User, String, HttpServletRequest, HttpServletResponse)}
+   * Given Scenario: The response has already been committed.
+   * Expected Result: No error is written (avoids IllegalStateException / double response).
+   */
+  @Test
+  public void test_sendPermissionDenied_committedResponse_isNoOp() throws Exception {
+
+    final User authenticated = mock(User.class);
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    final HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.isCommitted()).thenReturn(true);
+
+    SecurityUtils.sendPermissionDenied(authenticated, "/protected/file.pdf", request, response);
+
+    verify(response, never()).sendError(Mockito.anyInt());
   }
 
   /**


### PR DESCRIPTION
## Problem

On SAML-protected sites, a **SAML user without a back-end role** (front-end-only) who lands on a back-end URL (e.g. `/dotAdmin/`) — or any authenticated front-end user requesting a resource they lack READ on — was bounced back to the IdP repeatedly. Because the IdP re-authenticates the already-signed-in user but that never grants the missing access, the result was an **infinite redirect loop** (`ERR_TOO_MANY_REDIRECTS`) with no default "Access Denied" landing. This is the counterpart to the file-asset status-code fix in #36541.

## What this PR does

Cleanly separates **authentication** (401 → start login) from **authorization** (403 → Access Denied, never re-authenticate), and gives those users a real destination:

- **Centralized 401-vs-403 decision** — new `SecurityUtils.sendPermissionDenied(user, uri, req, resp)`: authenticated (non-anonymous) → **403** and clears `REDIRECT_AFTER_LOGIN`; anonymous/null → **401** + sets it. Adopted by `BinaryExporterServlet`, `SpeedyAssetServlet`, and `CMSUrlUtil` (which previously keyed only on `user == null`).
- **Default 403 "Access Denied" page** in `custom-error-page.jsp` with a provider-agnostic **sign-out** link: SAML SLO (`/api/v1/dotsaml/logout/{host}`) when the host has SAML enabled (Entra ID, Okta, …), else `/dotCMS/logout`. Honors the existing per-site `/cms403Page` vanity override.
- **Deterministic SAML loop-guard** in `SamlWebInterceptor`: if auto-login resolved a SAML user yet the request is still not logged in for its destination (`isAutoLogin() && isNotLogged()`), return a clean **403** instead of redirecting to the IdP again. This trips on the first futile cycle and is immune to the per-callback session churn caused by SameSite cookies.

Anonymous (not-logged-in) users still get the legitimate 401 → login flow; back-end/admin users still get 403.

## Fixes / Refs

- Fixes #32365
- Refs #36541

## Testing

- Unit: `SecurityUtilsTest` (401-vs-403 resolver) — 19/19 green.
- Manual (native login **and** real Entra ID): authenticated-but-unauthorized front-end user → clean **403** on pages and file assets (no `REDIRECT_AFTER_LOGIN`); anonymous → 401 → login; SAML front-end user hitting a back-end URL now gets a **403 Access Denied with a sign-out link** instead of an infinite loop.

## Follow-up (tracked separately)

- Preserve the original front-end URL through the SAML round-trip (default RelayState → original request, with open-redirect validation) so users return to the exact page they requested.
- Fix `DotSamlResource.logoutGet/logoutPost` missing `return` after redirect (spurious `DoesNotExistException`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #32365