### PR TITLE
security: upgrade Apache Tomcat 9.0.118 → 9.0.120

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
         <vipsffm.libpath.args></vipsffm.libpath.args>
 
         <maven.deploy.skip>false</maven.deploy.skip>
-        <tomcat.version>9.0.118</tomcat.version>
+        <tomcat.version>9.0.120</tomcat.version>
         <!-- Add any properties here that are to have defaults and overrides set in the environment properties -->
         <!--suppress UnresolvedMavenProperty -->
         <mvn.environment.name>${ext.mvn.environment.name}</mvn.environment.name>


### PR DESCRIPTION
### Proposed Changes

Bumps Apache Tomcat on `main` from **9.0.118** to the current release **9.0.120** (2026-07-03). PR #35798 backported a Tomcat bump to the 24.12.27 LTS branch but `main` was left behind.

Single-line change in `parent/pom.xml` — `tomcat.version` is the one source of truth; it drives the Maven dependency, the assembled `dotserver/tomcat-${tomcat.version}` distribution, and the `tomcat:${tomcat.version}-jdk11` Docker base image. No other hardcoded references exist.

### Security-relevant changes (9.0.119 → 9.0.120)

- **CVE-2024-56337** — startup check blocks web apps potentially vulnerable to it unless the JVM protection is confirmed; reflection only used when required
- **CVE-2025-49125** — regression fix restoring `PreResources`/`PostResources` access below the web-app root
- **WebDAV `serveSubpathOnly`** — operation destinations now also restricted to the sub-path
- **WebSocket `permessage-deflate`** — no longer drops bytes when a compressed message inflates past the buffer
- Fix for a 9.0.119 regression breaking some request-body reads via `Reader`

### Checklist

- [x] `org.apache.tomcat:tomcat:9.0.120:tar.gz` + `tomcat-embed-core:9.0.120` resolve from the dotCMS Artifactory mirror
- [x] `./mvnw install -pl :dotcms-core --am -DskipTests -Ddocker.skip` → BUILD SUCCESS; assembly unpacks `dotserver/tomcat-9.0.120/` with dotCMS overrides applied

Closes #36592

🤖 Generated with [Claude Code](https://claude.com/claude-code)