### PR TITLE
Respect workflow resolution for scheduled publishing

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/PublishDateUpdater.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/PublishDateUpdater.java
@@ -56,6 +56,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.db.HibernateUtil;
+import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotHibernateException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -70,12 +71,14 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import graphql.VisibleForTesting;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.quartz.CronExpression;
@@ -90,6 +93,11 @@ public class PublishDateUpdater {
 
     private final static String PUBLISH_LUCENE_QUERY = "+contentType:(%4$s) +live:false +deleted:false +%1$s:[1969-12-31t18:00:00-0000 TO %3$s] +%2$s:[%3$s TO 3000-12-31t18:00:00-0000]";
     private final static String UNPUBLISH_LUCENE_QUERY = "+live:true +deleted:false +%s:[1969-12-31t18:00:00-0000 TO %s]";
+
+    // Impossible wfstep term used when no resolved step exists, so the publish query stays valid
+    // and conservative instead of silently becoming an allow-all query
+    private static final String MATCH_NO_STEP_TOKEN = "no_resolved_workflow_step";
+    private static final Pattern LUCENE_SAFE_ID = Pattern.compile("[a-zA-Z0-9_-]+");
 
     private final static String GET_CONTENT_TYPE_WITH_PUBLISH_FIELD = "SELECT velocity_var_name from structure where publish_date_var is not null AND publish_date_var != ''";
 
@@ -264,7 +272,12 @@ public class PublishDateUpdater {
             final int transactionBatchSize = Config.getIntProperty("PUBLISH_JOB_QUEUE_TRANSACTION_BATCH_SIZE", 100);
 
         if (!contentTypeVariableWithPublishField.isEmpty()) {
-            final String luceneQueryToPublish = getPublishLuceneQuery(fireTime, contentTypeVariableWithPublishField);
+            // Read the workflow resolution configuration once per job run so the query filter and
+            // every per-contentlet decision in this run share the same stable snapshot
+            final WorkflowResolutionConfig workflowResolutionConfig = WorkflowResolutionConfig.fromConfig();
+            final String luceneQueryToPublish = getPublishLuceneQuery(fireTime,
+                    contentTypeVariableWithPublishField, workflowResolutionConfig,
+                    APILocator.getWorkflowAPI());
 
             // Use provided previousFireTime if available (from JobExecutionContext),
             // otherwise calculate it from cron expression
@@ -301,7 +314,7 @@ public class PublishDateUpdater {
 
             //This method fires both operations publish + unpublish using batches
             totalPublishedCount = processPublishContentInBatch(luceneQueryToPublish, forcePublishAllContent, previousJobRunTime,
-                    searchBatchSize, transactionBatchSize);
+                    searchBatchSize, transactionBatchSize, workflowResolutionConfig);
         }
 
         final String luceneQueryToUnPublish = getExpireLuceneQuery(fireTime);
@@ -336,6 +349,163 @@ public class PublishDateUpdater {
                 ESMappingConstants.EXPIRE_DATE,
                 time,
                 StringUtils.join(contentTypeVariableWithPublishField, " OR "));
+    }
+
+    /**
+     * Builds the scheduled publish query adding, when the workflow resolution check is enabled, an
+     * index-level pre-filter on the current workflow step. The pre-filter only reduces the
+     * candidate set so held content is not re-read on every run;
+     * {@link #workflowAllowsScheduledPublish} remains the final authoritative gate.
+     *
+     * @param date the fire time bounding the publish date range
+     * @param contentTypeVariableWithPublishField content types with a publish date field
+     * @param workflowResolutionConfig per-run snapshot of the workflow resolution configuration
+     * @param workflowAPI workflow API used to resolve the step IDs referenced by the filter
+     * @return the publish query, optionally extended with the workflow step pre-filter
+     */
+    @VisibleForTesting
+    static String getPublishLuceneQuery(final Date date,
+            final List<String> contentTypeVariableWithPublishField,
+            final WorkflowResolutionConfig workflowResolutionConfig,
+            final WorkflowAPI workflowAPI) {
+
+        final String baseQuery = getPublishLuceneQuery(date, contentTypeVariableWithPublishField);
+        if (!workflowResolutionConfig.respectWorkflowResolution()) {
+            return baseQuery;
+        }
+        return baseQuery + workflowResolutionQueryFilter(workflowResolutionConfig, workflowAPI);
+    }
+
+    /**
+     * Builds the workflow step clause appended to the publish query. Any failure while reading the
+     * workflow definitions falls back to the unfiltered historical query: the filter is only an
+     * optimization and {@link #workflowAllowsScheduledPublish} still enforces the policy.
+     *
+     * @param workflowResolutionConfig per-run snapshot of the workflow resolution configuration
+     * @param workflowAPI workflow API used to resolve schemes and steps
+     * @return the Lucene clause to append, or an empty string when no filtering is possible
+     */
+    private static String workflowResolutionQueryFilter(
+            final WorkflowResolutionConfig workflowResolutionConfig, final WorkflowAPI workflowAPI) {
+        try {
+            return workflowResolutionConfig.configuredSchemes().isEmpty()
+                    ? globalResolvedStepFilter(workflowAPI)
+                    : scopedUnresolvedStepFilter(workflowResolutionConfig.configuredSchemes(),
+                            workflowAPI);
+        } catch (final Exception e) {
+            Logger.warn(PublishDateUpdater.class,
+                    "Could not build the workflow resolution publish query filter, falling back to"
+                            + " the unfiltered query: " + e.getMessage(), e);
+            return StringUtils.EMPTY;
+        }
+    }
+
+    /**
+     * Builds the global-mode pre-filter: only content sitting on a resolved workflow step may be
+     * published, so the query is narrowed to the resolved step IDs. Content without a current step
+     * is intentionally excluded because the global check holds it as well. When no resolved step
+     * exists, a clause matching no content is returned instead of an allow-all query.
+     *
+     * @param workflowAPI workflow API used to list schemes and steps
+     * @return the Lucene clause restricting candidates to resolved steps
+     * @throws DotDataException when the workflow definitions cannot be read
+     */
+    private static String globalResolvedStepFilter(final WorkflowAPI workflowAPI)
+            throws DotDataException {
+        final List<String> resolvedStepIds = new ArrayList<>();
+        for (final WorkflowScheme scheme : workflowAPI.findSchemes(false)) {
+            resolvedStepIds.addAll(stepIds(workflowAPI.findSteps(scheme), true));
+        }
+        if (resolvedStepIds.isEmpty()) {
+            return stepFilterClause("+", List.of(MATCH_NO_STEP_TOKEN));
+        }
+        return stepFilterClause("+", resolvedStepIds);
+    }
+
+    /**
+     * Builds the scoped-mode pre-filter: only content currently sitting on an unresolved step of a
+     * configured scheme is excluded. Content without a step, content on unconfigured workflows and
+     * content on resolved configured steps stays a candidate so the Java gate can decide.
+     *
+     * @param configuredSchemes configured workflow scheme IDs or variable names
+     * @param workflowAPI workflow API used to resolve schemes and steps
+     * @return the Lucene clause excluding unresolved configured steps, or empty when none exist
+     * @throws DotDataException when the workflow definitions cannot be read
+     * @throws DotSecurityException when a configured scheme cannot be read
+     */
+    private static String scopedUnresolvedStepFilter(final Set<String> configuredSchemes,
+            final WorkflowAPI workflowAPI) throws DotDataException, DotSecurityException {
+        final List<String> unresolvedStepIds = new ArrayList<>();
+        for (final String schemeIdOrVariable : configuredSchemes) {
+            final Optional<WorkflowScheme> scheme =
+                    findConfiguredScheme(workflowAPI, schemeIdOrVariable);
+            if (scheme.isPresent()) {
+                unresolvedStepIds.addAll(stepIds(workflowAPI.findSteps(scheme.get()), false));
+            }
+        }
+        if (unresolvedStepIds.isEmpty()) {
+            return StringUtils.EMPTY;
+        }
+        return stepFilterClause("-", unresolvedStepIds);
+    }
+
+    /**
+     * Resolves a configured workflow scheme by ID or variable name. A scheme that no longer exists
+     * is skipped so a stale configuration entry does not disable the whole filter.
+     *
+     * @param workflowAPI workflow API used to resolve the scheme
+     * @param schemeIdOrVariable configured scheme ID or variable name
+     * @return the resolved scheme, or empty when it does not exist
+     * @throws DotDataException when the workflow definitions cannot be read
+     * @throws DotSecurityException when the scheme cannot be read
+     */
+    private static Optional<WorkflowScheme> findConfiguredScheme(final WorkflowAPI workflowAPI,
+            final String schemeIdOrVariable) throws DotDataException, DotSecurityException {
+        try {
+            return Optional.ofNullable(workflowAPI.findScheme(schemeIdOrVariable));
+        } catch (final DoesNotExistException e) {
+            Logger.debug(PublishDateUpdater.class, String.format(
+                    "Configured workflow scheme %s was not found, skipping it in the publish query filter",
+                    schemeIdOrVariable));
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Extracts the IDs of the steps whose {@code resolved} flag matches the requested value.
+     *
+     * @param steps workflow steps of a scheme
+     * @param resolved the {@code resolved} value to select
+     * @return the IDs of the matching steps
+     */
+    private static List<String> stepIds(final List<WorkflowStep> steps, final boolean resolved) {
+        return steps.stream()
+                .filter(step -> step.isResolved() == resolved)
+                .map(WorkflowStep::getId)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Formats a {@code wfstep} clause following the pattern already used by
+     * {@code WorkflowAPIImpl}: space-separated {@code wfstep:} terms inside a single required or
+     * prohibited group. If any step ID is not safe for the Lucene syntax, no clause is produced so
+     * the query never excludes content it should not; the Java gate still enforces the policy.
+     *
+     * @param operator {@code "+"} to require the group or {@code "-"} to prohibit it
+     * @param stepIds workflow step IDs to include in the clause
+     * @return the formatted clause, or an empty string when an unsafe ID is found
+     */
+    private static String stepFilterClause(final String operator, final List<String> stepIds) {
+        final boolean unsafeId = stepIds.stream()
+                .anyMatch(id -> id == null || !LUCENE_SAFE_ID.matcher(id).matches());
+        if (unsafeId) {
+            Logger.warn(PublishDateUpdater.class,
+                    "Found a workflow step ID that is not safe for the Lucene syntax, falling back"
+                            + " to the unfiltered publish query");
+            return StringUtils.EMPTY;
+        }
+        return String.format(" %s(%s:%s )", operator, ESMappingConstants.WORKFLOW_STEP,
+                String.join(" " + ESMappingConstants.WORKFLOW_STEP + ":", stepIds));
     }
 
     public static String getExpireLuceneQuery(final Date date) {
@@ -566,12 +736,15 @@ public class PublishDateUpdater {
         private final Date previousJobRunTime;
         private final ContentletAPI contentletAPI;
         private final WorkflowAPI workflowAPI;
+        private final WorkflowResolutionConfig workflowResolutionConfig;
 
-        public Publisher(final boolean forcePublishing, final Date previousJobRunTime) {
+        public Publisher(final boolean forcePublishing, final Date previousJobRunTime,
+                final WorkflowResolutionConfig workflowResolutionConfig) {
             this.forcePublishing = forcePublishing;
             this.previousJobRunTime = previousJobRunTime;
             this.contentletAPI = APILocator.getContentletAPI();
             this.workflowAPI = APILocator.getWorkflowAPI();
+            this.workflowResolutionConfig = workflowResolutionConfig;
         }
 
         /**
@@ -580,18 +753,21 @@ public class PublishDateUpdater {
          *
          * @param contentletAPI content API used to publish content
          * @param workflowAPI workflow API used to inspect the current step
+         * @param workflowResolutionConfig explicit workflow resolution configuration snapshot
          */
         @VisibleForTesting
-        Publisher(final ContentletAPI contentletAPI, final WorkflowAPI workflowAPI) {
+        Publisher(final ContentletAPI contentletAPI, final WorkflowAPI workflowAPI,
+                final WorkflowResolutionConfig workflowResolutionConfig) {
             this.forcePublishing = true;
             this.previousJobRunTime = null;
             this.contentletAPI = contentletAPI;
             this.workflowAPI = workflowAPI;
+            this.workflowResolutionConfig = workflowResolutionConfig;
         }
 
         @Override
         public boolean process(final Contentlet contentlet, final User systemUser) throws Exception {
-            if (!workflowAllowsScheduledPublish(contentlet, workflowAPI)) {
+            if (!workflowAllowsScheduledPublish(contentlet, workflowAPI, workflowResolutionConfig)) {
                 return false;
             }
 
@@ -657,19 +833,21 @@ public class PublishDateUpdater {
      *
      * @param contentlet content selected by the scheduled publishing job
      * @param workflowAPI workflow API used to inspect the current step
+     * @param workflowResolutionConfig per-run snapshot of the workflow resolution configuration
      * @return {@code true} when scheduled publication is allowed
      * @throws DotDataException when the current workflow state cannot be read
      * @throws DotSecurityException when the current workflow scheme cannot be read
      */
     @VisibleForTesting
     static boolean workflowAllowsScheduledPublish(final Contentlet contentlet,
-            final WorkflowAPI workflowAPI) throws DotDataException, DotSecurityException {
-        if (!Config.getBooleanProperty(RESPECT_WORKFLOW_RESOLUTION_PROPERTY, false)) {
+            final WorkflowAPI workflowAPI, final WorkflowResolutionConfig workflowResolutionConfig)
+            throws DotDataException, DotSecurityException {
+        if (!workflowResolutionConfig.respectWorkflowResolution()) {
             return true;
         }
 
         final Optional<WorkflowStep> currentStep = workflowAPI.findCurrentStep(contentlet);
-        final Set<String> configuredSchemes = configuredWorkflowSchemes();
+        final Set<String> configuredSchemes = workflowResolutionConfig.configuredSchemes();
         if (!configuredSchemes.isEmpty()
                 && !matchesConfiguredWorkflow(contentlet, currentStep, configuredSchemes,
                         workflowAPI)) {
@@ -678,7 +856,8 @@ public class PublishDateUpdater {
 
         final boolean resolved = currentStep.map(WorkflowStep::isResolved).orElse(false);
         if (!resolved) {
-            Logger.warn(PublishDateUpdater.class, String.format(
+            // Held content is a normal state, not an anomaly, so it is logged at debug level
+            Logger.debug(PublishDateUpdater.class, String.format(
                     "Skipping scheduled publish for contentlet %s: current workflow step %s is not resolved",
                     contentlet.getIdentifier(),
                     currentStep.map(WorkflowStep::getId).orElse("not found")));
@@ -686,12 +865,41 @@ public class PublishDateUpdater {
         return resolved;
     }
 
-    private static Set<String> configuredWorkflowSchemes() {
-        return Arrays.stream(Config.getStringProperty(WORKFLOW_RESOLUTION_SCHEMES_PROPERTY, "")
-                        .split(","))
-                .map(String::trim)
-                .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toSet());
+    /**
+     * Immutable per-run snapshot of the workflow resolution configuration. The properties are read
+     * once per job execution so the query filter and every per-contentlet decision within the same
+     * run use the same stable values, while property changes stay visible to the next run without
+     * a restart.
+     *
+     * @param respectWorkflowResolution whether scheduled publication requires a resolved step
+     * @param configuredSchemes workflow scheme IDs or variable names limiting the check; empty
+     *        applies the check to every workflow
+     */
+    record WorkflowResolutionConfig(boolean respectWorkflowResolution,
+                                    Set<String> configuredSchemes) {
+
+        WorkflowResolutionConfig {
+            configuredSchemes = Set.copyOf(configuredSchemes);
+        }
+
+        /**
+         * Reads and normalizes the workflow resolution properties, returning a stable snapshot for
+         * the current job run. When the flag is disabled the scheme list is not read at all.
+         *
+         * @return the configuration snapshot for this job execution
+         */
+        static WorkflowResolutionConfig fromConfig() {
+            if (!Config.getBooleanProperty(RESPECT_WORKFLOW_RESOLUTION_PROPERTY, false)) {
+                return new WorkflowResolutionConfig(false, Set.of());
+            }
+            final Set<String> configuredSchemes = Arrays.stream(
+                            Config.getStringProperty(WORKFLOW_RESOLUTION_SCHEMES_PROPERTY, "")
+                                    .split(","))
+                    .map(String::trim)
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.toSet());
+            return new WorkflowResolutionConfig(true, configuredSchemes);
+        }
     }
 
     private static boolean matchesConfiguredWorkflow(final Contentlet contentlet,
@@ -727,15 +935,18 @@ public class PublishDateUpdater {
      * @param previousJobRunTime Previous job run time for content validation
      * @param searchBatchSize The batch size for search operations
      * @param transactionBatchSize The batch size for transaction commits
+     * @param workflowResolutionConfig Per-run snapshot of the workflow resolution configuration
      * @return The number of contentlets actually published
      */
     private static int processPublishContentInBatch(final String luceneQuery,
                                                            final boolean forcePublishAllContent,
                                                            final Date previousJobRunTime,
                                                            final int searchBatchSize,
-                                                           final int transactionBatchSize) throws DotDataException {
+                                                           final int transactionBatchSize,
+                                                           final WorkflowResolutionConfig workflowResolutionConfig) throws DotDataException {
         //Build and pass a delegate to deal with the Publish Operation
-        final ContentProcessor publishProcessor = new Publisher(forcePublishAllContent, previousJobRunTime);
+        final ContentProcessor publishProcessor = new Publisher(forcePublishAllContent, previousJobRunTime,
+                workflowResolutionConfig);
         return processContentInBatch(luceneQuery, searchBatchSize, transactionBatchSize, publishProcessor);
     }
 

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/PublishDateUpdater.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/PublishDateUpdater.java
@@ -61,21 +61,32 @@ import com.dotmarketing.exception.DotHibernateException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
+import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
+import com.dotmarketing.portlets.workflows.model.WorkflowStep;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import graphql.VisibleForTesting;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.quartz.CronExpression;
 
 
 public class PublishDateUpdater {
+
+    private static final String RESPECT_WORKFLOW_RESOLUTION_PROPERTY =
+            "PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION";
+    private static final String WORKFLOW_RESOLUTION_SCHEMES_PROPERTY =
+            "PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION_SCHEMES";
 
     private final static String PUBLISH_LUCENE_QUERY = "+contentType:(%4$s) +live:false +deleted:false +%1$s:[1969-12-31t18:00:00-0000 TO %3$s] +%2$s:[%3$s TO 3000-12-31t18:00:00-0000]";
     private final static String UNPUBLISH_LUCENE_QUERY = "+live:true +deleted:false +%s:[1969-12-31t18:00:00-0000 TO %s]";
@@ -403,9 +414,7 @@ public class PublishDateUpdater {
      * Allows for flexible delegation of specific content operations while maintaining
      * common pagination and transaction management logic.
      */
-    private interface ContentProcessor {
-
-        ContentletAPI contentletAPI = APILocator.getContentletAPI();
+    interface ContentProcessor {
 
         /**
          * Process a single contentlet.
@@ -415,7 +424,7 @@ public class PublishDateUpdater {
          * @return true if the contentlet was processed, false if it was skipped
          * @throws Exception if processing fails
          */
-        void process(Contentlet contentlet, User systemUser) throws Exception;
+        boolean process(Contentlet contentlet, User systemUser) throws Exception;
 
         /**
          * Get the name of this operation for logging purposes.
@@ -436,7 +445,8 @@ public class PublishDateUpdater {
      * @param processor The content processor that provides operation logic and name
      * @return The number of contentlets actually processed (not skipped)
      */
-    private static int processContentInBatch(final String luceneQuery,
+    @VisibleForTesting
+    static int processContentInBatch(final String luceneQuery,
                                                    final int searchBatchSize,
                                                    final int transactionBatchSize,
                                                    final ContentProcessor processor) throws DotDataException {
@@ -462,7 +472,8 @@ public class PublishDateUpdater {
                             allInodes.size(), searchBatchSize, transactionBatchSize, operationName));
 
             int totalProcessed = 0;
-            int transactionProcessed = 0;
+            int totalVisited = 0;
+            int transactionVisited = 0;
             boolean transactionStarted;
             int currentIndex = 0;
 
@@ -482,6 +493,8 @@ public class PublishDateUpdater {
 
                 // Process each identifier in the current batch
                 for (final String inode : inodes) {
+                    totalVisited++;
+                    transactionVisited++;
                     try {
                         // Fetch fresh contentlet by inode
                         final Contentlet contentlet = contentletAPI.find(inode, systemUser, false);
@@ -489,32 +502,32 @@ public class PublishDateUpdater {
                         if (contentlet == null) {
                             Logger.warn(PublishDateUpdater.class,
                                     String.format("Contentlet with inode %s not found, skipping %s operation", inode, operationName));
-                            continue;
-                        }
-
-                        // Delegate to the processor function
-                        processor.process(contentlet, systemUser);
-                        totalProcessed++;
-                        transactionProcessed++;
-
-                        // Commit every transactionBatchSize processed records
-                        if (transactionProcessed >= transactionBatchSize) {
-                            Logger.debug(PublishDateUpdater.class,
-                                    String.format("Committing transaction after processing %d contentlets (total: %d) for %s",
-                                            transactionProcessed, totalProcessed, operationName));
-                            HibernateUtil.closeAndCommitTransaction();
-                            transactionStarted = false;
-                            transactionProcessed = 0;
-
-                            // Start new transaction if there are more records to process
-                            if (currentIndex + searchBatchSize < allInodes.size()) {
-                                HibernateUtil.startTransaction();
-                                transactionStarted = true;
+                        } else {
+                            // Delegate to the processor function
+                            final boolean processed = processor.process(contentlet, systemUser);
+                            if (processed) {
+                                totalProcessed++;
                             }
                         }
                     } catch (Exception e) {
                         Logger.error(PublishDateUpdater.class,
                                 String.format("Content failed to %s: %s - %s", operationName, inode, e.getMessage()), e);
+                    }
+
+                    // Commit every transactionBatchSize visited records, including failed or missing contentlets
+                    if (transactionVisited >= transactionBatchSize) {
+                        Logger.debug(PublishDateUpdater.class,
+                                String.format("Committing transaction after visiting %d contentlets (processed: %d) for %s",
+                                        transactionVisited, totalProcessed, operationName));
+                        HibernateUtil.closeAndCommitTransaction();
+                        transactionStarted = false;
+                        transactionVisited = 0;
+
+                        // Start new transaction if there are more records to visit
+                        if (totalVisited < allInodes.size()) {
+                            HibernateUtil.startTransaction();
+                            transactionStarted = true;
+                        }
                     }
                 }
 
@@ -522,9 +535,10 @@ public class PublishDateUpdater {
             }
 
             // Commit any remaining records
-            if (transactionStarted && transactionProcessed > 0) {
+            if (transactionStarted && transactionVisited > 0) {
                 Logger.debug(PublishDateUpdater.class,
-                        String.format("Committing final transaction with %d remaining contentlets for %s", transactionProcessed, operationName));
+                        String.format("Committing final transaction after visiting %d remaining contentlets for %s",
+                                transactionVisited, operationName));
                 HibernateUtil.closeAndCommitTransaction();
             }
 
@@ -547,25 +561,50 @@ public class PublishDateUpdater {
     /**
      * Content processor implementation for publish operations.
      */
-    private static class Publisher implements ContentProcessor {
+    static class Publisher implements ContentProcessor {
         private final boolean forcePublishing;
         private final Date previousJobRunTime;
+        private final ContentletAPI contentletAPI;
+        private final WorkflowAPI workflowAPI;
 
         public Publisher(final boolean forcePublishing, final Date previousJobRunTime) {
             this.forcePublishing = forcePublishing;
             this.previousJobRunTime = previousJobRunTime;
+            this.contentletAPI = APILocator.getContentletAPI();
+            this.workflowAPI = APILocator.getWorkflowAPI();
+        }
+
+        /**
+         * Creates a publisher with explicit dependencies for unit testing. The force-publishing
+         * setting ensures tests target the workflow gate instead of the date-window guard.
+         *
+         * @param contentletAPI content API used to publish content
+         * @param workflowAPI workflow API used to inspect the current step
+         */
+        @VisibleForTesting
+        Publisher(final ContentletAPI contentletAPI, final WorkflowAPI workflowAPI) {
+            this.forcePublishing = true;
+            this.previousJobRunTime = null;
+            this.contentletAPI = contentletAPI;
+            this.workflowAPI = workflowAPI;
         }
 
         @Override
-        public void process(final Contentlet contentlet, final User systemUser) throws Exception {
+        public boolean process(final Contentlet contentlet, final User systemUser) throws Exception {
+            if (!workflowAllowsScheduledPublish(contentlet, workflowAPI)) {
+                return false;
+            }
+
             //This Point is where we decide if the content should get published or skipped
             //But We can always force the publish operation though
             if (forcePublishing || shouldPublishContent(contentlet, previousJobRunTime)) {
                 contentletAPI.publish(contentlet, systemUser, false);
+                return true;
             } else {
                 Logger.debug(PublishDateUpdater.class,
                         "Skipping publish for contentlet " + contentlet.getIdentifier() +
                         " - content was already auto-published and manually unpublished");
+                return false;
             }
         }
 
@@ -578,16 +617,106 @@ public class PublishDateUpdater {
     /**
      * Content processor implementation for unpublish operations.
      */
-    private static class Unpublisher implements ContentProcessor {
+    static class Unpublisher implements ContentProcessor {
+
+        private final ContentletAPI contentletAPI;
+
+        public Unpublisher() {
+            this.contentletAPI = APILocator.getContentletAPI();
+        }
+
+        /**
+         * Creates an unpublisher with an explicit content API for unit testing.
+         *
+         * @param contentletAPI content API used to unpublish content
+         */
+        @VisibleForTesting
+        Unpublisher(final ContentletAPI contentletAPI) {
+            this.contentletAPI = contentletAPI;
+        }
+
         @Override
-        public void process(final Contentlet contentlet, final User systemUser) throws Exception {
+        public boolean process(final Contentlet contentlet, final User systemUser) throws Exception {
             contentletAPI.unpublish(contentlet, systemUser, false);
+            return true;
         }
 
         @Override
         public String getOperationName() {
             return "unpublish";
         }
+    }
+
+    /**
+     * Determines whether the scheduled local publisher may publish the content. When the feature
+     * flag is disabled, workflow state is not queried and historical behavior is preserved. When
+     * enabled, publication requires an explicitly resolved current workflow step. An optional list
+     * of workflow scheme IDs or variable names limits the check to selected workflows; an empty
+     * list applies it globally. Workflow lookup failures are propagated so the batch processor holds
+     * the affected content and continues with the remaining queue.
+     *
+     * @param contentlet content selected by the scheduled publishing job
+     * @param workflowAPI workflow API used to inspect the current step
+     * @return {@code true} when scheduled publication is allowed
+     * @throws DotDataException when the current workflow state cannot be read
+     * @throws DotSecurityException when the current workflow scheme cannot be read
+     */
+    @VisibleForTesting
+    static boolean workflowAllowsScheduledPublish(final Contentlet contentlet,
+            final WorkflowAPI workflowAPI) throws DotDataException, DotSecurityException {
+        if (!Config.getBooleanProperty(RESPECT_WORKFLOW_RESOLUTION_PROPERTY, false)) {
+            return true;
+        }
+
+        final Optional<WorkflowStep> currentStep = workflowAPI.findCurrentStep(contentlet);
+        final Set<String> configuredSchemes = configuredWorkflowSchemes();
+        if (!configuredSchemes.isEmpty()
+                && !matchesConfiguredWorkflow(contentlet, currentStep, configuredSchemes,
+                        workflowAPI)) {
+            return true;
+        }
+
+        final boolean resolved = currentStep.map(WorkflowStep::isResolved).orElse(false);
+        if (!resolved) {
+            Logger.warn(PublishDateUpdater.class, String.format(
+                    "Skipping scheduled publish for contentlet %s: current workflow step %s is not resolved",
+                    contentlet.getIdentifier(),
+                    currentStep.map(WorkflowStep::getId).orElse("not found")));
+        }
+        return resolved;
+    }
+
+    private static Set<String> configuredWorkflowSchemes() {
+        return Arrays.stream(Config.getStringProperty(WORKFLOW_RESOLUTION_SCHEMES_PROPERTY, "")
+                        .split(","))
+                .map(String::trim)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toSet());
+    }
+
+    private static boolean matchesConfiguredWorkflow(final Contentlet contentlet,
+            final Optional<WorkflowStep> currentStep, final Set<String> configuredSchemes,
+            final WorkflowAPI workflowAPI) throws DotDataException, DotSecurityException {
+        if (currentStep.isPresent()) {
+            final String schemeId = currentStep.get().getSchemeId();
+            if (!UtilMethods.isSet(schemeId)) {
+                throw new DotDataException("Current workflow step does not reference a workflow scheme");
+            }
+
+            if (configuredSchemes.contains(schemeId)) {
+                return true;
+            }
+            return matchesConfiguredScheme(workflowAPI.findScheme(schemeId), configuredSchemes);
+        }
+
+        return workflowAPI.findSchemesForContentType(contentlet.getContentType()).stream()
+                .anyMatch(scheme -> matchesConfiguredScheme(scheme, configuredSchemes));
+    }
+
+    private static boolean matchesConfiguredScheme(final WorkflowScheme scheme,
+            final Set<String> configuredSchemes) {
+        return scheme != null && (configuredSchemes.contains(scheme.getId())
+                || configuredSchemes.contains(scheme.getVariableName()));
     }
 
     /**

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -722,6 +722,15 @@ json.web.token.max.allowed.expiration.days=3560
 #    for the push to work correctly as this role will always be present in any end-point.
 HEADLESS_USER_CONTENT_DELIVERY=true
 
+# When true, PublishDateUpdater only performs scheduled local publication when the content's
+# current workflow step is resolved. Direct workflow publication, scheduled expire/unpublish,
+# and push publishing are not affected.
+PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION=false
+
+# Optional comma-separated workflow scheme IDs or variable names. When empty, the workflow
+# resolution check applies to all workflows. When set, it applies only to the listed workflows.
+PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION_SCHEMES=
+
 # If the vanity url doesnt exist in the current language the it will try to get it using
 # the default language bef
 DEFAULT_VANITY_URL_TO_DEFAULT_LANGUAGE=true

--- a/dotCMS/src/test/java/com/dotcms/enterprise/publishing/PublishDateUpdaterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/enterprise/publishing/PublishDateUpdaterTest.java
@@ -1,0 +1,257 @@
+package com.dotcms.enterprise.publishing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.UserAPI;
+import com.dotmarketing.common.model.ContentletSearch;
+import com.dotmarketing.db.HibernateUtil;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
+import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
+import com.dotmarketing.portlets.workflows.model.WorkflowStep;
+import com.dotmarketing.util.Config;
+import com.liferay.portal.model.User;
+import java.util.List;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class PublishDateUpdaterTest {
+
+    private static final String FLAG_KEY = "PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION";
+    private static final String SCHEMES_KEY =
+            "PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION_SCHEMES";
+    private static final String CONTENTLET_IDENTIFIER = "contentlet-id";
+    private static final String WORKFLOW_SCHEME_ID = "workflow-scheme-id";
+
+    private ContentletAPI contentletAPI;
+    private WorkflowAPI workflowAPI;
+    private Contentlet contentlet;
+    private User systemUser;
+    private PublishDateUpdater.Publisher publisher;
+    private MockedStatic<Config> configMock;
+
+    @Before
+    public void setUp() {
+        contentletAPI = mock(ContentletAPI.class);
+        workflowAPI = mock(WorkflowAPI.class);
+        contentlet = mock(Contentlet.class);
+        systemUser = mock(User.class);
+        publisher = new PublishDateUpdater.Publisher(contentletAPI, workflowAPI);
+        when(contentlet.getIdentifier()).thenReturn(CONTENTLET_IDENTIFIER);
+
+        configMock = mockStatic(Config.class);
+        configMock.when(() -> Config.getBooleanProperty(eq(FLAG_KEY), anyBoolean()))
+                .thenReturn(false);
+        configMock.when(() -> Config.getStringProperty(eq(SCHEMES_KEY), eq("")))
+                .thenReturn("");
+    }
+
+    @After
+    public void tearDown() {
+        configMock.close();
+    }
+
+    @Test
+    public void publisherPreservesHistoricalBehaviorWhenFlagIsDisabled() throws Exception {
+        when(workflowAPI.findCurrentStep(contentlet))
+                .thenThrow(new DotDataException("workflow must not be queried"));
+
+        assertTrue(publisher.process(contentlet, systemUser));
+
+        verify(workflowAPI, never()).findCurrentStep(contentlet);
+        verify(contentletAPI).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherBlocksForcedScheduledPublishAtUnresolvedStep() throws Exception {
+        enableWorkflowResolutionCheck();
+        when(workflowAPI.findCurrentStep(contentlet))
+                .thenReturn(Optional.of(step("review", false)));
+
+        assertFalse(publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI, never()).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherAllowsScheduledPublishAtResolvedStep() throws Exception {
+        enableWorkflowResolutionCheck();
+        when(workflowAPI.findCurrentStep(contentlet))
+                .thenReturn(Optional.of(step("approved", true)));
+
+        assertTrue(publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherBlocksScheduledPublishWithoutCurrentStep() throws Exception {
+        enableWorkflowResolutionCheck();
+        when(workflowAPI.findCurrentStep(contentlet)).thenReturn(Optional.empty());
+
+        assertFalse(publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI, never()).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherBlocksUnresolvedStepForConfiguredWorkflowVariable() throws Exception {
+        enableWorkflowResolutionCheck();
+        configureWorkflowSchemes("otherWorkflow, targetWorkflow");
+        when(workflowAPI.findCurrentStep(contentlet))
+                .thenReturn(Optional.of(step("review", WORKFLOW_SCHEME_ID, false)));
+        when(workflowAPI.findScheme(WORKFLOW_SCHEME_ID))
+                .thenReturn(scheme(WORKFLOW_SCHEME_ID, "targetWorkflow"));
+
+        assertFalse(publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI, never()).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherPreservesScheduledPublishForWorkflowOutsideConfiguredList()
+            throws Exception {
+        enableWorkflowResolutionCheck();
+        configureWorkflowSchemes("targetWorkflow");
+        when(workflowAPI.findCurrentStep(contentlet))
+                .thenReturn(Optional.of(step("review", WORKFLOW_SCHEME_ID, false)));
+        when(workflowAPI.findScheme(WORKFLOW_SCHEME_ID))
+                .thenReturn(scheme(WORKFLOW_SCHEME_ID, "differentWorkflow"));
+
+        assertTrue(publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherBlocksContentWithoutStepWhenConfiguredWorkflowIsAssigned()
+            throws Exception {
+        enableWorkflowResolutionCheck();
+        configureWorkflowSchemes("targetWorkflow");
+        final ContentType contentType = mock(ContentType.class);
+        when(contentlet.getContentType()).thenReturn(contentType);
+        when(workflowAPI.findCurrentStep(contentlet)).thenReturn(Optional.empty());
+        when(workflowAPI.findSchemesForContentType(contentType))
+                .thenReturn(List.of(scheme(WORKFLOW_SCHEME_ID, "targetWorkflow")));
+
+        assertFalse(publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI, never()).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherAllowsContentWithoutStepWhenConfiguredWorkflowIsNotAssigned()
+            throws Exception {
+        enableWorkflowResolutionCheck();
+        configureWorkflowSchemes("targetWorkflow");
+        final ContentType contentType = mock(ContentType.class);
+        when(contentlet.getContentType()).thenReturn(contentType);
+        when(workflowAPI.findCurrentStep(contentlet)).thenReturn(Optional.empty());
+        when(workflowAPI.findSchemesForContentType(contentType))
+                .thenReturn(List.of(scheme(WORKFLOW_SCHEME_ID, "differentWorkflow")));
+
+        assertTrue(publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void publisherFailsClosedWhenWorkflowLookupFails() throws Exception {
+        enableWorkflowResolutionCheck();
+        when(workflowAPI.findCurrentStep(contentlet))
+                .thenThrow(new DotDataException("workflow unavailable"));
+
+        assertThrows(DotDataException.class, () -> publisher.process(contentlet, systemUser));
+
+        verify(contentletAPI, never()).publish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void unpublisherIsNotBlockedWhenWorkflowResolutionFlagIsEnabled() throws Exception {
+        enableWorkflowResolutionCheck();
+        final PublishDateUpdater.Unpublisher unpublisher =
+                new PublishDateUpdater.Unpublisher(contentletAPI);
+
+        assertTrue(unpublisher.process(contentlet, systemUser));
+
+        verify(contentletAPI).unpublish(contentlet, systemUser, false);
+    }
+
+    @Test
+    public void batchClosesTransactionWhenProcessorFails() throws Exception {
+        final UserAPI userAPI = mock(UserAPI.class);
+        final ContentletSearch searchResult = mock(ContentletSearch.class);
+        final PublishDateUpdater.ContentProcessor processor =
+                mock(PublishDateUpdater.ContentProcessor.class);
+        when(userAPI.getSystemUser()).thenReturn(systemUser);
+        when(searchResult.getInode()).thenReturn("failed-inode");
+        when(contentletAPI.searchIndex(anyString(), anyInt(), anyInt(), isNull(),
+                eq(systemUser), eq(false))).thenReturn(List.of(searchResult));
+        when(contentletAPI.find("failed-inode", systemUser, false)).thenReturn(contentlet);
+        when(processor.getOperationName()).thenReturn("publish");
+        when(processor.process(contentlet, systemUser))
+                .thenThrow(new DotDataException("workflow unavailable"));
+
+        try (MockedStatic<APILocator> apiLocatorMock = mockStatic(APILocator.class);
+                MockedStatic<HibernateUtil> hibernateMock = mockStatic(HibernateUtil.class)) {
+            apiLocatorMock.when(APILocator::getUserAPI).thenReturn(userAPI);
+            apiLocatorMock.when(APILocator::getContentletAPI).thenReturn(contentletAPI);
+
+            assertEquals(0, PublishDateUpdater.processContentInBatch(
+                    "query", 1, 10, processor));
+
+            hibernateMock.verify(HibernateUtil::startTransaction, times(1));
+            hibernateMock.verify(HibernateUtil::closeAndCommitTransaction, times(1));
+        }
+    }
+
+    private void enableWorkflowResolutionCheck() {
+        configMock.when(() -> Config.getBooleanProperty(eq(FLAG_KEY), anyBoolean()))
+                .thenReturn(true);
+    }
+
+    private void configureWorkflowSchemes(final String schemes) {
+        configMock.when(() -> Config.getStringProperty(eq(SCHEMES_KEY), eq("")))
+                .thenReturn(schemes);
+    }
+
+    private WorkflowStep step(final String id, final boolean resolved) {
+        return step(id, WORKFLOW_SCHEME_ID, resolved);
+    }
+
+    private WorkflowStep step(final String id, final String schemeId, final boolean resolved) {
+        final WorkflowStep step = new WorkflowStep();
+        step.setId(id);
+        step.setSchemeId(schemeId);
+        step.setResolved(resolved);
+        return step;
+    }
+
+    private WorkflowScheme scheme(final String id, final String variableName) {
+        final WorkflowScheme scheme = new WorkflowScheme();
+        scheme.setId(id);
+        scheme.setVariableName(variableName);
+        return scheme;
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/enterprise/publishing/PublishDateUpdaterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/enterprise/publishing/PublishDateUpdaterTest.java
@@ -14,9 +14,11 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.enterprise.publishing.PublishDateUpdater.WorkflowResolutionConfig;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.UserAPI;
 import com.dotmarketing.common.model.ContentletSearch;
@@ -29,9 +31,11 @@ import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
 import com.dotmarketing.portlets.workflows.model.WorkflowStep;
 import com.dotmarketing.util.Config;
 import com.liferay.portal.model.User;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import org.junit.After;
+import java.util.Set;
+import java.util.TimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
@@ -43,13 +47,13 @@ public class PublishDateUpdaterTest {
             "PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION_SCHEMES";
     private static final String CONTENTLET_IDENTIFIER = "contentlet-id";
     private static final String WORKFLOW_SCHEME_ID = "workflow-scheme-id";
+    private static final Date FIRE_TIME = new Date(1700000000000L);
+    private static final List<String> CONTENT_TYPES = List.of("calendarEvent");
 
     private ContentletAPI contentletAPI;
     private WorkflowAPI workflowAPI;
     private Contentlet contentlet;
     private User systemUser;
-    private PublishDateUpdater.Publisher publisher;
-    private MockedStatic<Config> configMock;
 
     @Before
     public void setUp() {
@@ -57,19 +61,7 @@ public class PublishDateUpdaterTest {
         workflowAPI = mock(WorkflowAPI.class);
         contentlet = mock(Contentlet.class);
         systemUser = mock(User.class);
-        publisher = new PublishDateUpdater.Publisher(contentletAPI, workflowAPI);
         when(contentlet.getIdentifier()).thenReturn(CONTENTLET_IDENTIFIER);
-
-        configMock = mockStatic(Config.class);
-        configMock.when(() -> Config.getBooleanProperty(eq(FLAG_KEY), anyBoolean()))
-                .thenReturn(false);
-        configMock.when(() -> Config.getStringProperty(eq(SCHEMES_KEY), eq("")))
-                .thenReturn("");
-    }
-
-    @After
-    public void tearDown() {
-        configMock.close();
     }
 
     @Test
@@ -77,7 +69,7 @@ public class PublishDateUpdaterTest {
         when(workflowAPI.findCurrentStep(contentlet))
                 .thenThrow(new DotDataException("workflow must not be queried"));
 
-        assertTrue(publisher.process(contentlet, systemUser));
+        assertTrue(publisher(disabled()).process(contentlet, systemUser));
 
         verify(workflowAPI, never()).findCurrentStep(contentlet);
         verify(contentletAPI).publish(contentlet, systemUser, false);
@@ -85,46 +77,43 @@ public class PublishDateUpdaterTest {
 
     @Test
     public void publisherBlocksForcedScheduledPublishAtUnresolvedStep() throws Exception {
-        enableWorkflowResolutionCheck();
         when(workflowAPI.findCurrentStep(contentlet))
                 .thenReturn(Optional.of(step("review", false)));
 
-        assertFalse(publisher.process(contentlet, systemUser));
+        assertFalse(publisher(global()).process(contentlet, systemUser));
 
         verify(contentletAPI, never()).publish(contentlet, systemUser, false);
     }
 
     @Test
     public void publisherAllowsScheduledPublishAtResolvedStep() throws Exception {
-        enableWorkflowResolutionCheck();
         when(workflowAPI.findCurrentStep(contentlet))
                 .thenReturn(Optional.of(step("approved", true)));
 
-        assertTrue(publisher.process(contentlet, systemUser));
+        assertTrue(publisher(global()).process(contentlet, systemUser));
 
+        verify(workflowAPI).findCurrentStep(contentlet);
         verify(contentletAPI).publish(contentlet, systemUser, false);
     }
 
     @Test
     public void publisherBlocksScheduledPublishWithoutCurrentStep() throws Exception {
-        enableWorkflowResolutionCheck();
         when(workflowAPI.findCurrentStep(contentlet)).thenReturn(Optional.empty());
 
-        assertFalse(publisher.process(contentlet, systemUser));
+        assertFalse(publisher(global()).process(contentlet, systemUser));
 
         verify(contentletAPI, never()).publish(contentlet, systemUser, false);
     }
 
     @Test
     public void publisherBlocksUnresolvedStepForConfiguredWorkflowVariable() throws Exception {
-        enableWorkflowResolutionCheck();
-        configureWorkflowSchemes("otherWorkflow, targetWorkflow");
         when(workflowAPI.findCurrentStep(contentlet))
                 .thenReturn(Optional.of(step("review", WORKFLOW_SCHEME_ID, false)));
         when(workflowAPI.findScheme(WORKFLOW_SCHEME_ID))
                 .thenReturn(scheme(WORKFLOW_SCHEME_ID, "targetWorkflow"));
 
-        assertFalse(publisher.process(contentlet, systemUser));
+        assertFalse(publisher(scoped("otherWorkflow", "targetWorkflow"))
+                .process(contentlet, systemUser));
 
         verify(contentletAPI, never()).publish(contentlet, systemUser, false);
     }
@@ -132,14 +121,12 @@ public class PublishDateUpdaterTest {
     @Test
     public void publisherPreservesScheduledPublishForWorkflowOutsideConfiguredList()
             throws Exception {
-        enableWorkflowResolutionCheck();
-        configureWorkflowSchemes("targetWorkflow");
         when(workflowAPI.findCurrentStep(contentlet))
                 .thenReturn(Optional.of(step("review", WORKFLOW_SCHEME_ID, false)));
         when(workflowAPI.findScheme(WORKFLOW_SCHEME_ID))
                 .thenReturn(scheme(WORKFLOW_SCHEME_ID, "differentWorkflow"));
 
-        assertTrue(publisher.process(contentlet, systemUser));
+        assertTrue(publisher(scoped("targetWorkflow")).process(contentlet, systemUser));
 
         verify(contentletAPI).publish(contentlet, systemUser, false);
     }
@@ -147,15 +134,13 @@ public class PublishDateUpdaterTest {
     @Test
     public void publisherBlocksContentWithoutStepWhenConfiguredWorkflowIsAssigned()
             throws Exception {
-        enableWorkflowResolutionCheck();
-        configureWorkflowSchemes("targetWorkflow");
         final ContentType contentType = mock(ContentType.class);
         when(contentlet.getContentType()).thenReturn(contentType);
         when(workflowAPI.findCurrentStep(contentlet)).thenReturn(Optional.empty());
         when(workflowAPI.findSchemesForContentType(contentType))
                 .thenReturn(List.of(scheme(WORKFLOW_SCHEME_ID, "targetWorkflow")));
 
-        assertFalse(publisher.process(contentlet, systemUser));
+        assertFalse(publisher(scoped("targetWorkflow")).process(contentlet, systemUser));
 
         verify(contentletAPI, never()).publish(contentlet, systemUser, false);
     }
@@ -163,51 +148,166 @@ public class PublishDateUpdaterTest {
     @Test
     public void publisherAllowsContentWithoutStepWhenConfiguredWorkflowIsNotAssigned()
             throws Exception {
-        enableWorkflowResolutionCheck();
-        configureWorkflowSchemes("targetWorkflow");
         final ContentType contentType = mock(ContentType.class);
         when(contentlet.getContentType()).thenReturn(contentType);
         when(workflowAPI.findCurrentStep(contentlet)).thenReturn(Optional.empty());
         when(workflowAPI.findSchemesForContentType(contentType))
                 .thenReturn(List.of(scheme(WORKFLOW_SCHEME_ID, "differentWorkflow")));
 
-        assertTrue(publisher.process(contentlet, systemUser));
+        assertTrue(publisher(scoped("targetWorkflow")).process(contentlet, systemUser));
 
         verify(contentletAPI).publish(contentlet, systemUser, false);
     }
 
     @Test
     public void publisherFailsClosedWhenWorkflowLookupFails() throws Exception {
-        enableWorkflowResolutionCheck();
         when(workflowAPI.findCurrentStep(contentlet))
                 .thenThrow(new DotDataException("workflow unavailable"));
 
-        assertThrows(DotDataException.class, () -> publisher.process(contentlet, systemUser));
+        assertThrows(DotDataException.class,
+                () -> publisher(global()).process(contentlet, systemUser));
 
         verify(contentletAPI, never()).publish(contentlet, systemUser, false);
     }
 
     @Test
     public void unpublisherIsNotBlockedWhenWorkflowResolutionFlagIsEnabled() throws Exception {
-        enableWorkflowResolutionCheck();
         final PublishDateUpdater.Unpublisher unpublisher =
                 new PublishDateUpdater.Unpublisher(contentletAPI);
 
         assertTrue(unpublisher.process(contentlet, systemUser));
 
         verify(contentletAPI).unpublish(contentlet, systemUser, false);
+        verifyNoInteractions(workflowAPI);
+    }
+
+    @Test
+    public void workflowResolutionConfigIsReadOncePerJobRunAndNotPerContentlet() throws Exception {
+        final WorkflowResolutionConfig config;
+        try (MockedStatic<Config> configMock = mockStatic(Config.class)) {
+            configMock.when(() -> Config.getBooleanProperty(eq(FLAG_KEY), anyBoolean()))
+                    .thenReturn(true);
+            configMock.when(() -> Config.getStringProperty(eq(SCHEMES_KEY), eq("")))
+                    .thenReturn(" targetWorkflow ,, ");
+
+            config = WorkflowResolutionConfig.fromConfig();
+
+            assertTrue(config.respectWorkflowResolution());
+            assertEquals(Set.of("targetWorkflow"), config.configuredSchemes());
+            configMock.verify(() -> Config.getBooleanProperty(eq(FLAG_KEY), anyBoolean()),
+                    times(1));
+            configMock.verify(() -> Config.getStringProperty(eq(SCHEMES_KEY), eq("")), times(1));
+
+            when(workflowAPI.findCurrentStep(contentlet))
+                    .thenReturn(Optional.of(step("approved", true)));
+            when(workflowAPI.findScheme(WORKFLOW_SCHEME_ID))
+                    .thenReturn(scheme(WORKFLOW_SCHEME_ID, "targetWorkflow"));
+            final PublishDateUpdater.Publisher publisher = publisher(config);
+            assertTrue(publisher.process(contentlet, systemUser));
+            assertTrue(publisher.process(contentlet, systemUser));
+
+            configMock.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void publishQueryIsUnchangedAndAvoidsWorkflowLookupsWhenFlagIsDisabled() {
+        final String query = publishQuery(disabled());
+
+        assertEquals(basePublishQuery(), query);
+        verifyNoInteractions(workflowAPI);
+    }
+
+    @Test
+    public void publishQueryRestrictsGlobalModeToResolvedSteps() throws Exception {
+        final WorkflowScheme workflowScheme = scheme(WORKFLOW_SCHEME_ID, "targetWorkflow");
+        when(workflowAPI.findSchemes(false)).thenReturn(List.of(workflowScheme));
+        when(workflowAPI.findSteps(workflowScheme)).thenReturn(List.of(
+                step("published-step", true),
+                step("review-step", false),
+                step("archived-step", true)));
+
+        final String query = publishQuery(global());
+
+        assertTrue(query.startsWith(basePublishQuery()));
+        assertTrue(query.contains(" +(wfstep:published-step wfstep:archived-step )"));
+        assertFalse(query.contains("review-step"));
+    }
+
+    @Test
+    public void publishQueryMatchesNoContentWhenNoResolvedStepExists() throws Exception {
+        final WorkflowScheme workflowScheme = scheme(WORKFLOW_SCHEME_ID, "targetWorkflow");
+        when(workflowAPI.findSchemes(false)).thenReturn(List.of(workflowScheme));
+        when(workflowAPI.findSteps(workflowScheme))
+                .thenReturn(List.of(step("review-step", false)));
+
+        final String query = publishQuery(global());
+
+        assertTrue(query.contains(" +(wfstep:no_resolved_workflow_step )"));
+        assertFalse(query.contains("review-step"));
+    }
+
+    @Test
+    public void publishQueryExcludesOnlyUnresolvedConfiguredStepsInScopedMode() throws Exception {
+        final WorkflowScheme workflowScheme = scheme(WORKFLOW_SCHEME_ID, "targetWorkflow");
+        when(workflowAPI.findScheme("targetWorkflow")).thenReturn(workflowScheme);
+        when(workflowAPI.findSteps(workflowScheme)).thenReturn(List.of(
+                step("scoped-open-step", false),
+                step("scoped-done-step", true)));
+
+        final String query = publishQuery(scoped("targetWorkflow"));
+
+        assertTrue(query.startsWith(basePublishQuery()));
+        assertTrue(query.contains(" -(wfstep:scoped-open-step )"));
+        assertFalse(query.contains("scoped-done-step"));
+        // No positive wfstep clause: content without a step and content on unconfigured
+        // workflows stay candidates and are decided by the Java gate
+        assertFalse(query.contains("+(wfstep"));
+        verify(workflowAPI, never()).findSchemes(anyBoolean());
+    }
+
+    @Test
+    public void publishQueryStaysUnfilteredWhenConfiguredSchemesHaveNoUnresolvedSteps()
+            throws Exception {
+        final WorkflowScheme workflowScheme = scheme(WORKFLOW_SCHEME_ID, "targetWorkflow");
+        when(workflowAPI.findScheme("targetWorkflow")).thenReturn(workflowScheme);
+        when(workflowAPI.findSteps(workflowScheme))
+                .thenReturn(List.of(step("scoped-done-step", true)));
+
+        assertEquals(basePublishQuery(), publishQuery(scoped("targetWorkflow")));
+    }
+
+    @Test
+    public void publishQueryFallsBackToUnfilteredQueryWhenWorkflowLookupFails() throws Exception {
+        when(workflowAPI.findSchemes(false))
+                .thenThrow(new DotDataException("workflow unavailable"));
+
+        assertEquals(basePublishQuery(), publishQuery(global()));
+    }
+
+    @Test
+    public void expireQueryNeverContainsWorkflowStepFilter() {
+        final String query;
+        try (MockedStatic<APILocator> apiLocatorMock = mockStatic(APILocator.class)) {
+            apiLocatorMock.when(APILocator::systemTimeZone)
+                    .thenReturn(TimeZone.getTimeZone("UTC"));
+            query = PublishDateUpdater.getExpireLuceneQuery(FIRE_TIME);
+        }
+
+        assertTrue(query.contains("+live:true"));
+        assertFalse(query.contains("wfstep"));
+        verifyNoInteractions(workflowAPI);
     }
 
     @Test
     public void batchClosesTransactionWhenProcessorFails() throws Exception {
         final UserAPI userAPI = mock(UserAPI.class);
-        final ContentletSearch searchResult = mock(ContentletSearch.class);
         final PublishDateUpdater.ContentProcessor processor =
                 mock(PublishDateUpdater.ContentProcessor.class);
+        final ContentletSearch failedSearchResult = searchResult("failed-inode");
         when(userAPI.getSystemUser()).thenReturn(systemUser);
-        when(searchResult.getInode()).thenReturn("failed-inode");
         when(contentletAPI.searchIndex(anyString(), anyInt(), anyInt(), isNull(),
-                eq(systemUser), eq(false))).thenReturn(List.of(searchResult));
+                eq(systemUser), eq(false))).thenReturn(List.of(failedSearchResult));
         when(contentletAPI.find("failed-inode", systemUser, false)).thenReturn(contentlet);
         when(processor.getOperationName()).thenReturn("publish");
         when(processor.process(contentlet, systemUser))
@@ -226,14 +326,85 @@ public class PublishDateUpdaterTest {
         }
     }
 
-    private void enableWorkflowResolutionCheck() {
-        configMock.when(() -> Config.getBooleanProperty(eq(FLAG_KEY), anyBoolean()))
-                .thenReturn(true);
+    @Test
+    public void batchCommitsAtIntermediateThresholdAndProcessesRemainingQueueAfterFailure()
+            throws Exception {
+        final UserAPI userAPI = mock(UserAPI.class);
+        final PublishDateUpdater.ContentProcessor processor =
+                mock(PublishDateUpdater.ContentProcessor.class);
+        final Contentlet failing = mock(Contentlet.class);
+        final Contentlet second = mock(Contentlet.class);
+        final Contentlet third = mock(Contentlet.class);
+        final List<ContentletSearch> searchResults = List.of(searchResult("failing-inode"),
+                searchResult("second-inode"), searchResult("third-inode"));
+        when(userAPI.getSystemUser()).thenReturn(systemUser);
+        when(contentletAPI.searchIndex(anyString(), anyInt(), anyInt(), isNull(),
+                eq(systemUser), eq(false))).thenReturn(searchResults);
+        when(contentletAPI.find("failing-inode", systemUser, false)).thenReturn(failing);
+        when(contentletAPI.find("second-inode", systemUser, false)).thenReturn(second);
+        when(contentletAPI.find("third-inode", systemUser, false)).thenReturn(third);
+        when(processor.getOperationName()).thenReturn("publish");
+        when(processor.process(failing, systemUser))
+                .thenThrow(new DotDataException("workflow unavailable"));
+        when(processor.process(second, systemUser)).thenReturn(true);
+        when(processor.process(third, systemUser)).thenReturn(true);
+
+        try (MockedStatic<APILocator> apiLocatorMock = mockStatic(APILocator.class);
+                MockedStatic<HibernateUtil> hibernateMock = mockStatic(HibernateUtil.class)) {
+            apiLocatorMock.when(APILocator::getUserAPI).thenReturn(userAPI);
+            apiLocatorMock.when(APILocator::getContentletAPI).thenReturn(contentletAPI);
+
+            // Three visited inodes with a transaction batch of two: the failed first inode still
+            // counts as visited, so the intermediate commit happens exactly at the threshold, a
+            // new transaction covers the remaining queue and the final commit closes it
+            assertEquals(2, PublishDateUpdater.processContentInBatch(
+                    "query", 10, 2, processor));
+
+            hibernateMock.verify(HibernateUtil::startTransaction, times(2));
+            hibernateMock.verify(HibernateUtil::closeAndCommitTransaction, times(2));
+        }
+
+        verify(processor).process(second, systemUser);
+        verify(processor).process(third, systemUser);
     }
 
-    private void configureWorkflowSchemes(final String schemes) {
-        configMock.when(() -> Config.getStringProperty(eq(SCHEMES_KEY), eq("")))
-                .thenReturn(schemes);
+    private PublishDateUpdater.Publisher publisher(final WorkflowResolutionConfig config) {
+        return new PublishDateUpdater.Publisher(contentletAPI, workflowAPI, config);
+    }
+
+    private static WorkflowResolutionConfig disabled() {
+        return new WorkflowResolutionConfig(false, Set.of());
+    }
+
+    private static WorkflowResolutionConfig global() {
+        return new WorkflowResolutionConfig(true, Set.of());
+    }
+
+    private static WorkflowResolutionConfig scoped(final String... schemes) {
+        return new WorkflowResolutionConfig(true, Set.of(schemes));
+    }
+
+    private String publishQuery(final WorkflowResolutionConfig config) {
+        try (MockedStatic<APILocator> apiLocatorMock = mockStatic(APILocator.class)) {
+            apiLocatorMock.when(APILocator::systemTimeZone)
+                    .thenReturn(TimeZone.getTimeZone("UTC"));
+            return PublishDateUpdater.getPublishLuceneQuery(FIRE_TIME, CONTENT_TYPES, config,
+                    workflowAPI);
+        }
+    }
+
+    private String basePublishQuery() {
+        try (MockedStatic<APILocator> apiLocatorMock = mockStatic(APILocator.class)) {
+            apiLocatorMock.when(APILocator::systemTimeZone)
+                    .thenReturn(TimeZone.getTimeZone("UTC"));
+            return PublishDateUpdater.getPublishLuceneQuery(FIRE_TIME, CONTENT_TYPES);
+        }
+    }
+
+    private ContentletSearch searchResult(final String inode) {
+        final ContentletSearch searchResult = mock(ContentletSearch.class);
+        when(searchResult.getInode()).thenReturn(inode);
+        return searchResult;
     }
 
     private WorkflowStep step(final String id, final boolean resolved) {


### PR DESCRIPTION
### Proposed Changes

- Add the opt-in `PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION` configuration flag, disabled by default.
- When enabled, prevent `PublishDateUpdater` from locally publishing scheduled content unless its current workflow step is resolved.
- Add `PUBLISH_JOB_QUEUE_RESPECT_WORKFLOW_RESOLUTION_SCHEMES` to optionally scope the check to comma-separated workflow scheme IDs or variable names.
  - Empty value: apply the resolution check to all workflows.
  - Configured value: apply it only to the listed workflows.
- Keep immediate publishing, push publishing, and scheduled expiration/unpublishing unchanged.
- Fail closed for each affected content item when its workflow state cannot be determined.
- Ensure failed or missing content items still count toward batch transaction boundaries, so the transaction is always closed.
- Add tests covering:
  - default and explicitly disabled flag behavior;
  - global behavior when the workflow list is empty;
  - resolved and unresolved workflow steps;
  - configured and non-configured workflows;
  - content without a current workflow step;
  - workflow lookup failures;
  - transaction closure after a workflow lookup failure;
  - scheduled expiration remaining unaffected.

### Checklist

- [x] Tests
- [ ] Translations — not applicable
- [x] Security Implications Contemplated

### Additional Info

This change only affects local publishing triggered by `PublishDateUpdater` when a scheduled `publishDate` matures.

The main flag defaults to `false`, preserving the existing dotCMS behavior. When enabled with an empty workflow list, scheduled publishing is allowed only when the content's current workflow step has `resolved=true`. When workflow scheme IDs or variable names are configured, the gate applies only to those workflows.

For content without a current step, the global mode keeps the conservative behavior and blocks scheduled publication. In scoped mode, it blocks only when the content type is assigned to one of the configured workflow schemes.

Immediate workflow publishing and push publishing are not intercepted by this check. Scheduled expiration/unpublishing is also unaffected.

Workflow lookup failures are handled conservatively: the affected content item is not published, processing continues for the remaining items, and the batch transaction is still closed.

Validation performed:

- `PublishDateUpdaterTest`: 11 tests passed.
- Focused Maven test run completed successfully on the latest `main`.
- `git diff --check` passed.
- The PR changes only three files; OpenAPI output is unaffected.

### Related Issue

Fixes #36634

### Screenshots

Not applicable — backend-only change with no UI modifications.