### PR TITLE
fix(sdk): restore package.json copy for Vite SDK publish after nxViteTsPaths removal

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -203,13 +203,6 @@ runs:
           echo "📦 Processing @dotcms/${sdk}..."
           cd "$sdk"
 
-          if [ ! -f package.json ]; then
-            echo "  ⏭️ Skipping $sdk (no package.json)"
-            cd ..
-            echo ""
-            continue
-          fi
-
           ORIGINAL_VERSION=$(jq -r '.version' package.json)
 
           if [ "$PUBLISH_LATEST" = "true" ]; then

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -203,6 +203,13 @@ runs:
           echo "📦 Processing @dotcms/${sdk}..."
           cd "$sdk"
 
+          if [ ! -f package.json ]; then
+            echo "  ⏭️ Skipping $sdk (no package.json)"
+            cd ..
+            echo ""
+            continue
+          fi
+
           ORIGINAL_VERSION=$(jq -r '.version' package.json)
 
           if [ "$PUBLISH_LATEST" = "true" ]; then

--- a/core-web/libs/sdk/analytics/vite.config.mts
+++ b/core-web/libs/sdk/analytics/vite.config.mts
@@ -1,21 +1,12 @@
 /// <reference types='vitest' />
 import react from '@vitejs/plugin-react';
-import fs from 'fs';
 import * as path from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-// Plugin simple para copiar README.md
-const copyReadme = {
-    name: 'copy-readme',
-    writeBundle() {
-        fs.copyFileSync(
-            path.resolve(__dirname, 'README.md'),
-            path.resolve(__dirname, '../../../dist/libs/sdk/analytics/README.md')
-        );
-    }
-};
+const distDir = path.resolve(__dirname, '../../../dist/libs/sdk/analytics');
 
 export default defineConfig({
     root: __dirname,
@@ -34,8 +25,13 @@ export default defineConfig({
             root: path.resolve(__dirname, '../../../'),
             projects: ['tsconfig.base.json']
         }),
+        viteStaticCopy({
+            targets: [
+                { src: '*.md', dest: '.' },
+                { src: 'package.json', dest: '.' }
+            ]
+        }),
         dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') }),
-        copyReadme,
         // Ensure the React entry is tagged as a Client Component in the emitted bundle
         {
             name: 'preserve-use-client-react-entry',
@@ -56,7 +52,7 @@ export default defineConfig({
     build: {
         // Explicitly resolve outDir to prevent output from going to external dist folders
         // This ensures reproducible builds regardless of current working directory
-        outDir: path.resolve(__dirname, '../../../dist/libs/sdk/analytics'),
+        outDir: distDir,
         emptyOutDir: true,
         reportCompressedSize: true,
         commonjsOptions: {

--- a/core-web/libs/sdk/vue/vite.config.mts
+++ b/core-web/libs/sdk/vue/vite.config.mts
@@ -27,7 +27,12 @@ export default defineConfig(() => ({
             projects: ['tsconfig.base.json'],
             loose: true
         }),
-        viteStaticCopy({ targets: [{ src: '*.md', dest: '.' }] }),
+        viteStaticCopy({
+            targets: [
+                { src: '*.md', dest: '.' },
+                { src: 'package.json', dest: '.' }
+            ]
+        }),
         dts({
             entryRoot: 'src',
             tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'),


### PR DESCRIPTION
## Summary

- Restores explicit `package.json` (and README) copy into `dist` for `@dotcms/analytics` and `@dotcms/vue` via `viteStaticCopy`, replacing a hidden side effect of the removed `nxViteTsPaths()` plugin.
- Hardens the SDK NPM publish action to skip `dist` directories that have no `package.json` (e.g. `analytics-standalone`), so the publish loop does not fail with `jq: Could not open file package.json`.

## Context

Trunk SDK `@next` publish failed on [run 29416418823](https://github.com/dotCMS/core/actions/runs/29416418823) after [#36575](https://github.com/dotCMS/core/pull/36575) replaced `nxViteTsPaths()` with `vite-tsconfig-paths`. The Nx plugin copied `package.json` into the Vite `outDir` on `writeBundle`; the replacement does not. Publish then crashed while processing `@dotcms/analytics` after partially publishing `ai`, `angular`, and `types` as `1.7.1-next.2363`.

## Test plan

- [x] `pnpm exec nx build sdk-analytics --configuration=production` — `dist/libs/sdk/analytics/package.json` present
- [x] `pnpm exec nx build sdk-vue --configuration=production` — `dist/libs/sdk/vue/package.json` present
- [ ] After merge, next trunk deployment publishes a full coherent `@next` set (new `run_number`; do not re-run 2363)

This PR fixes: #36540

This PR fixes: #36540