### PR TITLE
fix(block-editor): preserve hard breaks on load for restricted fields

### DIFF
--- a/core-web/libs/block-editor/src/lib/shared/utils/parser.utils.spec.ts
+++ b/core-web/libs/block-editor/src/lib/shared/utils/parser.utils.spec.ts
@@ -1,0 +1,125 @@
+import { JSONContent } from '@tiptap/core';
+
+import { getBlockMap, purifyNodeTree, removeInvalidNodes } from './parser.utils';
+
+describe('parser.utils', () => {
+    describe('getBlockMap', () => {
+        it('should always include the basic nodes (paragraph, text, doc, hardBreak)', () => {
+            const map = getBlockMap(['heading']);
+
+            expect(map.paragraph).toBe(true);
+            expect(map.text).toBe(true);
+            expect(map.doc).toBe(true);
+            expect(map.hardBreak).toBe(true);
+        });
+
+        it('should expand related content dependencies (e.g. table)', () => {
+            const map = getBlockMap(['table']);
+
+            expect(map.table).toBe(true);
+            expect(map.tableRow).toBe(true);
+            expect(map.tableHeader).toBe(true);
+            expect(map.tableCell).toBe(true);
+        });
+
+        it('should add plain allowed blocks as-is', () => {
+            const map = getBlockMap(['heading', 'blockquote']);
+
+            expect(map.heading).toBe(true);
+            expect(map.blockquote).toBe(true);
+        });
+    });
+
+    describe('purifyNodeTree', () => {
+        it('should drop nodes whose type is not in the block map', () => {
+            const content: JSONContent[] = [
+                { type: 'paragraph', content: [{ type: 'text', text: 'keep' }] },
+                { type: 'blockquote', content: [{ type: 'text', text: 'drop' }] }
+            ];
+
+            const result = purifyNodeTree(content, getBlockMap(['paragraph']));
+
+            expect(result).toHaveLength(1);
+            expect(result[0].type).toBe('paragraph');
+        });
+
+        it('should preserve hardBreak nodes nested inside a paragraph', () => {
+            const content: JSONContent[] = [
+                {
+                    type: 'paragraph',
+                    content: [
+                        { type: 'text', text: 'line 1' },
+                        { type: 'hardBreak' },
+                        { type: 'text', text: 'line 2' }
+                    ]
+                }
+            ];
+
+            const result = purifyNodeTree(content, getBlockMap(['paragraph']));
+
+            expect(result[0].content).toHaveLength(3);
+            expect(result[0].content[1].type).toBe('hardBreak');
+        });
+    });
+
+    describe('removeInvalidNodes', () => {
+        // Regression for #35985: hard breaks were stripped when re-opening
+        // content for editing on a Block Editor field with allowed-block
+        // restrictions (allowedBlocks.length > 1).
+        it('should keep hardBreak nodes on a restricted-blocks field', () => {
+            const allowedBlocks = ['heading', 'paragraph', 'orderedList'];
+            const content: JSONContent = {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            { type: 'text', text: '123 Main St' },
+                            { type: 'hardBreak' },
+                            { type: 'text', text: 'Suite 100' },
+                            { type: 'hardBreak' },
+                            { type: 'text', text: 'Springfield' }
+                        ]
+                    }
+                ]
+            };
+
+            const result = removeInvalidNodes(content, allowedBlocks);
+
+            const paragraph = result[0];
+            expect(paragraph.type).toBe('paragraph');
+
+            const hardBreaks = paragraph.content.filter((node) => node.type === 'hardBreak');
+            expect(hardBreaks).toHaveLength(2);
+        });
+
+        it('should keep paragraph nodes via the basic-node fallback even when not in allowedBlocks', () => {
+            const allowedBlocks = ['heading', 'orderedList'];
+            const content: JSONContent = {
+                type: 'doc',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: 'plain text' }] }]
+            };
+
+            const result = removeInvalidNodes(content, allowedBlocks);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].type).toBe('paragraph');
+        });
+
+        it('should still strip nodes that are neither basic nor allowed', () => {
+            const allowedBlocks = ['heading', 'paragraph'];
+            const content: JSONContent = {
+                type: 'doc',
+                content: [
+                    { type: 'paragraph', content: [{ type: 'text', text: 'keep' }] },
+                    { type: 'codeBlock', content: [{ type: 'text', text: 'drop' }] }
+                ]
+            };
+
+            const result = removeInvalidNodes(content, allowedBlocks);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].type).toBe('paragraph');
+        });
+    });
+});

--- a/core-web/libs/block-editor/src/lib/shared/utils/parser.utils.ts
+++ b/core-web/libs/block-editor/src/lib/shared/utils/parser.utils.ts
@@ -32,7 +32,11 @@ const video: BlockMap = {
     youtube: true
 };
 
-const basicNodes: BlockMap = { paragrah: true, text: true, doc: true };
+// Nodes that are always allowed regardless of the field's allowed-block
+// restrictions. `hardBreak` (Shift+Enter line break) must live here so
+// `purifyNodeTree`/`removeInvalidNodes` never strips it when content is
+// re-opened for editing on a restricted field.
+const basicNodes: BlockMap = { paragraph: true, text: true, doc: true, hardBreak: true };
 
 const gridContent: BlockMap = {
     gridBlock: true,


### PR DESCRIPTION
## Summary

The legacy Block Editor silently stripped `hardBreak` (Shift+Enter) nodes when re-opening content for editing on fields configured with allowed-block restrictions. `setEditorJSONContent` runs loaded JSON through `removeInvalidNodes` → `purifyNodeTree`, which drops any node whose type isn't in the allowed map. `hardBreak` was never in the map, so every line break was lost on load — causing silent formatting/data loss on the next save.

This adds `hardBreak` to the always-allowed `basicNodes` map and fixes the latent `paragrah` → `paragraph` typo in the same map (the paragraph basic-node fallback was previously dead code).

Only affects fields with `allowedBlocks.length > 1`; unrestricted fields never entered the filtering path. The new Block Editor (`@dotcms/new-block-editor`) does not filter on load and was never affected.

Closes #35985

## Acceptance Criteria
- [x] Hard breaks preserved when re-opening content, including on restricted-block fields
- [x] `hardBreak` treated as an always-allowed basic node so `purifyNodeTree`/`removeInvalidNodes` never strips it
- [x] `paragrah` → `paragraph` typo fixed
- [x] Saving previously-saved content no longer drops line breaks (same load path)
- [x] Regression coverage: `hardBreak` survives `removeInvalidNodes` on a restricted editor

## Test Plan
- `pnpm nx test block-editor --testPathPatterns=parser.utils` — 8 tests pass (parser.utils.ts at 97% coverage)
- Verified manually in the editor: restricted-block field with a multi-line paragraph (Shift+Enter) now retains its line breaks after save + re-open

## Changed Files
- `core-web/libs/block-editor/src/lib/shared/utils/parser.utils.ts`
- `core-web/libs/block-editor/src/lib/shared/utils/parser.utils.spec.ts` (new)