### PR TITLE
fix(dotAI): forward maxCompletionTokens to Azure OpenAI builder for gpt-5.x and o-series models

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
@@ -12,6 +12,7 @@ import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
 
 import java.time.Duration;
+import java.util.function.Consumer;
 
 class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
 
@@ -31,8 +32,7 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
         if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
         if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
         if (config.temperature() != null) { builder.temperature(config.temperature()); }
-        if (config.maxTokens() != null && !requiresCompletionTokens(config)) { builder.maxTokens(config.maxTokens()); }
-        if (config.maxCompletionTokens() != null && requiresCompletionTokens(config)) { builder.maxCompletionTokens(config.maxCompletionTokens()); }
+        applyTokenLimit(config, builder::maxTokens, builder::maxCompletionTokens);
         return builder.build();
     }
 
@@ -47,8 +47,7 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
         if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
         if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
         if (config.temperature() != null) { builder.temperature(config.temperature()); }
-        if (config.maxTokens() != null && !requiresCompletionTokens(config)) { builder.maxTokens(config.maxTokens()); }
-        if (config.maxCompletionTokens() != null && requiresCompletionTokens(config)) { builder.maxCompletionTokens(config.maxCompletionTokens()); }
+        applyTokenLimit(config, builder::maxTokens, builder::maxCompletionTokens);
         return builder.build();
     }
 
@@ -135,6 +134,22 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
     private static boolean requiresCompletionTokens(final ProviderConfig config) {
         final String name = deploymentName(config) != null ? deploymentName(config) : "";
         return name.matches("o\\d+.*") || name.matches("gpt-([5-9]|\\d{2,}).*");
+    }
+
+    private static void applyTokenLimit(final ProviderConfig config,
+                                        final Consumer<Integer> maxTokensFn,
+                                        final Consumer<Integer> maxCompletionTokensFn) {
+        final Integer tokens = config.maxCompletionTokens() != null
+                ? config.maxCompletionTokens()
+                : config.maxTokens();
+        if (tokens == null) {
+            return;
+        }
+        if (requiresCompletionTokens(config)) {
+            maxCompletionTokensFn.accept(tokens);
+        } else {
+            maxTokensFn.accept(tokens);
+        }
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
@@ -27,10 +27,10 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
                 .apiKey(config.apiKey())
                 .endpoint(config.endpoint())
                 .deploymentName(deploymentName(config));
-        if (config.apiVersion() != null) builder.serviceVersion(config.apiVersion());
-        if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
-        if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
-        if (config.temperature() != null) builder.temperature(config.temperature());
+        if (config.apiVersion() != null) { builder.serviceVersion(config.apiVersion()); }
+        if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
+        if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
+        if (config.temperature() != null) { builder.temperature(config.temperature()); }
         if (config.maxTokens() != null && !requiresCompletionTokens(config)) { builder.maxTokens(config.maxTokens()); }
         if (config.maxCompletionTokens() != null && requiresCompletionTokens(config)) { builder.maxCompletionTokens(config.maxCompletionTokens()); }
         return builder.build();
@@ -43,10 +43,10 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
                 .apiKey(config.apiKey())
                 .endpoint(config.endpoint())
                 .deploymentName(deploymentName(config));
-        if (config.apiVersion() != null) builder.serviceVersion(config.apiVersion());
-        if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
-        if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
-        if (config.temperature() != null) builder.temperature(config.temperature());
+        if (config.apiVersion() != null) { builder.serviceVersion(config.apiVersion()); }
+        if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
+        if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
+        if (config.temperature() != null) { builder.temperature(config.temperature()); }
         if (config.maxTokens() != null && !requiresCompletionTokens(config)) { builder.maxTokens(config.maxTokens()); }
         if (config.maxCompletionTokens() != null && requiresCompletionTokens(config)) { builder.maxCompletionTokens(config.maxCompletionTokens()); }
         return builder.build();
@@ -59,10 +59,10 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
                 .apiKey(config.apiKey())
                 .endpoint(config.endpoint())
                 .deploymentName(deploymentName(config));
-        if (config.apiVersion() != null) builder.serviceVersion(config.apiVersion());
-        if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
-        if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
-        if (config.dimensions() != null) builder.dimensions(config.dimensions());
+        if (config.apiVersion() != null) { builder.serviceVersion(config.apiVersion()); }
+        if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
+        if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
+        if (config.dimensions() != null) { builder.dimensions(config.dimensions()); }
         return builder.build();
     }
 
@@ -96,9 +96,9 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
                     .baseUrl(config.endpoint())
                     .apiKey(config.apiKey())
                     .modelName(deploymentName(config));
-            if (config.size() != null) builder.size(config.size());
-            if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
-            if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
+            if (config.size() != null) { builder.size(config.size()); }
+            if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
+            if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
             return builder.build();
         }
         final OpenAiOfficialImageModel.Builder builder = OpenAiOfficialImageModel.builder()
@@ -110,9 +110,9 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
         if (config.apiVersion() != null) {
             builder.azureOpenAIServiceVersion(AzureOpenAIServiceVersion.Companion.fromString(config.apiVersion()));
         }
-        if (config.size() != null) builder.size(config.size());
-        if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
-        if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
+        if (config.size() != null) { builder.size(config.size()); }
+        if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
+        if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
         return builder.build();
     }
 

--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
@@ -31,7 +31,8 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
         if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
         if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
         if (config.temperature() != null) builder.temperature(config.temperature());
-        if (config.maxTokens() != null && !requiresCompletionTokens(config)) builder.maxTokens(config.maxTokens());
+        if (config.maxTokens() != null && !requiresCompletionTokens(config)) { builder.maxTokens(config.maxTokens()); }
+        if (config.maxCompletionTokens() != null && requiresCompletionTokens(config)) { builder.maxCompletionTokens(config.maxCompletionTokens()); }
         return builder.build();
     }
 
@@ -46,7 +47,8 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
         if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
         if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
         if (config.temperature() != null) builder.temperature(config.temperature());
-        if (config.maxTokens() != null && !requiresCompletionTokens(config)) builder.maxTokens(config.maxTokens());
+        if (config.maxTokens() != null && !requiresCompletionTokens(config)) { builder.maxTokens(config.maxTokens()); }
+        if (config.maxCompletionTokens() != null && requiresCompletionTokens(config)) { builder.maxCompletionTokens(config.maxCompletionTokens()); }
         return builder.build();
     }
 


### PR DESCRIPTION
## Summary

- `maxCompletionTokens` was defined in `ProviderConfig` but never forwarded to the LangChain4J Azure builder, leaving gpt-5.x and o-series users unable to control output length
- Fixed for both `buildChatModel` and `buildStreamingChatModel`
- Also added missing braces to the existing `maxTokens` guard (dotCMS convention)

## Test plan

- [ ] Configure Azure OpenAI with a gpt-5.x deployment and set `maxCompletionTokens` in the providerConfig — verify it is respected
- [ ] Configure with a gpt-4.x deployment and set `maxTokens` — verify it still works unchanged
- [ ] Verify no 500 error from Azure when using gpt-5.x models with the new field

Closes #36607

🤖 Generated with [Claude Code](https://claude.com/claude-code)