### PR TITLE
fix(ci): link-issue check must not fail on transient GitHub API errors

### DIFF
--- a/.github/workflows/issue_comp_link-issue-to-pr.yml
+++ b/.github/workflows/issue_comp_link-issue-to-pr.yml
@@ -256,12 +256,15 @@ jobs:
           pr_url="$PR_URL"
           pr_number=$(echo "$pr_url" | grep -o '[0-9]*$')
 
-          # Check for existing failure comment
-          existing_comments=$(curl -s \
+          # Check for existing failure comment. Best-effort cleanup: a transient API
+          # error (5xx/HTML body) must degrade to "no comment found", never fail the
+          # merge-gating check by feeding non-JSON to jq (#36610).
+          existing_comments=$(curl -sf --retry 3 --retry-all-errors \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$pr_number/comments")
+            "https://api.github.com/repos/${{ github.repository }}/issues/$pr_number/comments") || existing_comments="[]"
+          echo "$existing_comments" | jq -e . >/dev/null 2>&1 || existing_comments="[]"
 
           # Find failure comment by looking for the distinctive header
           failure_comment_id=$(echo "$existing_comments" | jq -r '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("❌ Issue Linking Required"))) | .id' | head -1)
@@ -338,11 +341,13 @@ jobs:
           pr_url="$PR_URL"
           pr_number=$(echo "$pr_url" | grep -o '[0-9]*$')
 
-          existing_comments=$(curl -s \
+          # Best-effort cleanup: transient API errors degrade to "no comment found" (#36610).
+          existing_comments=$(curl -sf --retry 3 --retry-all-errors \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$pr_number/comments")
+            "https://api.github.com/repos/${{ github.repository }}/issues/$pr_number/comments") || existing_comments="[]"
+          echo "$existing_comments" | jq -e . >/dev/null 2>&1 || existing_comments="[]"
           validation_comment_id=$(echo "$existing_comments" | jq -r '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("❌ Linked Issue Needs Team Label"))) | .id' | head -1)
 
           if [[ -n "$validation_comment_id" && "$validation_comment_id" != "null" ]]; then
@@ -364,13 +369,17 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ steps.determine_issue.outputs.final_issue_number }}
         run: |
-          # Fetch comments and write to temp file to avoid multiline JSON issues in GitHub Actions outputs
-          curl -s \
+          # Fetch comments and write to temp file to avoid multiline JSON issues in GitHub Actions outputs.
+          # A transient API error (5xx/HTML body) degrades to an empty list — downstream
+          # then posts a fresh comment instead of updating, rather than failing the
+          # merge-gating check on a jq parse error (#36610).
+          curl -sf --retry 3 --retry-all-errors \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments" \
-            | jq -c . > /tmp/issue_comments.json
+            | jq -c . > /tmp/issue_comments.json \
+            || echo "[]" > /tmp/issue_comments.json
 
           echo "comments_file=/tmp/issue_comments.json" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What

Makes the merge-gating `link-issue` check resilient to transient GitHub API errors. Three comment-maintenance steps in `issue_comp_link-issue-to-pr.yml` piped raw `curl -s` output straight into `jq`; during an API brownout the 5xx/HTML error body made `jq` exit 5 and fail the required check even on correctly linked PRs (observed on #36606 — 3 consecutive failures — and #36608 on 2026-07-16).

## How

Same minimal guard at all three sites:
- `curl -sf --retry 3 --retry-all-errors` (fail on HTTP errors, retry through brownouts)
- fall back to an empty JSON array if the fetch or a `jq -e` validity check still fails

These steps are best-effort comment maintenance, so the correct degraded behavior is "skip cleanup / post a fresh comment", never "fail the check". Verified: YAML parses; guard pattern exercised against a live 502 endpoint and against non-JSON garbage — both degrade cleanly.

Closes: #36610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ogYXVeZsBVUHkwzdStYPJ

This PR fixes: #36610