### PR TITLE
36597 uve style editor styling non default persona content fails with content not found

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/dot-uve-style-editor-form.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/dot-uve-style-editor-form.component.spec.ts
@@ -27,6 +27,7 @@ import {
 import { UVE_STATUS } from '../../../../../shared/enums';
 import { ActionPayload, SelectedContentlet } from '../../../../../shared/models';
 import { UVEStore } from '../../../../../store/dot-uve.store';
+import { PageData } from '../../../../../store/features/editor/models';
 import { PageType } from '../../../../../store/models';
 
 // Workaround: the `schema` input alias causes a compilation error when used directly.
@@ -43,6 +44,7 @@ type MockUveStore = {
     editorSelected: ReturnType<typeof signal<SelectedContentlet | null>>;
     pageAsset: ReturnType<typeof computed<DotCMSPageAsset | null>>;
     pageType: ReturnType<typeof signal<PageType>>;
+    $pageData: ReturnType<typeof signal<PageData>>;
     saveStyleEditor: jest.Mock;
     rollbackPageAssetResponse: jest.Mock;
     addCurrentPageToHistory: jest.Mock;
@@ -189,6 +191,13 @@ describe('DotUveStyleEditorFormComponent', () => {
                 return pageAsset ? { ...pageAsset, clientResponse: pageAsset } : null;
             }),
             pageType: signal(PageType.HEADLESS),
+            $pageData: signal<PageData>({
+                containers: [],
+                personalization: 'dot:default',
+                id: 'test-page',
+                languageId: 1,
+                personaTag: undefined
+            }),
             saveStyleEditor: jest.fn().mockReturnValue(of({})),
             rollbackPageAssetResponse: jest.fn().mockReturnValue(true),
             addCurrentPageToHistory: jest.fn(),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/dot-uve-style-editor-form.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/dot-uve-style-editor-form.component.ts
@@ -479,7 +479,8 @@ export class DotUveStyleEditorFormComponent {
                 contentletIdentifier: activeContentlet.contentlet.identifier,
                 styleProperties: filteredFormValues,
                 pageId: activeContentlet.pageId,
-                containerUUID: activeContentlet.container.uuid
+                containerUUID: activeContentlet.container.uuid,
+                personaTag: this.#uveStore.$pageData().personaTag
             })
             .pipe(
                 map((): SaveResult => ({ ok: true, isTraditionalPage })),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.spec.ts
@@ -239,5 +239,36 @@ describe('DotPageApiService', () => {
                 }
             ]);
         });
+
+        it('should include personaTag in the payload when styling non-default-persona content', () => {
+            const payload = {
+                pageId: 'test-page-123',
+                containerIdentifier: 'container-id-456',
+                containerUUID: 'container-uuid-789',
+                contentletIdentifier: 'contentlet-id-abc',
+                styleProperties: {
+                    'font-size': '16px'
+                },
+                personaTag: 'persona.returning_visitor'
+            };
+
+            spectator.service.saveStyleProperties(payload).subscribe();
+
+            const { request } = spectator.expectOne(
+                '/api/v1/page/test-page-123/styles',
+                HttpMethod.PUT
+            );
+
+            expect(request.body).toEqual([
+                {
+                    identifier: 'container-id-456',
+                    uuid: 'container-uuid-789',
+                    personaTag: 'persona.returning_visitor',
+                    'contentlet-id-abc': {
+                        'font-size': '16px'
+                    }
+                }
+            ]);
+        });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.ts
@@ -107,6 +107,7 @@ export class DotPageApiService {
      * @param {Record<string, unknown>} payload.styleProperties - Style properties to apply.
      * @param {string} payload.pageId - The page ID where styles are being saved.
      * @param {string} payload.containerUUID - UUID of the container.
+     * @param {string} [payload.personaTag] - Persona key tag to personalize this style update for.
      * @returns {Observable<unknown>} Observable that completes when properties are saved.
      * @memberof DotPageApiService
      */
@@ -115,11 +116,13 @@ export class DotPageApiService {
         contentletIdentifier,
         styleProperties,
         pageId,
-        containerUUID
+        containerUUID,
+        personaTag
     }: SaveStylePropertiesPayload): Observable<unknown> {
         const payload = {
             identifier: containerIdentifier,
             uuid: containerUUID,
+            personaTag,
             [contentletIdentifier]: styleProperties
         };
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -110,6 +110,7 @@ export interface SaveStylePropertiesPayload {
     containerIdentifier: string;
     contentletIdentifier: string;
     styleProperties: StyleEditorProperties;
+    personaTag?: string;
 }
 
 export interface NavigationBarItem {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/ContentWithStylesForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/ContentWithStylesForm.java
@@ -49,8 +49,10 @@ public class ContentWithStylesForm extends Validated {
 
     @JsonProperty("personaTag")
     @Schema(
-            description = "Persona key tag to personalize this style update for. Omit for the default persona.",
-            example = "dot:persona-key",
+            description = "Raw Persona key tag (e.g. the value of viewAs.persona.keyTag) to personalize "
+                    + "this style update for. Do not include the 'dot:persona:' prefix -- the backend adds "
+                    + "it automatically. Omit for the default persona.",
+            example = "returning_visitor",
             requiredMode = RequiredMode.NOT_REQUIRED
     )
     private final String personaTag;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/ContentWithStylesForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/ContentWithStylesForm.java
@@ -47,6 +47,14 @@ public class ContentWithStylesForm extends Validated {
     )
     private final String uuid;
 
+    @JsonProperty("personaTag")
+    @Schema(
+            description = "Persona key tag to personalize this style update for. Omit for the default persona.",
+            example = "dot:persona-key",
+            requiredMode = RequiredMode.NOT_REQUIRED
+    )
+    private final String personaTag;
+
     @JsonIgnore
     @Schema(hidden = true)
     private final Map<String, Map<String, Object>> contentletStyles;
@@ -58,10 +66,12 @@ public class ContentWithStylesForm extends Validated {
     @JsonCreator
     public ContentWithStylesForm(
             @JsonProperty("identifier") final String containerId,
-            @JsonProperty("uuid") final String uuid) {
+            @JsonProperty("uuid") final String uuid,
+            @JsonProperty("personaTag") final String personaTag) {
 
         this.containerId = containerId;
         this.uuid = uuid;
+        this.personaTag = personaTag;
         this.contentletStyles = new HashMap<>();
     }
 
@@ -76,6 +86,7 @@ public class ContentWithStylesForm extends Validated {
     public void addContentletStyle(final String contentletId, final Object styleProperties) {
         // Only process if it's not one of the known fields and is a Map
         if (!"containerId".equals(contentletId) && !"uuid".equals(contentletId)
+                && !"personaTag".equals(contentletId)
                 && styleProperties instanceof Map) {
 
             final Map<String, Object> styles = new HashMap<>((Map<String, Object>) styleProperties);
@@ -89,6 +100,10 @@ public class ContentWithStylesForm extends Validated {
 
     public String getUuid() {
         return uuid;
+    }
+
+    public String getPersonaTag() {
+        return personaTag;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -2069,8 +2069,9 @@ public class PageResource {
     /**
      * Reduces duplicate containers by combining their contentlet style mappings.
      * Converts ContentWithStylesForm (REST input) to ContainerEntry (internal format).
-     * If the same container (containerId + uuid) appears multiple times, their styles are merged.
-     * When the same contentlet appears in multiple entries, the last one wins (overwrites).
+     * If the same container (personaTag + containerId + uuid) appears multiple times, their
+     * styles are merged. When the same contentlet appears in multiple entries, the last one wins
+     * (overwrites).
      *
      * @param stylesForms List of style forms that may contain duplicates
      * @return List of deduplicated ContainerEntry objects ready for processing
@@ -2083,13 +2084,14 @@ public class PageResource {
             final Map<String, Map<String, Object>> contentletStylesMap = new HashMap<>();
         }
 
-        // Map key: containerId|uuid → accumulated contentlet styles
+        // Map key: personaTag|containerId|uuid → accumulated contentlet styles
         final Map<MultiKey, ContainerStylesData> containerMap = new HashMap<>();
 
         // Merge duplicate containers
         for (final ContentWithStylesForm styleForm : stylesForms) {
-            // Create unique key for this container (containerId + uuid)
-            final MultiKey containerKey = new MultiKey(styleForm.getContainerId(), styleForm.getUuid());
+            // Create unique key for this container (personaTag + containerId + uuid)
+            final MultiKey containerKey = new MultiKey(styleForm.getPersonaTag(),
+                    styleForm.getContainerId(), styleForm.getUuid());
 
             // Get or create accumulator for this container
             final ContainerStylesData accumulatedData = containerMap.computeIfAbsent(
@@ -2107,12 +2109,13 @@ public class PageResource {
         // Convert to ContainerEntry list
         return containerMap.entrySet().stream()
                 .map(entry -> {
-                    final String containerId = (String) entry.getKey().getKeys()[0];
-                    final String containerUuid = (String) entry.getKey().getKeys()[1];
+                    final String personaTag = (String) entry.getKey().getKeys()[0];
+                    final String containerId = (String) entry.getKey().getKeys()[1];
+                    final String containerUuid = (String) entry.getKey().getKeys()[2];
                     final ContainerStylesData data = entry.getValue();
 
                     return new ContainerEntry(
-                            null, // No persona tag for style updates (uses default personalization)
+                            personaTag,
                             containerId,
                             containerUuid,
                             new ArrayList<>(data.contentletIds),

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -204,9 +204,7 @@ public class PageResourceHelper implements Serializable {
         for (final ContainerEntry containerEntry : containerEntries) {
             int i = 0;
             final List<String> contentIds = containerEntry.getContentIds();
-            final String personalization = UtilMethods.isSet(containerEntry.getPersonaTag()) ?
-                    Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + containerEntry.getPersonaTag() :
-                    MultiTree.DOT_PERSONALIZATION_DEFAULT;
+            final String personalization = resolvePersonalizationFromTag(containerEntry.getPersonaTag());
 
             if (UtilMethods.isSet(contentIds)) {
                 for (final String contentletId : contentIds) {
@@ -788,9 +786,7 @@ public class PageResourceHelper implements Serializable {
 
             final String containerId = containerEntry.getContainerId();
             final String containerUuid = containerEntry.getContainerUUID();
-            final String personalization = UtilMethods.isSet(containerEntry.getPersonaTag())
-                    ? Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + containerEntry.getPersonaTag()
-                    : MultiTree.DOT_PERSONALIZATION_DEFAULT;
+            final String personalization = resolvePersonalizationFromTag(containerEntry.getPersonaTag());
             final Map<String, Map<String, Object>> contentletStylesMap = containerEntry.getStylePropertiesMap();
 
             // For each contentlet in this container, update its styles
@@ -1202,6 +1198,18 @@ public class PageResourceHelper implements Serializable {
                     + e.getMessage());
         }
         return MultiTree.DOT_PERSONALIZATION_DEFAULT;
+    }
+
+    /**
+     * Builds the personalization key from a raw Persona key tag (e.g. {@code ContainerEntry.getPersonaTag()},
+     * which the client sends as {@code viewAs.persona.keyTag}, unprefixed). Treats a missing tag, or the
+     * bare {@code "dot:persona"} prefix with no tag segment, as the default personalization: the latter guards
+     * against a client accidentally echoing back the prefix scheme itself instead of a real Persona tag.
+     */
+    private String resolvePersonalizationFromTag(final String personaTag) {
+        return UtilMethods.isSet(personaTag) && !Persona.DOT_PERSONA_PREFIX_SCHEME.equals(personaTag)
+                ? Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + personaTag
+                : MultiTree.DOT_PERSONALIZATION_DEFAULT;
     }
 
     /**

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -25567,6 +25567,11 @@ components:
           type: string
           description: Container identifier
           example: //demo.dotcms.com/application/containers/default/
+        personaTag:
+          type: string
+          description: Persona key tag to personalize this style update for. Omit
+            for the default persona.
+          example: dot:persona-key
         uuid:
           type: string
           description: Container unique identifier (UUID)

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -25569,9 +25569,10 @@ components:
           example: //demo.dotcms.com/application/containers/default/
         personaTag:
           type: string
-          description: Persona key tag to personalize this style update for. Omit
-            for the default persona.
-          example: dot:persona-key
+          description: Raw Persona key tag (e.g. the value of viewAs.persona.keyTag)
+            to personalize this style update for. Do not include the 'dot:persona:'
+            prefix -- the backend adds it automatically. Omit for the default persona.
+          example: returning_visitor
         uuid:
           type: string
           description: Container unique identifier (UUID)

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -565,6 +565,104 @@ public class PageResourceTest {
     }
 
     /**
+     * methodToTest {@link PageResource#updateStyles(HttpServletRequest, HttpServletResponse, String, List)}
+     * Given Scenario: The Style Editor saves a style update for the Default Visitor -- i.e. with no
+     * {@code personaTag} (null), and separately with the bare {@code "dot:persona"} prefix scheme sent
+     * as the tag (an edge case a client should never send, but the backend must not misinterpret).
+     * ExpectedResult: Both cases resolve to the default personalization ({@code dot:default}), not to
+     * {@code dot:persona:dot:persona}. Locks down the contract behind.
+     */
+    @Test
+    public void test_updateStyles_with_defaultVisitor() throws Exception {
+        final boolean originalFeatureFlagValue = Config.getBooleanProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", true);
+
+        try {
+            Config.setProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", true);
+            final PageRenderTestUtil.PageRenderTest pageRenderTest = PageRenderTestUtil.createPage(1, host);
+            final HTMLPageAsset testPage = pageRenderTest.getPage();
+            final Container container = pageRenderTest.getFirstContainer();
+
+            final ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(APILocator.systemUser());
+            final ContentType contentGenericType = contentTypeAPI.find("webPageContent");
+            final Contentlet contentlet = new ContentletDataGen(contentGenericType.id())
+                    .languageId(1)
+                    .folder(APILocator.getFolderAPI().findSystemFolder())
+                    .host(host)
+                    .setProperty("title", "Test Content for Default Visitor")
+                    .setProperty("body", TestDataUtils.BLOCK_EDITOR_DUMMY_CONTENT)
+                    .nextPersisted();
+
+            contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
+            contentlet.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
+            contentlet.setBoolProperty(Contentlet.IS_TEST_MODE, true);
+            APILocator.getContentletAPI().publish(contentlet, user, false);
+
+            final List<ContainerEntry> entries = new ArrayList<>();
+            final String containerUUID = UUIDGenerator.generateUuid();
+
+            final ContainerEntry containerEntry = new ContainerEntry(
+                    null,
+                    container.getIdentifier(),
+                    containerUUID,
+                    list(contentlet.getIdentifier())
+            );
+
+            entries.add(containerEntry);
+            final PageContainerForm pageContainerForm = new PageContainerForm(entries, null);
+
+            final Response addContentResponse = this.pageResourceWithHelper.addContent(
+                    request,
+                    response,
+                    testPage.getIdentifier(),
+                    VariantAPI.DEFAULT_VARIANT.name(),
+                    pageContainerForm
+            );
+
+            assertNotNull(addContentResponse);
+            assertEquals(200, addContentResponse.getStatus());
+
+            final Map<String, Object> styleProperties = new HashMap<>();
+            styleProperties.put("backgroundColor", "green");
+
+            // Simulate the edge case: a client sending the bare "dot:persona" prefix instead of
+            // omitting personaTag. Must still resolve to the default personalization.
+            final ContentWithStylesForm contentWithStylesForm = new ContentWithStylesForm(
+                    container.getIdentifier(),
+                    containerUUID,
+                    Persona.DOT_PERSONA_PREFIX_SCHEME
+            );
+            contentWithStylesForm.addContentletStyle(contentlet.getIdentifier(), styleProperties);
+
+            final Response updateStylesResponse = this.pageResourceWithHelper.updateStyles(
+                    request,
+                    response,
+                    testPage.getIdentifier(),
+                    List.of(contentWithStylesForm)
+            );
+
+            assertNotNull(updateStylesResponse);
+            assertEquals(200, updateStylesResponse.getStatus());
+
+            final MultiTreeAPI multiTreeAPI = APILocator.getMultiTreeAPI();
+            final List<MultiTree> multiTrees = multiTreeAPI.getMultiTrees(testPage.getIdentifier());
+
+            final Optional<MultiTree> defaultMultiTreeOpt = multiTrees.stream()
+                    .filter(mt -> mt.getContentlet().equals(contentlet.getIdentifier()))
+                    .filter(mt -> MultiTree.DOT_PERSONALIZATION_DEFAULT.equals(mt.getPersonalization()))
+                    .findFirst();
+
+            assertTrue("MultiTree should be personalized as dot:default, not dot:persona:dot:persona",
+                    defaultMultiTreeOpt.isPresent());
+
+            final Map<String, Object> savedStyleProperties = defaultMultiTreeOpt.get().getStyleProperties();
+            assertNotNull("StyleProperties should not be null", savedStyleProperties);
+            assertEquals("backgroundColor should match", "green", savedStyleProperties.get("backgroundColor"));
+        } finally {
+            Config.setProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", originalFeatureFlagValue);
+        }
+    }
+
+    /**
      * Should return at least one persona personalized
      *
      * @throws JSONException

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -393,7 +393,8 @@ public class PageResourceTest {
             // create ContentWithStylesForm with styleProperties
             final ContentWithStylesForm contentWithStylesForm = new ContentWithStylesForm(
                     container.getIdentifier(),
-                    containerUUID
+                    containerUUID,
+                    null
             );
             contentWithStylesForm.addContentletStyle(contentlet.getIdentifier(), styleProperties);
 
@@ -434,6 +435,129 @@ public class PageResourceTest {
             assertEquals("padding should match", "10px", savedStyleProperties.get("padding"));
 
             Logger.info(this, "StyleProperties saved successfully: " + savedStyleProperties);
+        } finally {
+            // Restore the original feature flag value
+            Config.setProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", originalFeatureFlagValue);
+        }
+    }
+
+    /**
+     * methodToTest {@link PageResource#updateStyles(HttpServletRequest, HttpServletResponse, String, List)}
+     * Given Scenario: A contentlet is personalized under a non-default Persona (not {@code dot:default})
+     * and the Style Editor sends a style update carrying that Persona's {@code personaTag}.
+     * ExpectedResult: The save succeeds (no CONTENT_NOT_FOUND/400) and the styles are persisted on the
+     * MultiTree row personalized for that Persona -- not on the default-personalization row. This is the
+     * regression scenario for issue #36597, where {@code reduceStyleForms()} used to hardcode a {@code null}
+     * persona tag, always resolving to {@code dot:default} and causing the lookup to fail for any other
+     * Persona.
+     */
+    @Test
+    public void test_updateStyles_with_nonDefaultPersona() throws Exception {
+        // Save the original feature flag value
+        final boolean originalFeatureFlagValue = Config.getBooleanProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", true);
+
+        try {
+            // Enable the Style Editor feature flag
+            Config.setProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", true);
+            final PageRenderTestUtil.PageRenderTest pageRenderTest = PageRenderTestUtil.createPage(1, host);
+            final HTMLPageAsset testPage = pageRenderTest.getPage();
+            final Container container = pageRenderTest.getFirstContainer();
+
+            // Create a non-default Persona
+            final Persona persona = new PersonaDataGen()
+                    .keyTag("persona" + System.currentTimeMillis())
+                    .hostFolder(host.getIdentifier())
+                    .nextPersisted();
+            persona.setIndexPolicy(IndexPolicy.WAIT_FOR);
+            APILocator.getContentletAPI().publish(persona, user, false);
+            final String personaTag = persona.getKeyTag();
+            final String personalization = Persona.DOT_PERSONA_PREFIX_SCHEME + StringPool.COLON + personaTag;
+
+            // Create contentlet
+            final ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(APILocator.systemUser());
+            final ContentType contentGenericType = contentTypeAPI.find("webPageContent");
+            final Contentlet contentlet = new ContentletDataGen(contentGenericType.id())
+                    .languageId(1)
+                    .folder(APILocator.getFolderAPI().findSystemFolder())
+                    .host(host)
+                    .setProperty("title", "Test Content Personalized for Non-Default Persona")
+                    .setProperty("body", TestDataUtils.BLOCK_EDITOR_DUMMY_CONTENT)
+                    .nextPersisted();
+
+            contentlet.setIndexPolicy(IndexPolicy.WAIT_FOR);
+            contentlet.setIndexPolicyDependencies(IndexPolicy.WAIT_FOR);
+            contentlet.setBoolProperty(Contentlet.IS_TEST_MODE, true);
+            APILocator.getContentletAPI().publish(contentlet, user, false);
+
+            // Add the contentlet to the container under the non-default Persona
+            final List<ContainerEntry> entries = new ArrayList<>();
+            final String containerUUID = UUIDGenerator.generateUuid();
+
+            final ContainerEntry containerEntry = new ContainerEntry(
+                    personaTag,
+                    container.getIdentifier(),
+                    containerUUID,
+                    list(contentlet.getIdentifier())
+            );
+
+            entries.add(containerEntry);
+            final PageContainerForm pageContainerForm = new PageContainerForm(entries, null);
+
+            final Response addContentResponse = this.pageResourceWithHelper.addContent(
+                    request,
+                    response,
+                    testPage.getIdentifier(),
+                    VariantAPI.DEFAULT_VARIANT.name(),
+                    pageContainerForm
+            );
+
+            assertNotNull(addContentResponse);
+            assertEquals(200, addContentResponse.getStatus());
+
+            // Prepare styleProperties, including the same personaTag used above
+            final Map<String, Object> styleProperties = new HashMap<>();
+            styleProperties.put("backgroundColor", "blue");
+            styleProperties.put("fontSize", "20px");
+
+            final ContentWithStylesForm contentWithStylesForm = new ContentWithStylesForm(
+                    container.getIdentifier(),
+                    containerUUID,
+                    personaTag
+            );
+            contentWithStylesForm.addContentletStyle(contentlet.getIdentifier(), styleProperties);
+
+            // Save styleProperties for the non-default-Persona content -- this used to fail with
+            // a 400 CONTENT_NOT_FOUND because the personaTag was silently dropped.
+            final Response updateStylesResponse = this.pageResourceWithHelper.updateStyles(
+                    request,
+                    response,
+                    testPage.getIdentifier(),
+                    List.of(contentWithStylesForm)
+            );
+
+            assertNotNull(updateStylesResponse);
+            assertEquals(200, updateStylesResponse.getStatus());
+
+            // Verify the styles were saved on the row personalized for our Persona, not on default
+            final MultiTreeAPI multiTreeAPI = APILocator.getMultiTreeAPI();
+            final List<MultiTree> multiTrees = multiTreeAPI.getMultiTrees(testPage.getIdentifier());
+
+            assertNotNull("MultiTrees should not be null", multiTrees);
+
+            final Optional<MultiTree> personalizedMultiTreeOpt = multiTrees.stream()
+                    .filter(mt -> mt.getContentlet().equals(contentlet.getIdentifier()))
+                    .filter(mt -> personalization.equals(mt.getPersonalization()))
+                    .findFirst();
+
+            assertTrue("MultiTree personalized for the non-default Persona should exist",
+                    personalizedMultiTreeOpt.isPresent());
+
+            final Map<String, Object> savedStyleProperties = personalizedMultiTreeOpt.get().getStyleProperties();
+            assertNotNull("StyleProperties should not be null", savedStyleProperties);
+            assertEquals("backgroundColor should match", "blue", savedStyleProperties.get("backgroundColor"));
+            assertEquals("fontSize should match", "20px", savedStyleProperties.get("fontSize"));
+
+            Logger.info(this, "Non-default Persona styleProperties saved successfully: " + savedStyleProperties);
         } finally {
             // Restore the original feature flag value
             Config.setProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", originalFeatureFlagValue);


### PR DESCRIPTION
### Proposed Changes
* Fixed a bug in the UVE Style Editor where styling content that was personalized for a specific Persona (i.e. not the "Default Visitor") failed with an error and the change wasn't saved.
* The editor now correctly keeps track of which Persona you're viewing while you make style changes, so the update is saved against that Persona's version of the content instead of always falling back to the default one.

### Additional Info
Previously, saving a style change while viewing a page under a non-default Persona threw an error ("Contentlet not found...") because the save request always looked for the default Persona's version of the content, even when a different Persona was selected in the editor. This fix makes sure the currently selected Persona is included when the style change is saved, so it lands on the correct personalized content.

This PR fixes: #36597

This PR fixes: #36597