### PR TITLE
feat(build): support mise via idiomatic version files for Java/Node

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -30,6 +30,11 @@ shellcheck = "latest"
 _.python.venv = { path = ".venv", create = true }
 
 [settings]
+# Read tool versions from the repo's canonical version files instead of
+# duplicating them here: java from .sdkmanrc (25.0.2-ms -> microsoft-25.0.2),
+# node from .nvmrc. Keeps CI (which parses .sdkmanrc) and mise in sync.
+idiomatic_version_file_enable_tools = ["java", "node"]
+
 # Experimental features
 experimental = true
 


### PR DESCRIPTION
### Proposed Changes

* Enable `idiomatic_version_file_enable_tools = ["java", "node"]` in `.mise.toml` so [mise](https://mise.jdx.dev/) users get the repo's required tool versions automatically, resolved from the existing canonical version files:
  * Java from `.sdkmanrc` — mise maps the SDKMAN vendor suffix (`25.0.2-ms` → `microsoft-25.0.2`)
  * Node from `.nvmrc` (`v22.15.0`)

No versions are duplicated in `.mise.toml`, so `.sdkmanrc` remains the single source of truth that CI's `setup-java` action parses. SDKMAN/nvm users and CI are unaffected.

Verified locally — `mise ls --current` in the repo:

```
java        microsoft-25.0.2  ~/Developer/dotcms/core/.sdkmanrc   microsoft-25.0.2
node        22.15.0           ~/Developer/dotcms/core/.nvmrc      22.15.0
```

### Checklist

- [x] Tests (verified locally with `mise ls --current`; config-only change, no code paths affected)

This PR resolves #36625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36625