### PR TITLE
feat(analytics): expose visitor postal/zip code in Geolocation ($visitor.geo.postal) (#36232)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/business/PageAPIGraphQLTypesProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/business/PageAPIGraphQLTypesProvider.java
@@ -333,6 +333,8 @@ public enum PageAPIGraphQLTypesProvider implements GraphQLTypesProvider {
                 new PropertyDataFetcher<Geolocation>("subdivision")));
         geoFields.put("subdivisionCode", new TypeFetcher(GraphQLString,
                 new PropertyDataFetcher<Geolocation>("subdivisionCode")));
+        geoFields.put("postal", new TypeFetcher(GraphQLString,
+                new PropertyDataFetcher<Geolocation>("postal")));
         geoFields.put("ipAddress", new TypeFetcher(GraphQLString,
                 new PropertyDataFetcher<Geolocation>("ipAddress")));
 

--- a/dotCMS/src/main/java/com/dotcms/util/GeoIp2CityDbUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/GeoIp2CityDbUtil.java
@@ -331,6 +331,29 @@ public class GeoIp2CityDbUtil {
 	}
 
 	/**
+	 * Returns the postal/zip code the specified IP address belongs to, when the
+	 * MaxMind database provides it.
+	 *
+	 * @param ipAddress
+	 *            - The IP address to get information from.
+	 * @return The postal/zip code, or {@code null} if the database has none for
+	 *         this IP.
+	 * @throws UnknownHostException
+	 *             If the IP address of a host could not be determined.
+	 * @throws IOException
+	 *             If the connection to the GeoIP2 service could not be
+	 *             established, or the result object could not be created.
+	 * @throws GeoIp2Exception
+	 *             If the IP address is not present in the service database.
+	 */
+	public String getPostalCode(String ipAddress) throws UnknownHostException,
+			IOException, GeoIp2Exception {
+		InetAddress inetAddress = InetAddress.getByName(ipAddress);
+		CityResponse cityResponse = getDatabaseReader().city(inetAddress);
+		return cityResponse.getPostal() != null ? cityResponse.getPostal().getCode() : null;
+	}
+
+	/**
 	 * Returns the {@link TimeZone} associated with location, as specified by
 	 * the <a href="http://www.iana.org/time-zones">IANA Time Zone Database</a>.
 	 * For example: {@code "America/New_York"}.
@@ -413,7 +436,8 @@ public class GeoIp2CityDbUtil {
         .withLongitude(cityResponse.getLocation().getLongitude())
         .withSubdivision(cityResponse.getMostSpecificSubdivision().getName())
         .withIpAddress(ipAddress.getHostAddress())
-        .withSubdivisionCode(cityResponse.getMostSpecificSubdivision().getIsoCode());
+        .withSubdivisionCode(cityResponse.getMostSpecificSubdivision().getIsoCode())
+        .withPostal(cityResponse.getPostal() != null ? cityResponse.getPostal().getCode() : null);
         return builder.build();
     }
     

--- a/dotCMS/src/main/java/com/dotcms/visitor/domain/Geolocation.java
+++ b/dotCMS/src/main/java/com/dotcms/visitor/domain/Geolocation.java
@@ -15,7 +15,7 @@ public class Geolocation implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private final double latitude, longitude;
-    private final String country,countryCode, city, continent, continentCode, company, timezone, subdivision,subdivisionCode, ipAddress;
+    private final String country,countryCode, city, continent, continentCode, company, timezone, subdivision,subdivisionCode, postal, ipAddress;
 
     public static long getSerialversionuid() {
         return serialVersionUID;
@@ -40,6 +40,7 @@ public class Geolocation implements Serializable {
         result = prime * result + (int) (temp ^ (temp >>> 32));
         result = prime * result + ((subdivision == null) ? 0 : subdivision.hashCode());
         result = prime * result + ((subdivisionCode == null) ? 0 : subdivisionCode.hashCode());
+        result = prime * result + ((postal == null) ? 0 : postal.hashCode());
         result = prime * result + ((timezone == null) ? 0 : timezone.hashCode());
         return result;
     }
@@ -102,6 +103,11 @@ public class Geolocation implements Serializable {
             if (other.subdivisionCode != null)
                 return false;
         } else if (!subdivisionCode.equals(other.subdivisionCode))
+            return false;
+        if (postal == null) {
+            if (other.postal != null)
+                return false;
+        } else if (!postal.equals(other.postal))
             return false;
         if (timezone == null) {
             if (other.timezone != null)
@@ -167,6 +173,11 @@ public class Geolocation implements Serializable {
     }
 
 
+    public String getPostal() {
+        return postal;
+    }
+
+
     public String getIpAddress() {
         return ipAddress;
     }
@@ -185,6 +196,7 @@ public class Geolocation implements Serializable {
         this.country = builder.country;
         this.subdivisionCode = builder.subdivisionCode;
         this.continentCode = builder.continentCode;
+        this.postal = builder.postal;
     }
 
     @JsonIgnore
@@ -217,7 +229,7 @@ public class Geolocation implements Serializable {
      */
     public static final class Builder {
         private  double latitude, longitude;
-        private  String country,countryCode, city, continent, continentCode, company, timezone, subdivision,subdivisionCode, ipAddress;
+        private  String country,countryCode, city, continent, continentCode, company, timezone, subdivision,subdivisionCode, postal, ipAddress;
 
         public Builder() {}
 
@@ -234,6 +246,7 @@ public class Geolocation implements Serializable {
             this.country = geolocation.country;
             this.subdivisionCode = geolocation.subdivisionCode;
             this.continentCode = geolocation.continentCode;
+            this.postal = geolocation.postal;
         }
 
         public Builder withLatitude(@Nonnull double latitude) {
@@ -293,6 +306,11 @@ public class Geolocation implements Serializable {
 
         public Builder withSubdivision(@Nonnull String subdivision) {
             this.subdivision = subdivision;
+            return this;
+        }
+
+        public Builder withPostal(String postal) {
+            this.postal = postal;
             return this;
         }
 

--- a/dotCMS/src/main/java/com/dotcms/visitor/filter/characteristics/GeoCharacter.java
+++ b/dotCMS/src/main/java/com/dotcms/visitor/filter/characteristics/GeoCharacter.java
@@ -21,11 +21,13 @@ public class GeoCharacter extends AbstractCharacter {
             try {
                 String ipAddress = visitor.getIpAddress().getHostAddress();
                 GeoIp2CityDbUtil geo = GeoIp2CityDbUtil.getInstance();
+                final String postalCode = geo.getPostalCode(ipAddress);
                 m = new ImmutableMap.Builder<String, String>().put("g.latLong", geo.getLocationAsString(ipAddress))
                     .put("g.countryCode", geo.getCountryIsoCode(ipAddress))
                     .put("g.cityName", geo.getCityName(ipAddress))
                     .put("g.continent", geo.getContinent(ipAddress))
                     .put("g.company", geo.getCompany())
+                    .put("g.postalCode", postalCode != null ? postalCode : "")
                     .build();
             } catch (Exception e) {
                 m = ImmutableMap.of("g.ip", "ukn");

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -27796,6 +27796,8 @@ components:
         longitude:
           type: number
           format: double
+        postal:
+          type: string
         subdivision:
           type: string
         subdivisionCode:

--- a/dotCMS/src/test/java/com/dotcms/util/GeoIp2CityDbUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/GeoIp2CityDbUtilTest.java
@@ -50,6 +50,8 @@ public class GeoIp2CityDbUtilTest {
         assertEquals(geo.getSubdivision(), "Massachusetts");
         assertEquals(geo.getSubdivisionCode(), "MA");
         assertEquals(geo.getIpAddress(), ipAddress);
+        assertEquals(geo.getPostal(), "01810");
+        assertEquals(GeoIp2CityDbUtil.getInstance().getPostalCode(ipAddress), "01810");
     }
 
     @Test


### PR DESCRIPTION
### Proposed Changes
Exposes the visitor's postal/zip code across the Visitor Geolocation surfaces. The bundled MaxMind GeoLite2-City database already contains postal code (`CityResponse.getPostal().getCode()`) — dotCMS just never read it. This is read-surface only (additive, backward-compatible).

* `Geolocation.java` — add `postal` field, `getPostal()`, `withPostal(...)` builder, plus constructor/copy-constructor/`equals`/`hashCode` (mirrors `subdivision`). Picked up by Velocity (`$visitor.geo.postal`) and JSON via reflection.
* `GeoIp2CityDbUtil.java` — populate postal in `getGeolocation(InetAddress)` (null-guarded) and add a `getPostalCode(String ip)` accessor mirroring `getCityName(ip)`.
* `GeoCharacter.java` — add `g.postalCode` to the `$visitor.g` map, **null-safe** (empty string fallback) so a missing postal can't collapse the whole geo map to `"ukn"` via `ImmutableMap`'s null-value NPE.
* `PageAPIGraphQLTypesProvider.java` — register `postal` on the GraphQL geo type.
* `openapi.yaml` — regenerated; `postal` added to the `Geolocation` schema.

### Checklist
- [x] Tests — `GeoIp2CityDbUtilTest` extended: exact-value assertions on `getPostal()`, the `getPostalCode(ip)` accessor, and the JSON serialize round-trip (exercises `equals`/`hashCode`). `Tests run: 4, Failures: 0, Errors: 0`.
- [ ] Translations — n/a
- [x] Security Implications Contemplated — no new input; reads an existing local DB. Postal is already personal-ish geo data on par with city/subdivision already exposed.

### Additional Info
Postal-based personalization **rules** (rules-engine conditionlet + Angular UI) are intentionally out of scope — the conditionlet is distance-only today and would need new comparison types (separate, larger effort).

`openapi.yaml` was regenerated via `./mvnw compile -pl :dotcms-core`; the committed diff matches the generator output exactly, so the CI openapi drift-check stays green.

Refs: #36232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36232