### PR TITLE
feat(edit-content): apply 18px field padding and form max-width guidelines

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -48,38 +48,43 @@
         <!-- Template for the tab tabPanel -->
         <ng-template #tabPanelTemplate let-tab="tab">
             @let hiddenFields = $store.hiddenFields();
+            @let isSingleColumnTab = isSingleColumnLayout(tab.layout);
             <div class="p-4">
-                @for (row of tab.layout; track row) {
-                    <div
-                        class="mb-4 grid auto-cols-fr grid-flow-col gap-4 last:mb-0"
-                        [class.hidden]="row.columns.some(c => c.fields.length > 0) && row.columns.every(c => c.fields.every(f => hiddenFields[f.variable]))"
-                        data-testId="row">
-                        @for (column of row.columns; track column) {
-                            <div
-                                class="flex flex-col gap-4"
-                                [class.hidden]="column.fields.length > 0 && column.fields.every(f => hiddenFields[f.variable])"
-                                data-testId="column">
-                                @for (field of column.fields; track field) {
-                                    @if (
-                                        isPreservedField(field.fieldType)
-                                            ? $shouldRenderPreservedFields()
-                                            : $shouldRenderFields()
-                                    ) {
-                                        <dot-edit-content-field
-                                            [contentType]="contentType"
-                                            [contentlet]="contentlet"
-                                            [field]="field"
-                                            [class.hidden]="hiddenFields[field.variable]"
-                                            (disabledWYSIWYGChange)="
-                                                onDisabledWYSIWYGChange($event)
-                                            "
-                                            data-testId="field" />
+                <div
+                    [class]="isSingleColumnTab ? 'mx-auto max-w-206' : 'mx-auto max-w-286'"
+                    data-testId="tab-layout-container">
+                    @for (row of tab.layout; track row) {
+                        <div
+                            class="mb-5 grid auto-cols-fr grid-flow-col gap-5 last:mb-0"
+                            [class.hidden]="row.columns.some(c => c.fields.length > 0) && row.columns.every(c => c.fields.every(f => hiddenFields[f.variable]))"
+                            data-testId="row">
+                            @for (column of row.columns; track column) {
+                                <div
+                                    class="flex flex-col gap-5"
+                                    [class.hidden]="column.fields.length > 0 && column.fields.every(f => hiddenFields[f.variable])"
+                                    data-testId="column">
+                                    @for (field of column.fields; track field) {
+                                        @if (
+                                            isPreservedField(field.fieldType)
+                                                ? $shouldRenderPreservedFields()
+                                                : $shouldRenderFields()
+                                        ) {
+                                            <dot-edit-content-field
+                                                [contentType]="contentType"
+                                                [contentlet]="contentlet"
+                                                [field]="field"
+                                                [class.hidden]="hiddenFields[field.variable]"
+                                                (disabledWYSIWYGChange)="
+                                                    onDisabledWYSIWYGChange($event)
+                                                "
+                                                data-testId="field" />
+                                        }
                                     }
-                                }
-                            </div>
-                        }
-                    </div>
-                }
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
             </div>
         </ng-template>
     </form>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -38,6 +38,7 @@ import {
 import {
     DotCMSBaseTypesContentTypes,
     DotCMSContentlet,
+    DotCMSContentType,
     DotCMSContentTypeField,
     DotCMSWorkflowAction,
     DotContentletCanLock,
@@ -299,6 +300,73 @@ describe('DotFormComponent', () => {
             // Clean up any pending async operations
             flush();
         }));
+    });
+
+    describe('Field padding and form max-width (issue #36615)', () => {
+        // MOCK_CONTENTTYPE_1_TAB has a single row with two columns, i.e. a multi-column tab.
+        it('should apply the 1000px max-width and the 18px gap classes for a multi-column layout', () => {
+            dotContentTypeService.getContentTypeWithRender.mockReturnValue(
+                of(MOCK_CONTENTTYPE_1_TAB)
+            );
+            workflowActionsService.getDefaultActions.mockReturnValue(
+                of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+            );
+            workflowActionsService.getWorkFlowActions.mockReturnValue(
+                of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+            );
+            dotContentletService.canLock.mockReturnValue(
+                of({ canLock: true } as DotContentletCanLock)
+            );
+
+            store.initializeNewContent('TestMock');
+            spectator.detectChanges();
+
+            const container = spectator.query(byTestId('tab-layout-container'));
+            expect(container?.classList.contains('max-w-286')).toBe(true);
+            expect(container?.classList.contains('max-w-206')).toBe(false);
+            expect(container?.classList.contains('mx-auto')).toBe(true);
+
+            const row = spectator.query(byTestId('row'));
+            const column = spectator.query(byTestId('column'));
+            expect(row?.classList.contains('gap-5')).toBe(true);
+            expect(row?.classList.contains('mb-5')).toBe(true);
+            expect(column?.classList.contains('gap-5')).toBe(true);
+        });
+
+        it('should apply the 720px max-width for a single-column layout (every row has exactly one column)', () => {
+            const singleColumnRow = MOCK_CONTENTTYPE_1_TAB.layout[0];
+            const singleColumnContentType: DotCMSContentType = {
+                ...MOCK_CONTENTTYPE_1_TAB,
+                layout: [
+                    { divider: singleColumnRow.divider, columns: [singleColumnRow.columns[0]] },
+                    { divider: singleColumnRow.divider, columns: [singleColumnRow.columns[1]] }
+                ]
+            };
+
+            dotContentTypeService.getContentTypeWithRender.mockReturnValue(
+                of(singleColumnContentType)
+            );
+            workflowActionsService.getDefaultActions.mockReturnValue(
+                of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+            );
+            workflowActionsService.getWorkFlowActions.mockReturnValue(
+                of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+            );
+            dotContentletService.canLock.mockReturnValue(
+                of({ canLock: true } as DotContentletCanLock)
+            );
+
+            store.initializeNewContent('TestMock');
+            spectator.detectChanges();
+
+            const container = spectator.query(byTestId('tab-layout-container'));
+            expect(container?.classList.contains('max-w-206')).toBe(true);
+            expect(container?.classList.contains('max-w-286')).toBe(false);
+            expect(container?.classList.contains('mx-auto')).toBe(true);
+
+            const rows = spectator.queryAll(byTestId('row'));
+            expect(rows.length).toBe(2);
+        });
     });
 
     describe('With multiple tabs and existing content', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -304,7 +304,7 @@ describe('DotFormComponent', () => {
 
     describe('Field padding and form max-width (issue #36615)', () => {
         // MOCK_CONTENTTYPE_1_TAB has a single row with two columns, i.e. a multi-column tab.
-        it('should apply the 1000px max-width and the 18px gap classes for a multi-column layout', () => {
+        it('should apply the wider max-width and gap classes for a multi-column layout', () => {
             dotContentTypeService.getContentTypeWithRender.mockReturnValue(
                 of(MOCK_CONTENTTYPE_1_TAB)
             );
@@ -333,7 +333,7 @@ describe('DotFormComponent', () => {
             expect(column?.classList.contains('gap-5')).toBe(true);
         });
 
-        it('should apply the 720px max-width for a single-column layout (every row has exactly one column)', () => {
+        it('should apply the narrower max-width for a single-column layout (every row has exactly one column)', () => {
             const singleColumnRow = MOCK_CONTENTTYPE_1_TAB.layout[0];
             const singleColumnContentType: DotCMSContentType = {
                 ...MOCK_CONTENTTYPE_1_TAB,

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -64,6 +64,7 @@ import {
     generatePreviewUrl,
     getFinalCastedValue,
     isFilteredType,
+    isSingleColumnLayout,
     processFieldValue
 } from '../../utils/functions.util';
 import { blockEditorRequiredValidator } from '../../utils/validators';
@@ -236,6 +237,14 @@ export class DotEditContentFormComponent implements OnInit {
      * @memberof DotEditContentFormComponent
      */
     $tabs = this.$store.tabs;
+
+    /**
+     * Determines whether a given tab's layout is single-column, so the template can pick the
+     * form's max-width per tab (720px vs 1000px).
+     *
+     * @memberof DotEditContentFormComponent
+     */
+    protected readonly isSingleColumnLayout = isSingleColumnLayout;
 
     /**
      * Context for the append template passed to TabViewInsertDirective.

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -22,6 +22,7 @@ import {
     getFieldVariablesParsed,
     getStoredUIState,
     isFilteredType,
+    isSingleColumnLayout,
     isValidJson,
     resolveLocker,
     sortLocalesTranslatedFirst,
@@ -1307,6 +1308,28 @@ describe('Utils Functions', () => {
                 const fieldType = field.fieldType as NON_FORM_CONTROL_FIELD_TYPES;
                 expect(nonFormControlFieldTypes.includes(fieldType)).toBe(false);
             });
+        });
+    });
+
+    describe('isSingleColumnLayout', () => {
+        const row = (columnCount: number) => ({
+            divider: {} as DotCMSContentTypeField,
+            columns: Array.from({ length: columnCount }, () => ({
+                columnDivider: {} as DotCMSContentTypeField,
+                fields: [] as DotCMSContentTypeField[]
+            }))
+        });
+
+        it('returns true when every row has exactly one column', () => {
+            expect(isSingleColumnLayout([row(1), row(1)])).toBe(true);
+        });
+
+        it('returns false when any row has more than one column', () => {
+            expect(isSingleColumnLayout([row(1), row(4)])).toBe(false);
+        });
+
+        it('returns false for an empty layout', () => {
+            expect(isSingleColumnLayout([])).toBe(false);
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -355,6 +355,17 @@ export const isFilteredType = (field: DotCMSContentTypeField): boolean => {
 };
 
 /**
+ * Determines whether a tab's layout is single-column, i.e. every row has exactly one column.
+ * Used to pick the form's max-width: single-column tabs cap at 720px, multi-column tabs cap
+ * at 1000px.
+ *
+ * @param {Tab['layout']} layout - The layout rows of a tab.
+ * @returns {boolean} True when every row has exactly one column.
+ */
+export const isSingleColumnLayout = (layout: Tab['layout']): boolean =>
+    layout.every((row) => row.columns.length === 1);
+
+/**
  * Transforms the form data by filtering out specific field types and organizing the content into tabs.
  *
  * @param formData - The original form data to be transformed.

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -357,13 +357,14 @@ export const isFilteredType = (field: DotCMSContentTypeField): boolean => {
 /**
  * Determines whether a tab's layout is single-column, i.e. every row has exactly one column.
  * Used to pick the form's max-width: single-column tabs cap at 720px, multi-column tabs cap
- * at 1000px.
+ * at 1000px. An empty layout (e.g. an empty tab) is treated as multi-column since `every`
+ * would otherwise be vacuously true and there's nothing to render anyway.
  *
  * @param {Tab['layout']} layout - The layout rows of a tab.
  * @returns {boolean} True when every row has exactly one column.
  */
 export const isSingleColumnLayout = (layout: Tab['layout']): boolean =>
-    layout.every((row) => row.columns.length === 1);
+    layout.length > 0 && layout.every((row) => row.columns.length === 1);
 
 /**
  * Transforms the form data by filtering out specific field types and organizing the content into tabs.


### PR DESCRIPTION
## Summary
- Adds consistent 18px gaps (row and column) between fields in the Edit Content form layout.
- Adds a max-width cap on the form: single-column layouts cap narrower than multi-column layouts, matching the design spec (720px / 1000px).
- The single-column vs multi-column decision is computed per tab from the content type's own field layout, so it applies consistently across content types with different field/column configurations.

## Acceptance criteria
- [x] In a single-column layout, the vertical spacing between consecutive fields is 18px
- [x] In the 4-column grid, the row gap between fields is 18px
- [x] In the 4-column grid, the column gap between fields is 18px
- [x] A single-column form is constrained to a max width
- [x] In a single-column layout, a lone field fills the full form width (up to the max-width cap)
- [x] A multi-column form is constrained to a wider max width
- [x] The padding and max-width rules apply consistently across content types with different field/column configurations

Closes #36615

IMAGES

SINGLE COLUMN

<img width="1725" height="896" alt="Screenshot 2026-07-20 at 4 18 59 PM" src="https://github.com/user-attachments/assets/cf711fc5-9505-4906-b41f-051a9e49da0f" />


MULTIPLE COLUMNS

<img width="1724" height="888" alt="Screenshot 2026-07-20 at 4 20 08 PM" src="https://github.com/user-attachments/assets/33c800e8-0fd3-4637-b08f-980cee206d94" />

## Test plan
- [x] `pnpm nx test edit-content --testPathPatterns=dot-edit-content-form.component.spec.ts` — 65 passed, 1 pre-existing skip
- [x] `pnpm nx lint edit-content` — 0 errors (3 pre-existing warnings, unrelated files)
- [ ] Manual check in the browser: open Edit Content for a single-column content type and a multi-column one, confirm spacing/width visually

## Changed files
- `libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html`
- `libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts`
- `libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts`
- `libs/edit-content/src/lib/utils/functions.util.ts`

## Visual Changes
This PR changes rendered layout (spacing + max-width) in the Edit Content form. Screenshots pending.

This PR fixes: #36615