### PR TITLE
ci: repoint sdk-ai generate-spec default host to healthy headless instance

### DIFF
--- a/core-web/libs/sdk/ai/scripts/generate-spec.ts
+++ b/core-web/libs/sdk/ai/scripts/generate-spec.ts
@@ -58,7 +58,7 @@ const EXCLUDED_PATTERNS = [
 ];
 
 const DEFAULT_SPEC_PATH = '/api/openapi.json';
-const DEFAULT_SPEC_URL = `https://corpsites-headless.dotcms.cloud${DEFAULT_SPEC_PATH}`;
+const DEFAULT_SPEC_URL = `https://dotcms-corp-headless-prod.dotcms.dev${DEFAULT_SPEC_PATH}`;
 
 /**
  * Matches a path against a pattern. Pattern syntax:


### PR DESCRIPTION
### Proposed Changes

Fixes #36650 — a **repo-wide CI blocker**.

The default OpenAPI spec host in `core-web/libs/sdk/ai/scripts/generate-spec.ts`, `corpsites-headless.dotcms.cloud`, now returns **HTTP 503**. That fails the `sdk-ai:generate-spec` Nx task, which bails the whole `dotcms-core-web` build with exit 130, failing **Initial Artifact Build** and gating every downstream test suite (MainSuites, Postman, E2E) on **all** PRs.

This one-line change repoints `DEFAULT_SPEC_URL` to the current healthy headless instance, `https://dotcms-corp-headless-prod.dotcms.dev/api/openapi.json`.

### Verification

| Host | HTTP | Spec |
|---|---|---|
| `corpsites-headless.dotcms.cloud` (old) | **503** | — |
| `dotcms-corp-headless-prod.dotcms.dev` (new) | **200** | OpenAPI 3.0.1, "dotCMS REST API" v3, 579 paths |

Ran `generate-spec` locally against the new host: produced an equivalent **168-path** filtered spec — same count as the previous instance, no content regression. The generated `libs/sdk/ai/src/generated/spec.json` is gitignored and regenerated each build, so there is no committed-artifact change.

### Follow-up (out of scope)

A single external host outage should not be able to red-fail all CI. Worth hardening `generate-spec` to fall back to a committed/cached spec or tolerate a fetch failure — noted in #36650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)