### PR TITLE
fix(ui): Escape key on content edit dialog freezes tab (#35063)

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-iframe-dialog/dot-iframe-dialog.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-iframe-dialog/dot-iframe-dialog.component.spec.ts
@@ -203,9 +203,14 @@ describe('DotIframeDialogComponent', () => {
                         });
                     });
 
-                    it('should call close method on dot-dialog on dot-iframe escape key', () => {
+                    it('should run the same close/teardown as the X button on Escape key', () => {
                         dotIframeDe?.triggerEventHandler('keyWasDown', { key: 'Escape' });
                         expect(component.keyWasDown.emit).toHaveBeenCalledTimes(1);
+                        // Escape must funnel through onDialogHide() exactly like the X button
+                        expect(component.url).toBe(null);
+                        expect(component.show).toBe(false);
+                        expect(component.header).toBe('');
+                        expect(component.shutdown.emit).toHaveBeenCalledTimes(1);
                     });
                 });
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-iframe-dialog/dot-iframe-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-iframe-dialog/dot-iframe-dialog.component.ts
@@ -67,7 +67,7 @@ export class DotIframeDialogComponent implements OnChanges {
         this.keyWasDown.emit($event);
 
         if ($event.key === 'Escape') {
-            this.show = false;
+            this.onDialogHide();
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Fixes #35063 — pressing **Escape** to close the content edit dialog froze the browser tab and blocked opening any other contentlet, while the **X button** worked fine.

### Root cause
`DotIframeDialogComponent.onKeyDown()` handled Escape by setting `this.show = false` directly. Because the dialog's visibility is bound as an input (`[visible]="show"`), pushing `false` down as an input hides the dialog visually but never fires PrimeNG's `(visibleChange)` output — the only thing wired to `onDialogHide()`.

As a result the Escape path skipped the entire teardown that the X button gets:
- `url` / `header` were never reset
- `shutdown` was never emitted, so `DotContentletWrapperComponent.onClose()` (which calls `dotContentletEditorService.clear()`, restores the title, and navigates back) never ran

The editor was left in a stuck "open" state, which is why reopening any contentlet did nothing and the tab eventually became unresponsive.

### Fix
The Escape branch now calls `this.onDialogHide()`, routing Escape through the exact same teardown path as the X button (`url`/`header` reset + single `shutdown` emit) — satisfying the acceptance criterion that *"using the Escape key works like clicking the X on the content edit screen."*

### Files changed
- `dot-iframe-dialog.component.ts` — Escape calls `onDialogHide()` instead of mutating `show`
- `dot-iframe-dialog.component.spec.ts` — strengthened the existing Escape test (which asserted nothing about the close) to verify `shutdown` is emitted once and `url`/`show`/`header` are reset

## Checklist
- [x] Unit tests pass — `pnpm nx test dotcms-ui --testPathPatterns=dot-iframe-dialog` (15/15)
- [x] Manually verified in a locally built Docker image: Escape closes the editor cleanly with no freeze, and another contentlet can be opened immediately afterward

## How to test
1. Content portlet → open a **Blog** contentlet
2. Press **Escape**
3. Editor closes cleanly (like the X button); open another contentlet — it works, no frozen tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35063