### PR TITLE
fix(uve): prevent infinite loop in untranslated language dialog

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2228,6 +2228,47 @@ describe('EditEmaEditorComponent', () => {
                     // NOT to id=2 (which would cause an infinite loop)
                     expect(pageLoadSpy).toHaveBeenCalledWith({ language_id: '1' });
                 });
+
+                it('should NOT call pageLoad when no translated language exists and user rejects', () => {
+                    const confirmationService = spectator.inject(ConfirmationService, true);
+                    const confirmSpy = jest.spyOn(confirmationService, 'confirm');
+
+                    store.pageLoad({
+                        clientHost: 'http://localhost:3000',
+                        url: 'index',
+                        language_id: '2',
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
+                    });
+
+                    spectator.flushEffects();
+                    spectator.detectChanges();
+
+                    expect(confirmSpy).toHaveBeenCalled();
+
+                    // Patch pageLanguages to only contain untranslated languages — no safe fallback.
+                    // #goBackToCurrentLanguage() must bail (no-op) to avoid looping.
+                    // protectedState:false on the root store makes patchState available in tests.
+                    patchState(store, {
+                        pageLanguages: [
+                            {
+                                id: 2,
+                                languageCode: 'es',
+                                countryCode: 'ES',
+                                language: 'Spanish',
+                                country: 'España',
+                                translated: false
+                            }
+                        ]
+                    });
+
+                    const pageLoadSpy = jest.spyOn(store, 'pageLoad');
+
+                    const rejectCallback = (confirmSpy.mock.calls[0][0] as Confirmation).reject;
+                    rejectCallback?.();
+
+                    // No translated language → bail without reloading to avoid any loop
+                    expect(pageLoadSpy).not.toHaveBeenCalled();
+                });
             });
 
             describe('handleOpenFullEditor', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2174,6 +2174,62 @@ describe('EditEmaEditorComponent', () => {
                 });
             });
 
+            describe('$translatePageEffect — dialog loop prevention', () => {
+                it('should NOT show the translation dialog when uveStatus is LOADING', () => {
+                    const confirmSpy = jest.spyOn(
+                        spectator.inject(ConfirmationService, true),
+                        'confirm'
+                    );
+
+                    // Load with an untranslated language (language_id=2 returns viewAs.language.id=2,
+                    // and mockLanguageArray has id:2 with translated:false)
+                    store.pageLoad({
+                        clientHost: 'http://localhost:3000',
+                        url: 'index',
+                        language_id: '2',
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
+                    });
+
+                    // Immediately force LOADING status before effects flush — simulates in-flight state
+                    patchState(store, { uveStatus: UVE_STATUS.LOADING });
+                    spectator.flushEffects();
+                    spectator.detectChanges();
+
+                    expect(confirmSpy).not.toHaveBeenCalled();
+                });
+
+                it('should navigate to a translated language when the user rejects creating a new translation', () => {
+                    const confirmationService = spectator.inject(ConfirmationService, true);
+                    // Set up the spy BEFORE loading so we capture the confirm call made by the effect
+                    const confirmSpy = jest.spyOn(confirmationService, 'confirm');
+
+                    // language_id=2 → viewAs.language.id=2, pageLanguages has id:2 translated:false
+                    store.pageLoad({
+                        clientHost: 'http://localhost:3000',
+                        url: 'index',
+                        language_id: '2',
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
+                    });
+
+                    spectator.flushEffects();
+                    spectator.detectChanges();
+
+                    // The effect should have shown the dialog because currentLanguage.translated=false
+                    expect(confirmSpy).toHaveBeenCalled();
+
+                    // Spy on pageLoad AFTER the initial load to track only the reject navigation
+                    const pageLoadSpy = jest.spyOn(store, 'pageLoad');
+
+                    // Simulate user clicking "No"
+                    const rejectCallback = (confirmSpy.mock.calls[0][0] as Confirmation).reject;
+                    rejectCallback?.();
+
+                    // Must navigate to language id=1 (the only translated language in mockLanguageArray),
+                    // NOT to id=2 (which would cause an infinite loop)
+                    expect(pageLoadSpy).toHaveBeenCalledWith({ language_id: '1' });
+                });
+            });
+
             describe('handleOpenFullEditor', () => {
                 afterEach(() => {
                     jest.restoreAllMocks();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1729,15 +1729,15 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
      * @memberof DotEmaShellComponent
      */
     #goBackToCurrentLanguage(): void {
-        const pageLanguages = this.uveStore.pageLanguages();
         // Must not navigate back to the current (untranslated) language — doing so would
-        // reload the same state and re-trigger the dialog. Navigate to the default translated
-        // language instead, falling back to the first translated language if needed.
-        const targetLanguage =
-            pageLanguages.find((l) => l.defaultLanguage && l.translated) ??
-            pageLanguages.find((l) => l.translated);
-        const targetLanguageId = targetLanguage?.id?.toString() ?? '1';
-        this.uveStore.pageLoad({ language_id: targetLanguageId });
+        // reload the same state and re-trigger the dialog.
+        // Note: the /api/v1/page/{id}/languages endpoint does not include defaultLanguage in
+        // its response (Language.toMap() omits it), so we simply take the first translated
+        // language. If none exists, bail without reloading to avoid any loop.
+        const targetLanguage = this.uveStore.pageLanguages().find((l) => l.translated);
+        if (targetLanguage) {
+            this.uveStore.pageLoad({ language_id: targetLanguage.id.toString() });
+        }
     }
 
     #clientPayload() {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -419,9 +419,14 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
 
     readonly $translatePageEffect = effect(() => {
         const { page, currentLanguage } = this.uveStore.pageTranslateProps();
+        const status = this.uveStore.uveStatus();
 
-        if (currentLanguage && !currentLanguage?.translated) {
-            this.createNewTranslation(currentLanguage, page);
+        // Guard: only act on a freshly-loaded page. Without the LOADED check the effect
+        // could fire while a previous pageLoad is still in-flight (stale translated:false data).
+        // untracked: confirmationService.confirm reads PrimeNG-internal signals; tracking them
+        // would cause the effect to re-fire every time the dialog opens/closes.
+        if (status === UVE_STATUS.LOADED && currentLanguage && !currentLanguage.translated) {
+            untracked(() => this.createNewTranslation(currentLanguage, page));
         }
     });
 
@@ -1724,8 +1729,15 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
      * @memberof DotEmaShellComponent
      */
     #goBackToCurrentLanguage(): void {
-        const currentLanguageId = this.uveStore.pageLanguage()?.id?.toString() ?? '1';
-        this.uveStore.pageLoad({ language_id: currentLanguageId });
+        const pageLanguages = this.uveStore.pageLanguages();
+        // Must not navigate back to the current (untranslated) language — doing so would
+        // reload the same state and re-trigger the dialog. Navigate to the default translated
+        // language instead, falling back to the first translated language if needed.
+        const targetLanguage =
+            pageLanguages.find((l) => l.defaultLanguage && l.translated) ??
+            pageLanguages.find((l) => l.translated);
+        const targetLanguageId = targetLanguage?.id?.toString() ?? '1';
+        this.uveStore.pageLoad({ language_id: targetLanguageId });
     }
 
     #clientPayload() {


### PR DESCRIPTION
## Summary

Fixes #34518

When a page is opened with a `language_id` URL param pointing to a language that has no translation, `$translatePageEffect` shows the "Create New Language Version?" dialog. Clicking **"No"** triggered `#goBackToCurrentLanguage()`, which read `pageLanguage()` — but `pageLanguage()` returns the **untranslated** language the page was just loaded with. This caused `pageLoad()` to reload the same untranslated language, re-triggering the effect in an infinite loop.

### Changes

- **`#goBackToCurrentLanguage()`** — now reads `pageLanguages()` and navigates to the **default translated language** (or first translated language) instead of the current untranslated one. This is the primary loop-breaker.
- **`$translatePageEffect`** — added `UVE_STATUS.LOADED` guard (prevents the dialog firing while a page load is in-flight) and wrapped the `createNewTranslation` call in `untracked()` (prevents PrimeNG internal confirmation signals from being tracked by the effect, which caused spurious re-fires on dialog open/close).

### Before / After

| Action | Before | After |
|---|---|---|
| Open page with untranslated `language_id` in URL → click "No" | Dialog reappears immediately in an infinite loop | Dialog dismisses; navigates back to the default language |

## Test plan

- [ ] Open a page that only exists in English
- [ ] Change URL param to `language_id` of an untranslated language
- [ ] When "Create New Language Version?" dialog appears, click **No**
- [ ] Verify the dialog dismisses and you are returned to the default language — no loop
- [ ] Verify clicking **Yes** still correctly opens the translation workflow
- [ ] `node_modules/.bin/jest libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts --config=libs/portlets/edit-ema/portlet/jest.config.ts --no-coverage` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34518