### PR TITLE
feat(contenttype): add optional 'system' query param to exclude system types (#36072)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPI.java
@@ -509,7 +509,11 @@ public interface ContentTypeAPI {
    *                            passed by param. e.g:
    *                            offset = 0 -> start from the first record
    *                            offset = 10 -> start from the #11 record
-   * @param requestedContentTypes The Content Types that are explicitly requested to be included.
+   * @param requestedContentTypes The "ensure" set: Velocity Variable Names (or keys) of Content
+   *                            Types that must always be included in the result, regardless of the
+   *                            {@code condition} (name search) and any Site filter. This is not a
+   *                            Site filter -- it guarantees inclusion. Pass {@code null} or an empty
+   *                            list for no forced inclusions.
    * @return List of Content Types Objects
    * @throws DotDataException Error occurred when performing the action.
    */
@@ -527,7 +531,11 @@ public interface ContentTypeAPI {
    * @param limit                Amount of results
    * @param offset               Start position of the resulting list
    * @param hostId               hostId where the content type lives, pass null to bring from all sites.
-   * @param requestedContentTypes The Content Types that are explicitly requested to be included.
+   * @param requestedContentTypes The "ensure" set: Velocity Variable Names (or keys) of Content
+   *                            Types that must always be included in the result, regardless of the
+   *                            {@code condition} (name search) and any Site filter. This is not a
+   *                            Site filter -- it guarantees inclusion. Pass {@code null} or an empty
+   *                            list for no forced inclusions.
    * @param includeSystemTypes   When {@code false}, excludes system Content Types via a dedicated
    *                             {@code and system = false} predicate. When {@code true}, behavior
    *                             is unchanged.
@@ -581,8 +589,10 @@ public interface ContentTypeAPI {
    *                  by param. e.g:
    *                  offset = 0 -> start from the first record
    *                  offset = 10 -> start from the #11 record
-   * @param includeContentTypeIds
-   *                  The Content Types that are explicitly required to be included.
+   * @param includeContentTypeIds The "ensure" set: Velocity Variable Names (or keys) of Content
+   *                  Types that must always be included in the result, regardless of the
+   *                  {@code condition} (name search) and the Site filter. This is not a Site filter
+   *                  -- it guarantees inclusion. Pass {@code null} or an empty list for none.
    *
    * @return The list of {@link ContentType} objects matching the specified search criteria.
    *
@@ -603,7 +613,11 @@ public interface ContentTypeAPI {
    * @param orderBy              The order-by clause, which is internally sanitized by this Factory.
    * @param limit                The maximum number of returned items in the result set.
    * @param offset               Start position of the result list.
-   * @param includeContentTypeIds The Content Types that are explicitly required to be included.
+   * @param includeContentTypeIds The "ensure" set: Velocity Variable Names (or keys) of Content
+   *                             Types that must always be included in the result, regardless of the
+   *                             {@code condition} (name search) and the Site filter. This is not a
+   *                             Site filter -- it guarantees inclusion. Pass {@code null} or empty
+   *                             for none.
    * @param includeSystemTypes   When {@code false}, excludes system Content Types via a dedicated
    *                             {@code and system = false} predicate. When {@code true}, behavior
    *                             is unchanged.

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPI.java
@@ -245,6 +245,27 @@ public interface ContentTypeAPI {
   int countForSites(final String condition, final BaseContentType base, final List<String> siteIds) throws DotDataException;
 
   /**
+   * Counts the amount of Content Types in the DB filtered by the given condition, the Base
+   * Content Type, and the specific Sites they live in, optionally excluding system Content Types.
+   *
+   * @param condition          Condition that the Content Type needs to meet.
+   * @param base               The {@link BaseContentType} that must be searched for. If you need
+   *                           to get all types, use {@link BaseContentType#ANY}.
+   * @param siteIds            The list of Site IDs or Site Keys -- aka, site names -- where the
+   *                           Content Types live in.
+   * @param includeSystemTypes When {@code false}, system Content Types are excluded from the count
+   *                           (adds an {@code and system = false} predicate). When {@code true},
+   *                           behavior is unchanged.
+   *
+   * @return The total number of Content Types that meet the search criteria and live in the
+   * specified Sites.
+   *
+   * @throws DotDataException An error occurred when retrieving information from the database.
+   */
+  int countForSites(final String condition, final BaseContentType base, final List<String> siteIds,
+          final boolean includeSystemTypes) throws DotDataException;
+
+  /**
    * Counts the amount of Content Types in the DB filtered by the given condition and the BaseContentType.
    *
    * @param condition Condition that the Content Type needs to meet
@@ -497,6 +518,28 @@ public interface ContentTypeAPI {
           throws DotDataException;
 
   /**
+   * Returns a List of content type based on the given condition and the Base Content Type,
+   * optionally excluding system Content Types.
+   *
+   * @param condition            Condition that the Content Type needs to meet
+   * @param base                 Base Content Type that wants to be searched
+   * @param orderBy              Specifies an order criteria for the results
+   * @param limit                Amount of results
+   * @param offset               Start position of the resulting list
+   * @param hostId               hostId where the content type lives, pass null to bring from all sites.
+   * @param requestedContentTypes The Content Types that are explicitly requested to be included.
+   * @param includeSystemTypes   When {@code false}, excludes system Content Types via a dedicated
+   *                             {@code and system = false} predicate. When {@code true}, behavior
+   *                             is unchanged.
+   * @return List of Content Types Objects
+   * @throws DotDataException Error occurred when performing the action.
+   */
+  List<ContentType> search(String condition, BaseContentType base, String orderBy, int limit,
+          int offset, String hostId, List<String> requestedContentTypes,
+          boolean includeSystemTypes)
+          throws DotDataException;
+
+  /**
    * Returns a list of Content Types based on the specified list of search criteria. In
    * particular, this method allows you to search for Content Types in a specific list of Sites
    * only, not in all the dotCMS content repository.
@@ -551,6 +594,30 @@ public interface ContentTypeAPI {
           throws DotDataException;
 
   /**
+   * Returns a list of Content Types living in the specified list of Sites, optionally excluding
+   * system Content Types.
+   *
+   * @param sites                The list of one or more Sites to search for Content Types.
+   * @param condition            Allows you to add more conditions to the query via SQL code.
+   * @param base                 The {@link BaseContentType} to search for.
+   * @param orderBy              The order-by clause, which is internally sanitized by this Factory.
+   * @param limit                The maximum number of returned items in the result set.
+   * @param offset               Start position of the result list.
+   * @param includeContentTypeIds The Content Types that are explicitly required to be included.
+   * @param includeSystemTypes   When {@code false}, excludes system Content Types via a dedicated
+   *                             {@code and system = false} predicate. When {@code true}, behavior
+   *                             is unchanged.
+   *
+   * @return The list of {@link ContentType} objects matching the specified search criteria.
+   *
+   * @throws DotDataException An error occurred when retrieving information from the database.
+   */
+  List<ContentType> search(final List<String> sites, final String condition,
+          final BaseContentType base, final String orderBy, final int limit, final int offset,
+          List<String> includeContentTypeIds, boolean includeSystemTypes)
+          throws DotDataException;
+
+  /**
    * Searches for Content Types matching multiple base types in a single efficient database query.
    * This method uses a UNION query to combine results from multiple base types, sort them,
    * and paginate efficiently at the database level.
@@ -575,6 +642,34 @@ public interface ContentTypeAPI {
   List<ContentType> searchMultipleTypes(final String condition, final java.util.Collection<BaseContentType> types,
                                         final String orderBy, final int limit, final int offset,
                                         final String siteId, final List<String> requestedContentTypes)
+          throws DotDataException;
+
+  /**
+   * Searches for Content Types matching multiple base types in a single efficient database query,
+   * optionally excluding system Content Types.
+   *
+   * @param condition          Filter condition that Content Types must meet.
+   * @param types              Collection of Base Content Types to search for (must not be empty).
+   * @param orderBy            The order-by clause, which is internally sanitized by the API.
+   * @param limit              Maximum number of items to return in the result set. Use -1 for no
+   *                           limit (up to 10000).
+   * @param offset             The page offset in the result set.
+   * @param siteId             The ID of the Site that Content Types live in. Can be null or empty
+   *                           for all sites.
+   * @param requestedContentTypes Optional list of specific content type variables to ensure are
+   *                           included.
+   * @param includeSystemTypes When {@code false}, excludes system Content Types via a dedicated
+   *                           {@code and system = false} predicate. When {@code true}, behavior is
+   *                           unchanged.
+   *
+   * @return The list of {@link ContentType} objects matching the criteria, sorted and paginated.
+   *
+   * @throws DotDataException An error occurred when retrieving information from the database.
+   */
+  List<ContentType> searchMultipleTypes(final String condition, final java.util.Collection<BaseContentType> types,
+                                        final String orderBy, final int limit, final int offset,
+                                        final String siteId, final List<String> requestedContentTypes,
+                                        final boolean includeSystemTypes)
           throws DotDataException;
 
   /**

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
@@ -474,13 +474,19 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
     return countForSites(condition, base, UtilMethods.isSet(siteId) ? List.of(siteId) : null);
   }
 
-  @CloseDBIfOpened
   @Override
   public int countForSites(final String condition, final BaseContentType base, final List<String> siteIds) throws DotDataException {
+    return countForSites(condition, base, siteIds, true);
+  }
+
+  @CloseDBIfOpened
+  @Override
+  public int countForSites(final String condition, final BaseContentType base, final List<String> siteIds,
+          final boolean includeSystemTypes) throws DotDataException {
     try {
       final List<String> resolvedSiteIds = HostUtil.resolveSiteIds(siteIds, this.user, this.respectFrontendRoles);
       return this.perms.filterCollection(this.contentTypeFactory.search(resolvedSiteIds,
-              condition, base.getType(), ContentTypeFactory.MOD_DATE_COLUMN, -1, 0),
+              condition, base.getType(), ContentTypeFactory.MOD_DATE_COLUMN, -1, 0, includeSystemTypes),
               PermissionAPI.PERMISSION_READ, this.respectFrontendRoles, this.user).size();
     } catch (final DotSecurityException e) {
       Logger.error(this, String.format("An error occurred when getting the Content Type count for Sites " +
@@ -820,11 +826,18 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
       return search(sites, condition, base, orderBy, limit, offset, null);
   }
 
-  @CloseDBIfOpened
   @Override
   public List<ContentType> search(final List<String> sites, final String condition,
           final BaseContentType base, final String orderBy, final int limit, final int offset,
           final List<String> requestedContentTypes) throws DotDataException {
+      return search(sites, condition, base, orderBy, limit, offset, requestedContentTypes, true);
+  }
+
+  @CloseDBIfOpened
+  @Override
+  public List<ContentType> search(final List<String> sites, final String condition,
+          final BaseContentType base, final String orderBy, final int limit, final int offset,
+          final List<String> requestedContentTypes, final boolean includeSystemTypes) throws DotDataException {
 
       final List<ContentType> returnTypes = new ArrayList<>();
       final Set<String> includedIds = new HashSet<>();
@@ -879,7 +892,7 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
 
           // Perform paginated search — ensure items excluded via includedIds, offset corrected
           final List<ContentType> searchResults = performSearch(resolvedSiteIds, condition, base,
-                  orderBy, remainingLimit, adjustedOffset, includedIds);
+                  orderBy, remainingLimit, adjustedOffset, includedIds, includeSystemTypes);
 
           returnTypes.addAll(searchResults);
 
@@ -907,16 +920,30 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
    * {@inheritDoc}
    */
   @Override
-  @WrapInTransaction
   public List<ContentType> searchMultipleTypes(final String condition,
                                                 final java.util.Collection<BaseContentType> types,
                                                 final String orderBy, final int limit, final int offset,
                                                 final String siteId, final List<String> requestedContentTypes)
           throws DotDataException {
+      return searchMultipleTypes(condition, types, orderBy, limit, offset, siteId,
+              requestedContentTypes, true);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  @WrapInTransaction
+  public List<ContentType> searchMultipleTypes(final String condition,
+                                                final java.util.Collection<BaseContentType> types,
+                                                final String orderBy, final int limit, final int offset,
+                                                final String siteId, final List<String> requestedContentTypes,
+                                                final boolean includeSystemTypes)
+          throws DotDataException {
 
       // Delegate directly to the factory method which performs efficient UNION query
       final List<ContentType> allResults = this.contentTypeFactory.searchMultipleTypes(
-              condition, types, orderBy, limit, offset, siteId, requestedContentTypes);
+              condition, types, orderBy, limit, offset, siteId, requestedContentTypes, includeSystemTypes);
 
       // Filter by permissions
       try {
@@ -932,7 +959,8 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
 
   private List<ContentType> performSearch(final List<String> resolvedSiteIds,
           final String condition, final BaseContentType base, final String orderBy,
-          final int limit, final int offset, final Set<String> includedIds)
+          final int limit, final int offset, final Set<String> includedIds,
+          final boolean includeSystemTypes)
           throws DotDataException {
 
       final List<ContentType> returnTypes = new ArrayList<>();
@@ -943,7 +971,7 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
           int currentLimit = (remainingLimit < 0) ? -1 : remainingLimit;
 
           final List<ContentType> rawContentTypes = this.contentTypeFactory.search(resolvedSiteIds,
-                  condition, base.getType(), orderBy, currentLimit, rollingOffset);
+                  condition, base.getType(), orderBy, currentLimit, rollingOffset, includeSystemTypes);
 
           if (rawContentTypes.isEmpty()) {
               break;
@@ -998,8 +1026,17 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
           final String orderBy, final int limit, final int offset, final String siteId,
           final List<String> requestedContentTypes)
           throws DotDataException {
+      return search(condition, base, orderBy, limit, offset, siteId, requestedContentTypes, true);
+  }
+
+  @CloseDBIfOpened
+  @Override
+  public List<ContentType> search(final String condition, final BaseContentType base,
+          final String orderBy, final int limit, final int offset, final String siteId,
+          final List<String> requestedContentTypes, final boolean includeSystemTypes)
+          throws DotDataException {
       return search(UtilMethods.isSet(siteId) ? List.of(siteId) : List.of(), condition, base,
-              orderBy, limit, offset, requestedContentTypes);
+              orderBy, limit, offset, requestedContentTypes, includeSystemTypes);
   }
 
   @CloseDBIfOpened

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactory.java
@@ -125,6 +125,26 @@ public interface ContentTypeFactory {
 	List<ContentType> search(final List<String> sites, final String search, final int type, final String orderBy, final int limit, final int offset) throws DotDataException;
 
 	/**
+	 * Returns a list of Content Types living in the specified list of Sites, optionally excluding
+	 * system Content Types.
+	 *
+	 * @param sites              The list of one or more Site IDs to search for Content Types.
+	 * @param search             Allows you to add more conditions to the query via SQL code.
+	 * @param type               The Base Content Type to search for.
+	 * @param orderBy            The order-by clause, which is internally sanitized by this Factory.
+	 * @param limit              The maximum number of returned items in the result set.
+	 * @param offset             The requested page number of the result set.
+	 * @param includeSystemTypes When {@code false}, excludes system Content Types via a dedicated
+	 *                           {@code and structure.system = false} predicate. When {@code true},
+	 *                           behavior is unchanged.
+	 *
+	 * @return The list of {@link ContentType} objects matching the specified search criteria.
+	 *
+	 * @throws DotDataException An error occurred when retrieving information from the database.
+	 */
+	List<ContentType> search(final List<String> sites, final String search, final int type, final String orderBy, final int limit, final int offset, final boolean includeSystemTypes) throws DotDataException;
+
+	/**
 	 * Returns a list of Content Types matching multiple base types in a single efficient query.
 	 * This method uses a UNION query at the database level to combine results from multiple
 	 * base types, sort them, and paginate efficiently.
@@ -150,6 +170,31 @@ public interface ContentTypeFactory {
 	List<ContentType> searchMultipleTypes(final String search, final Collection<BaseContentType> types,
 										   final String orderBy, final int limit, final int offset,
 										   final String siteId, final List<String> requestedContentTypes)
+			throws DotDataException;
+
+	/**
+	 * Returns a list of Content Types matching multiple base types in a single efficient query,
+	 * optionally excluding system Content Types.
+	 *
+	 * @param search             Allows you to add more conditions to the query via SQL code.
+	 * @param types              The collection of Base Content Types to search for (must not be empty).
+	 * @param orderBy            The order-by clause, which is internally sanitized by this Factory.
+	 * @param limit              The maximum number of returned items in the result set. Use -1 for no limit.
+	 * @param offset             The requested page number of the result set.
+	 * @param siteId             The ID of the Site that the Content Types live in. Can be null or empty for all sites.
+	 * @param requestedContentTypes Optional list of specific content type variables to ensure are included.
+	 * @param includeSystemTypes When {@code false}, excludes system Content Types via a dedicated
+	 *                           {@code and structure.system = false} predicate. When {@code true},
+	 *                           behavior is unchanged.
+	 *
+	 * @return The list of {@link ContentType} objects matching the specified search criteria.
+	 *
+	 * @throws DotDataException An error occurred when retrieving information from the database.
+	 */
+	List<ContentType> searchMultipleTypes(final String search, final Collection<BaseContentType> types,
+										   final String orderBy, final int limit, final int offset,
+										   final String siteId, final List<String> requestedContentTypes,
+										   final boolean includeSystemTypes)
 			throws DotDataException;
 
 	int searchCount(String search, BaseContentType baseType) throws DotDataException;

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
@@ -794,7 +794,7 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
     // Dedicated system predicate: excludes system Content Types when requested, independent of
     // the search/condition string so it combines (ANDs) with the name filter.
     if (!includeSystemTypes) {
-        sqlBuilder.append(" AND structure.system = ? ");
+        sqlBuilder.append(" AND coalesce(structure.system, false) = ? ");
     }
 
     // SECURITY: Add sites filter using parameterized LIKE clauses for substring matching
@@ -1573,7 +1573,7 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
                 // Dedicated system predicate: excludes system Content Types when requested,
                 // independent of the search/condition string so it combines with the name filter.
                 if (!includeSystemTypes) {
-                    unionQuery.append(" AND structure.system = ? ");
+                    unionQuery.append(" AND coalesce(structure.system, false) = ? ");
                     parameters.add(false);
                 }
 

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeFactoryImpl.java
@@ -226,7 +226,7 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
   @Override
   public List<ContentType> findUrlMapped() throws DotDataException {
       try {
-          return dbSearch(" url_map_pattern is not null ", BaseContentType.ANY.getType(), "mod_date", -1, 0, null);
+          return dbSearch(" url_map_pattern is not null ", BaseContentType.ANY.getType(), "mod_date", -1, 0, null, true);
       } catch (DotSecurityException e) {
           throw new DotDataException("Security validation failed: " + e.getMessage(), e);
       }
@@ -258,8 +258,8 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
             throws DotDataException {
         try {
             return UtilMethods.isSet(siteId)
-                    ? dbSearch(search, baseType, orderBy, limit, offset, List.of(siteId))
-                    : dbSearch(search, baseType,orderBy, limit, offset, null);
+                    ? dbSearch(search, baseType, orderBy, limit, offset, List.of(siteId), true)
+                    : dbSearch(search, baseType,orderBy, limit, offset, null, true);
         } catch (DotSecurityException e) {
             throw new DotDataException("Security validation failed: " + e.getMessage(), e);
         }
@@ -299,8 +299,15 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
   @Override
   public List<ContentType> search(final List<String> sites, final String search, final int type,
                                   final String orderBy, final int limit, final int offset) throws DotDataException {
+      return search(sites, search, type, orderBy, limit, offset, true);
+  }
+
+  @Override
+  public List<ContentType> search(final List<String> sites, final String search, final int type,
+                                  final String orderBy, final int limit, final int offset,
+                                  final boolean includeSystemTypes) throws DotDataException {
       try {
-          return dbSearch(search, type, orderBy, limit, offset, sites);
+          return dbSearch(search, type, orderBy, limit, offset, sites, includeSystemTypes);
       } catch (DotSecurityException e) {
           throw new DotDataException("Security validation failed: " + e.getMessage(), e);
       }
@@ -730,6 +737,9 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
  * @param offset   The requested page number of the result set, for pagination purposes.
  * @param siteIds  The list of one or more Sites to search for Content Types. You can pass down
  *                 their Identifiers or Site Keys.
+ * @param includeSystemTypes When {@code false}, excludes system Content Types via a dedicated
+ *                 {@code and structure.system = false} predicate. When {@code true}, behavior is
+ *                 unchanged.
  *
  * @return The list of {@link ContentType} objects matching the specified search criteria.
  *
@@ -737,7 +747,8 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
  */
  @CloseDBIfOpened
  private List<ContentType> dbSearch(final String search, final int baseType, String orderBy,
-                                    int limit, final int offset, final List<String> siteIds) throws DotDataException, DotSecurityException {
+                                    int limit, final int offset, final List<String> siteIds,
+                                    final boolean includeSystemTypes) throws DotDataException, DotSecurityException {
     if (limit == 0) {
         throw new DotDataException("The 'limit' param must be greater than 0");
     }
@@ -779,7 +790,13 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
         sqlBuilder.append(" AND structuretype <> ").append(BaseContentType.FORM.getType())
                   .append(" AND structuretype <> ").append(BaseContentType.PERSONA.getType()).append(" ");
     }
-    
+
+    // Dedicated system predicate: excludes system Content Types when requested, independent of
+    // the search/condition string so it combines (ANDs) with the name filter.
+    if (!includeSystemTypes) {
+        sqlBuilder.append(" AND structure.system = ? ");
+    }
+
     // SECURITY: Add sites filter using parameterized LIKE clauses for substring matching
     if (!validatedSites.isEmpty()) {
         // Build multiple OR conditions with proper parameterization and escaping
@@ -807,7 +824,12 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
     
     // Add common search parameters using helper method
     addCommonSearchParameters(dc, searchCondition);
-    
+
+    // Bind the system predicate parameter (order matches its position in the SQL above).
+    if (!includeSystemTypes) {
+        dc.addParam(false);
+    }
+
     // Add site parameters for LIKE clauses (substring matching with escaping)
     if (!validatedSites.isEmpty()) {
         // Add escaped LIKE patterns with wildcards: %escaped_site%
@@ -1402,10 +1424,23 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
      * {@inheritDoc}
      */
     @Override
-    @CloseDBIfOpened
     public List<ContentType> searchMultipleTypes(final String search, final Collection<BaseContentType> types,
                                                   final String orderBy, final int limit, final int offset,
                                                   final String siteId, final List<String> requestedContentTypes)
+            throws DotDataException {
+        return searchMultipleTypes(search, types, orderBy, limit, offset, siteId,
+                requestedContentTypes, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @CloseDBIfOpened
+    public List<ContentType> searchMultipleTypes(final String search, final Collection<BaseContentType> types,
+                                                  final String orderBy, final int limit, final int offset,
+                                                  final String siteId, final List<String> requestedContentTypes,
+                                                  final boolean includeSystemTypes)
             throws DotDataException {
 
         if (types == null || types.isEmpty()) {
@@ -1533,6 +1568,13 @@ public class ContentTypeFactoryImpl implements ContentTypeFactory {
                 if (searchCondition.isCommunityEdition) {
                     unionQuery.append(" AND structuretype <> ").append(BaseContentType.FORM.getType())
                               .append(" AND structuretype <> ").append(BaseContentType.PERSONA.getType()).append(" ");
+                }
+
+                // Dedicated system predicate: excludes system Content Types when requested,
+                // independent of the search/condition string so it combines with the name filter.
+                if (!includeSystemTypes) {
+                    unionQuery.append(" AND structure.system = ? ");
+                    parameters.add(false);
                 }
 
                 // SECURITY: Add sites filter using parameterized LIKE clauses

--- a/dotCMS/src/main/java/com/dotcms/contenttype/transform/contenttype/DbContentTypeTransformer.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/transform/contenttype/DbContentTypeTransformer.java
@@ -132,7 +132,10 @@ public class DbContentTypeTransformer implements ContentTypeTransformer{
 
 			@Override
 			public boolean system() {
-				return DbConnectionFactory.isDBTrue(map.get(ContentTypeFactory.SYSTEM_COLUMN).toString());
+				// The system column is a nullable boolean; treat NULL as non-system (false) instead
+				// of NPEing on null.toString(). Matches the coalesce(system, false) SQL predicate.
+				final Object systemValue = map.get(ContentTypeFactory.SYSTEM_COLUMN);
+				return systemValue != null && DbConnectionFactory.isDBTrue(systemValue.toString());
 			}
 
 			@Override

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
@@ -1715,7 +1715,14 @@ public class ContentTypeResource implements Serializable {
             @QueryParam(ContentTypesPaginator.ENSURE) @Parameter(schema = @Schema(type = "string"),
                     description = "Guarantee Content Types to be included in the response: " +
                             "Comma-separated content type keys (e.g. `activity, blog, product`)."
-            ) String ensureContentTypesParam) throws DotDataException {
+            ) String ensureContentTypesParam,
+            @QueryParam(ContentTypesPaginator.SYSTEM_PARAMETER_NAME) @Parameter(
+                    schema = @Schema(type = "boolean", defaultValue = "true"),
+                    description = "Whether to include system Content Types (e.g. Host, Favorite " +
+                            "Page) in the response.\n\nWhen `true` or omitted, system Content " +
+                            "Types are included (default, backward-compatible). When `false`, " +
+                            "they are excluded. Combines with `filter`."
+            ) final Boolean system) throws DotDataException {
 
 		final User user = new WebResource.InitBuilder(this.webResource)
 				.requestAndResponse(httpRequest, httpResponse)
@@ -1762,6 +1769,10 @@ public class ContentTypeResource implements Serializable {
             if (ensureContentTypesParam != null) {
                 extraParams.put(ContentTypesPaginator.ENSURE,
                         contentTypeHelper.getEnsuredContentTypes(ensureContentTypesParam));
+            }
+
+            if (null != system) {
+                extraParams.put(ContentTypesPaginator.SYSTEM_PARAMETER_NAME, system);
             }
 
 			final PaginationUtil paginationUtil = new PaginationUtil(new ContentTypesPaginator(APILocator.getContentTypeAPI(user)));

--- a/dotCMS/src/main/java/com/dotcms/util/pagination/ContentTypesPaginator.java
+++ b/dotCMS/src/main/java/com/dotcms/util/pagination/ContentTypesPaginator.java
@@ -55,6 +55,7 @@ public class ContentTypesPaginator implements PaginatorOrdered<Map<String, Objec
     public static final String WORKFLOWS = "workflows";
     public static final String SYSTEM_ACTION_MAPPINGS = "systemActionMappings";
     public static final String ENSURE = "ensure";
+    public static final String SYSTEM_PARAMETER_NAME = "system";
 
 
     private final ContentTypeAPI contentTypeAPI;
@@ -73,15 +74,18 @@ public class ContentTypesPaginator implements PaginatorOrdered<Map<String, Objec
     /**
      * Returns the total amount of the specified Base Content Types living in a list of Site.
      *
-     * @param condition Condition that the base Content Type needs to meet.
-     * @param type      The Base Content Type to search for.
-     * @param siteIds   One or more IDs of the Sites where the total amount of Content Types will be
-     *                  determined.
+     * @param condition          Condition that the base Content Type needs to meet.
+     * @param type               The Base Content Type to search for.
+     * @param siteIds            One or more IDs of the Sites where the total amount of Content
+     *                           Types will be determined.
+     * @param includeSystemTypes When {@code false}, system Content Types are excluded from the
+     *                           count so it stays consistent with the filtered item list.
      *
      * @return The total amount of Base Types living in the specified list of Site.
      */
-    private long getTotalRecords(final String condition, final BaseContentType type, final List<String> siteIds) {
-        return Sneaky.sneak(() ->this.contentTypeAPI.countForSites(condition, type, siteIds));
+    private long getTotalRecords(final String condition, final BaseContentType type, final List<String> siteIds,
+            final boolean includeSystemTypes) {
+        return Sneaky.sneak(() ->this.contentTypeAPI.countForSites(condition, type, siteIds, includeSystemTypes));
     }
 
     /**
@@ -134,6 +138,10 @@ public class ContentTypesPaginator implements PaginatorOrdered<Map<String, Objec
         final String siteId = Try.of(() -> extraParams.get(HOST_PARAMETER_ID).toString()).getOrElse(BLANK);
         final List<String> baseTypeNames = getBaseTypeNames(extraParams);
         final Set<BaseContentType> types = BaseContentType.fromNames(baseTypeNames); //This will get me BaseType Any if none is passed
+        // "system" is an "include system types" flag, default true (current behavior). Only an
+        // explicit FALSE excludes system Content Types via a dedicated predicate.
+        final Object systemParam = Objects.nonNull(extraParams) ? extraParams.get(SYSTEM_PARAMETER_NAME) : null;
+        final boolean includeSystemTypes = !Boolean.FALSE.equals(systemParam);
         try {
             long totalRecords = 0L;
             final PaginatedArrayList<Map<String, Object>> result = new PaginatedArrayList<>();
@@ -144,11 +152,11 @@ public class ContentTypesPaginator implements PaginatorOrdered<Map<String, Objec
             if (types.size() > 1 && !UtilMethods.isSet(varNamesList) && !UtilMethods.isSet(siteList)) {
                 // MULTI-TYPE EFFICIENT PATH: Use database UNION query for optimal performance
                 contentTypes = this.contentTypeAPI.searchMultipleTypes(filter, types, orderByParam,
-                        limit, offset, siteId, requestedContentTypes);
+                        limit, offset, siteId, requestedContentTypes, includeSystemTypes);
 
                 // Calculate total records across all types
                 for (final BaseContentType type : types) {
-                    totalRecords += getTotalRecords(filter, type, List.of(siteId));
+                    totalRecords += getTotalRecords(filter, type, List.of(siteId), includeSystemTypes);
                 }
             } else {
                 // SINGLE-TYPE OR SPECIAL CASES PATH: Use existing logic
@@ -169,11 +177,11 @@ public class ContentTypesPaginator implements PaginatorOrdered<Map<String, Objec
                             totalRecords = varNamesList.size();
                         }
                     } else if (UtilMethods.isSet(siteList)) {
-                        collectedContentTypes.addAll(this.contentTypeAPI.search(siteList, filter, type, orderByParam, limit, offset));
-                        totalRecords += this.getTotalRecords(BLANK, type, siteList);
+                        collectedContentTypes.addAll(this.contentTypeAPI.search(siteList, filter, type, orderByParam, limit, offset, null, includeSystemTypes));
+                        totalRecords += this.getTotalRecords(BLANK, type, siteList, includeSystemTypes);
                     } else {
-                        collectedContentTypes.addAll(this.contentTypeAPI.search(filter, type, orderByParam, limit, offset, siteId, requestedContentTypes));
-                        totalRecords += getTotalRecords(filter, type, List.of(siteId));
+                        collectedContentTypes.addAll(this.contentTypeAPI.search(filter, type, orderByParam, limit, offset, siteId, requestedContentTypes, includeSystemTypes));
+                        totalRecords += getTotalRecords(filter, type, List.of(siteId), includeSystemTypes);
                     }
                 }
 

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -7673,6 +7673,15 @@ paths:
         name: ensure
         schema:
           type: string
+      - description: |-
+          Whether to include system Content Types (e.g. Host, Favorite Page) in the response.
+
+          When `true` or omitted, system Content Types are included (default, backward-compatible). When `false`, they are excluded. Combines with `filter`.
+        in: query
+        name: system
+        schema:
+          type: boolean
+          default: true
       responses:
         "200":
           content:

--- a/dotcms-integration/src/test/java/com/dotcms/util/pagination/ContentTypesPaginatorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/pagination/ContentTypesPaginatorTest.java
@@ -14,6 +14,7 @@ import com.dotmarketing.beans.Permission;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.Role;
+import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
@@ -635,6 +636,52 @@ public class ContentTypesPaginatorTest {
     private void removeQuietly(final ContentType contentType) {
         if (null != contentType) {
             ContentTypeDataGen.remove(contentType);
+        }
+    }
+
+    /**
+     * Method to test: {@link ContentTypesPaginator#getItems(User, String, int, int, String, OrderDirection, Map)}
+     *
+     * Given Scenario: A regular (non-system) Content Type whose {@code structure.system} column is
+     * forced to {@code NULL} at the DB level (the column is a nullable boolean, so legacy/externally
+     * created rows may be NULL), queried with {@code system=false}.
+     *
+     * Expected Result: The Content Type is still returned. The system predicate uses
+     * {@code coalesce(system, false)} (so a NULL {@code system} is treated as non-system and not
+     * silently dropped by a plain {@code system = false} equality), and the DB-to-object transform
+     * maps a NULL {@code system} to {@code false} instead of throwing.
+     */
+    @Test
+    public void test_getItems_systemFalse_includesTypeWithNullSystemColumn() throws Exception {
+        final long ts = System.currentTimeMillis();
+        final String token = "nullsys" + ts;
+        ContentType contentType = null;
+
+        try {
+            contentType = createTypeWithSystemFlag(BaseContentType.CONTENT, token + "Reg",
+                    token + "reg", false);
+
+            // Simulate a row whose system column is NULL (nullable boolean, no NOT NULL constraint).
+            final DotConnect dc = new DotConnect();
+            dc.setSQL("update structure set system = null where inode = ?");
+            dc.addParam(contentType.inode());
+            dc.loadResult();
+
+            final Map<String, Object> params = new HashMap<>();
+            params.put(ContentTypesPaginator.TYPE_PARAMETER_NAME,
+                    Set.of(BaseContentType.CONTENT.name()));
+            params.put(ContentTypesPaginator.SYSTEM_PARAMETER_NAME, false);
+
+            final ContentTypesPaginator paginator = new ContentTypesPaginator();
+            final PaginatedArrayList<Map<String, Object>> result =
+                    paginator.getItems(user, token, -1, 0, "name", OrderDirection.ASC, params);
+
+            assertEquals("A Content Type with a NULL system column must not be dropped by system=false",
+                    1, result.size());
+            assertEquals(1, result.getTotalResults());
+            assertEquals(token + "Reg", result.get(0).get("name"));
+        } finally {
+            removeQuietly(contentType);
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/util/pagination/ContentTypesPaginatorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/pagination/ContentTypesPaginatorTest.java
@@ -2,6 +2,7 @@ package com.dotcms.util.pagination;
 
 import com.dotcms.content.elasticsearch.business.IndiciesInfo;
 import com.dotcms.contenttype.business.ContentTypeAPI;
+import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
@@ -512,9 +513,135 @@ public class ContentTypesPaginatorTest {
     }
 
     /**
+     * Method to test: {@link ContentTypesPaginator#getItems(User, String, int, int, String, OrderDirection, Map)}
+     *
+     * Given Scenario: Multiple base types (CONTENT + WIDGET), each with one system and one regular
+     * Content Type, filtered by a shared name token, exercising the multi-type UNION path.
+     *
+     * Expected Result:
+     * <ul>
+     *     <li>With the {@code system} param omitted, all 4 types are returned (backward compat):
+     *     system types are still present, total is exact.</li>
+     *     <li>With {@code system=false}, only the 2 regular types are returned; no system type
+     *     appears and the total reflects the filter exactly (no client-side adjustment).</li>
+     * </ul>
+     */
+    @Test
+    public void test_getItems_multiType_systemParam_excludesSystemTypesAndKeepsExactCount() {
+        final long ts = System.currentTimeMillis();
+        final String token = "sysflag" + ts;
+        ContentType contentReg = null;
+        ContentType contentSys = null;
+        ContentType widgetReg = null;
+        ContentType widgetSys = null;
+
+        try {
+            contentReg = createTypeWithSystemFlag(BaseContentType.CONTENT, token + "ContentReg", token + "cr", false);
+            contentSys = createTypeWithSystemFlag(BaseContentType.CONTENT, token + "ContentSys", token + "cs", true);
+            widgetReg = createTypeWithSystemFlag(BaseContentType.WIDGET, token + "WidgetReg", token + "wr", false);
+            widgetSys = createTypeWithSystemFlag(BaseContentType.WIDGET, token + "WidgetSys", token + "ws", true);
+
+            final ContentTypesPaginator paginator = new ContentTypesPaginator();
+            final Set<String> baseTypes = Set.of(BaseContentType.CONTENT.name(), BaseContentType.WIDGET.name());
+
+            // Backward compat: system omitted -> all 4 present, system types included.
+            final Map<String, Object> paramsDefault = new HashMap<>();
+            paramsDefault.put(ContentTypesPaginator.TYPE_PARAMETER_NAME, baseTypes);
+            final PaginatedArrayList<Map<String, Object>> all =
+                    paginator.getItems(user, token, -1, 0, "name", OrderDirection.ASC, paramsDefault);
+
+            assertEquals("All 4 filtered types must be returned when system is omitted", 4, all.size());
+            assertEquals("Total must include system types when system is omitted", 4, all.getTotalResults());
+            assertTrue("System types must be present (backward compat)",
+                    all.stream().anyMatch(ct -> Boolean.TRUE.equals(ct.get("system"))));
+
+            // system=false -> only the 2 regular types, no system, exact total.
+            final Map<String, Object> paramsNoSystem = new HashMap<>();
+            paramsNoSystem.put(ContentTypesPaginator.TYPE_PARAMETER_NAME, baseTypes);
+            paramsNoSystem.put(ContentTypesPaginator.SYSTEM_PARAMETER_NAME, false);
+            final PaginatedArrayList<Map<String, Object>> noSystem =
+                    paginator.getItems(user, token, -1, 0, "name", OrderDirection.ASC, paramsNoSystem);
+
+            assertEquals("Only the 2 regular types must be returned when system=false", 2, noSystem.size());
+            assertEquals("Total must be exact when system=false (no client-side -1)", 2, noSystem.getTotalResults());
+            assertTrue("No system type must be returned when system=false",
+                    noSystem.stream().noneMatch(ct -> Boolean.TRUE.equals(ct.get("system"))));
+        } finally {
+            removeQuietly(contentReg);
+            removeQuietly(contentSys);
+            removeQuietly(widgetReg);
+            removeQuietly(widgetSys);
+        }
+    }
+
+    /**
+     * Method to test: {@link ContentTypesPaginator#getItems(User, String, int, int, String, OrderDirection, Map)}
+     *
+     * Given Scenario: A single base type (CONTENT) with one system and one regular Content Type
+     * sharing a name token, exercising the single-type path with {@code filter} + {@code system}.
+     *
+     * Expected Result: {@code system=false} combined with the name filter returns only the regular
+     * type; the count is exact. This proves the single-type path honors the system predicate.
+     */
+    @Test
+    public void test_getItems_singleType_filterAndSystemFalse_combine() {
+        final long ts = System.currentTimeMillis();
+        final String token = "sysflagsingle" + ts;
+        ContentType regular = null;
+        ContentType systemType = null;
+
+        try {
+            regular = createTypeWithSystemFlag(BaseContentType.CONTENT, token + "Reg", token + "reg", false);
+            systemType = createTypeWithSystemFlag(BaseContentType.CONTENT, token + "Sys", token + "sys", true);
+
+            final ContentTypesPaginator paginator = new ContentTypesPaginator();
+            final Set<String> singleBaseType = Set.of(BaseContentType.CONTENT.name());
+
+            // system omitted -> both present.
+            final Map<String, Object> paramsDefault = new HashMap<>();
+            paramsDefault.put(ContentTypesPaginator.TYPE_PARAMETER_NAME, singleBaseType);
+            final PaginatedArrayList<Map<String, Object>> both =
+                    paginator.getItems(user, token, -1, 0, "name", OrderDirection.ASC, paramsDefault);
+            assertEquals("Both types must be returned when system is omitted", 2, both.size());
+            assertEquals(2, both.getTotalResults());
+
+            // filter + system=false -> only the regular type.
+            final Map<String, Object> paramsNoSystem = new HashMap<>();
+            paramsNoSystem.put(ContentTypesPaginator.TYPE_PARAMETER_NAME, singleBaseType);
+            paramsNoSystem.put(ContentTypesPaginator.SYSTEM_PARAMETER_NAME, false);
+            final PaginatedArrayList<Map<String, Object>> noSystem =
+                    paginator.getItems(user, token, -1, 0, "name", OrderDirection.ASC, paramsNoSystem);
+
+            assertEquals("Only the regular type must be returned for filter + system=false", 1, noSystem.size());
+            assertEquals("Total must be exact for filter + system=false", 1, noSystem.getTotalResults());
+            assertFalse("The returned type must not be a system type",
+                    Boolean.TRUE.equals(noSystem.get(0).get("system")));
+        } finally {
+            removeQuietly(regular);
+            removeQuietly(systemType);
+        }
+    }
+
+    private ContentType createTypeWithSystemFlag(final BaseContentType baseType, final String name,
+            final String varName, final boolean system) {
+        return new ContentTypeDataGen()
+                .baseContentType(baseType)
+                .name(name)
+                .velocityVarName(varName)
+                .system(system)
+                .nextPersisted();
+    }
+
+    private void removeQuietly(final ContentType contentType) {
+        if (null != contentType) {
+            ContentTypeDataGen.remove(contentType);
+        }
+    }
+
+    /**
      * Helper method to create a Content Type with a specific Base Type
      */
-    private ContentType createContentTypeWithBaseType(BaseContentType baseType, String name) 
+    private ContentType createContentTypeWithBaseType(BaseContentType baseType, String name)
             throws DotSecurityException, DotDataException {
         final long timestamp = System.currentTimeMillis();
         final String variable = "velocityVar" + name + timestamp;

--- a/dotcms-postman/src/main/resources/postman/ContentTypeResourceTests.json
+++ b/dotcms-postman/src/main/resources/postman/ContentTypeResourceTests.json
@@ -2011,6 +2011,172 @@
 					"response": []
 				},
 				{
+					"name": "Get ContentTypes without system param (system types included)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var json = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Default listing (no 'system' param) includes system Content Types\", function () {",
+									"    var list = json.entity;",
+									"    var systemCount = list.filter(function (ct) { return ct.system === true; }).length;",
+									"    pm.expect(systemCount, \"There must be at least one system Content Type in the default listing\").to.be.gte(1);",
+									"    // Persist the baseline for the system=false / system=true comparisons below.",
+									"    pm.collectionVariables.set(\"ctAllTotal\", json.pagination.totalEntries);",
+									"    pm.collectionVariables.set(\"ctSystemCount\", systemCount);",
+									"});",
+									"",
+									"pm.test(\"Total is coherent with the returned list\", function () {",
+									"    pm.expect(json.pagination.totalEntries).to.eql(json.entity.length);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype?per_page=1000",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							],
+							"query": [
+								{
+									"key": "per_page",
+									"value": "1000"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get ContentTypes with system=false (excludes system types)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var json = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"No system Content Type is returned when system=false\", function () {",
+									"    var withSystem = json.entity.filter(function (ct) { return ct.system === true; });",
+									"    pm.expect(withSystem.length, \"system=false must exclude every system Content Type\").to.eql(0);",
+									"});",
+									"",
+									"pm.test(\"Total excludes the system types and stays coherent with the list\", function () {",
+									"    var allTotal = Number(pm.collectionVariables.get(\"ctAllTotal\"));",
+									"    var systemCount = Number(pm.collectionVariables.get(\"ctSystemCount\"));",
+									"    // The total no longer counts the excluded system types...",
+									"    pm.expect(json.pagination.totalEntries, \"Total must drop exactly the system types\").to.eql(allTotal - systemCount);",
+									"    // ...and it still matches the actual number of items returned (no client-side adjustment).",
+									"    pm.expect(json.pagination.totalEntries).to.eql(json.entity.length);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype?per_page=1000&system=false",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							],
+							"query": [
+								{
+									"key": "per_page",
+									"value": "1000"
+								},
+								{
+									"key": "system",
+									"value": "false"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get ContentTypes with system=true (includes system types)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var json = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"system=true includes system Content Types and matches the default total\", function () {",
+									"    var systemCount = json.entity.filter(function (ct) { return ct.system === true; }).length;",
+									"    pm.expect(systemCount, \"system=true must include system Content Types\").to.be.gte(1);",
+									"    var allTotal = Number(pm.collectionVariables.get(\"ctAllTotal\"));",
+									"    pm.expect(json.pagination.totalEntries, \"system=true total must equal the default (no param) total\").to.eql(allTotal);",
+									"});",
+									"",
+									"pm.test(\"Total is coherent with the returned list\", function () {",
+									"    pm.expect(json.pagination.totalEntries).to.eql(json.entity.length);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype?per_page=1000&system=true",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							],
+							"query": [
+								{
+									"key": "per_page",
+									"value": "1000"
+								},
+								{
+									"key": "system",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get ContentTypes sending not existing hostID",
 					"event": [
 						{


### PR DESCRIPTION
## Issue

Part 1 of #36072 (Content Drive "New" button content-type picker).

`GET /api/v1/contenttype` returns non-creatable **system** content types (e.g. `dotFavoritePage`, Host) that share a base type with real content, so the `type` base-type filter can't exclude them. Frontends strip them client-side (`!ct.system`, `-1` count adjustment), which breaks pagination counts.

## Change

Adds an optional `system` query param to `GET /api/v1/contenttype`:

- **`system` = "include system types", Boolean, default `true`.** Absent or `true` ⇒ current behavior (system types included). `system=false` ⇒ excludes them (`and structure.system = false`). No system-only mode.
- Threaded as a **dedicated predicate**, independent of the `search`/condition string, so it **ANDs with the `filter`** (name search). Previously the string was name-search XOR condition, so they couldn't combine.
- Applied in **both** the multi-type UNION path (`searchMultipleTypes`) and the single-type path (`dbSearch`), and in the **count path** (`countForSites` → `dbSearch`) so `totalResults` stays exact — no client-side `-1`.
- New API/factory method overloads are additive; existing signatures delegate with `includeSystemTypes = true` (backward compatible).
- `openapi.yaml` regenerated (endpoint is not `@Hidden`) — diff is only the new `system` param.

## Testing

`ContentTypesPaginatorTest` (registered in `MainSuite1a`) — **16 tests, 0 failures**:
- Multi-type: `system` omitted ⇒ system types present + exact total (backward compat); `system=false` ⇒ only regular types, exact total, no system type returned.
- Single-type: `filter` + `system=false` combine ⇒ only the regular type, exact total.

## Rollback safety

Additive optional API param + query changes. No schema/migration, no ES mapping. N-1 ignores the new param. **Rollback-safe.**

This PR fixes: #36072