### PR TITLE
refactor(sitesearch): tag the physical OpenSearch Site Search index with .os (#36672)

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/OSSiteSearchAPI.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/OSSiteSearchAPI.java
@@ -93,14 +93,16 @@ import org.quartz.SchedulerException;
  * — routing through the neutral {@code IndexAPI} router here would dual-write a second time.</p>
  *
  * <h2>Index naming</h2>
- * <p>Site-search index names are handled as plain logical names (e.g. {@code sitesearch_1718000000000}),
- * exactly as in {@link ESSiteSearchAPI}: the cluster-id prefix is added only when a name reaches the
- * OpenSearch client (via {@link IndexAPI#getNameWithClusterIDPrefix(String)}). The {@code .os}
- * {@link com.dotcms.content.index.IndexTag} is intentionally not applied to site-search indices —
- * production ES and OS run on separate clusters, and the site-search pointer lives in its own
- * {@code siteSearch} slot, so there is no shared-name collision to disambiguate.
- * TODO OS: revisit if single-cluster dual-write of site-search is ever required (then tag with
- * {@code IndexTag.OS}).</p>
+ * <p>Site-search index names flow through this class as plain <em>logical</em> names
+ * (e.g. {@code sitesearch_1718000000000}) — that is what {@link #listIndices()}, the search/alias
+ * parameters, and the {@code siteSearch} pointer expose, so the ES∪OS merge in the router keeps
+ * deduplicating and nothing user-facing ever shows a {@code .os} suffix. The {@code .os}
+ * {@link com.dotcms.content.index.IndexTag} is applied at the <strong>physical boundary only</strong>
+ * (see {@link #physicalName(String)} / {@link #osTagged(String)}), so the actual OpenSearch index is
+ * {@code cluster_<id>.sitesearch_….os} — consistent with every other migrated index and with the
+ * {@code .os}-tagged pointer persisted by {@link VersionedIndicesAPI}. Tagging the physical index also
+ * removes the single-cluster ({@code esSameAsOs()}) name-collision hazard the previous bare naming
+ * carried (issue #36672).</p>
  *
  * @author Fabrizio Araya
  * @see ESSiteSearchAPI
@@ -148,8 +150,12 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
         if (LicenseUtil.getLevel() < LicenseLevel.STANDARD.level) {
             return Collections.emptyList();
         }
+        // The physical OS indices are .os-tagged; strip back to logical names so the ES∪OS merge in
+        // SiteSearchAPIImpl.listIndices() deduplicates and no .os leaks to the portlet (issue #36672).
         final List<String> indices = indexApi.listIndices().stream()
                 .filter(IndexType.SITE_SEARCH::is)
+                .map(IndexTag::strip)
+                .distinct()
                 .collect(Collectors.toList());
 
         Collections.sort(indices);
@@ -188,7 +194,7 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
         }
         for (final String indexName : indexApi.getClosedIndexes()) {
             if (IndexType.SITE_SEARCH.is(indexName)) {
-                indices.add(indexName);
+                indices.add(IndexTag.strip(indexName)); // logical form — see listIndices (issue #36672)
             }
         }
         Collections.sort(indices);
@@ -419,13 +425,15 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
         final String mapping = readResource(classLoader, "os-sitesearch-mapping.json");
 
         try {
-            indexApi.createIndex(indexName, settings, shards);
+            // Create the .os-tagged physical index (osTagged), matching physicalName()/putMapping()
+            // so create, mapping, writes and searches all hit the same index (issue #36672).
+            indexApi.createIndex(osTagged(indexName), settings, shards);
         } catch (final Exception e) {
             throw new DotSearchException("Error creating OpenSearch site search index: " + e.getMessage(), e);
         }
 
         if (UtilMethods.isSet(alias)) {
-            indexApi.createAlias(indexName, alias);
+            indexApi.createAlias(osTagged(indexName), alias);
         }
 
         putMapping(indexName, mapping);
@@ -492,7 +500,7 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
                     " either one or both params aren't set. index: `%s`, alias: `%s` ", indexName, alias));
         }
         indexName = indexName.toLowerCase();
-        indexApi.createAlias(indexName, alias);
+        indexApi.createAlias(osTagged(indexName), alias); // alias points at the .os index (issue #36672)
         // createAlias is void and throws on failure, so reaching here means the alias was created.
         // (Legacy ESSiteSearchAPI returns false here, but its only caller — ESSiteSearchPublisher —
         // ignores the result, so the divergence is benign; reporting success honestly is correct.)
@@ -511,19 +519,20 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
         if (!IndexType.SITE_SEARCH.is(indexName)) {
             throw new DotDataException("Index '" + indexName + "' is not a site-search index");
         }
-        // Deletes only from THIS engine (indexApi is the direct OSIndexAPIImpl, not the router).
-        // Site-search OS indices are plain-named (no .os tag). Active-index protection is enforced
-        // by the SiteSearchAPIImpl router before dispatch.
+        // Deletes only from THIS engine (indexApi is the direct OSIndexAPIImpl, not the router). The
+        // physical OS index is .os-tagged (osTagged), matching create/search. Active-index protection
+        // is enforced by the SiteSearchAPIImpl router before dispatch.
         // Idempotent per engine: during migration a site-search index can exist on only one engine
         // (e.g. a Phase-0 ES-only index has no OpenSearch twin), so skip when it is absent here
         // rather than letting deleteMultiple throw index_not_found and crash the fan-out — which
         // would otherwise abort the Site Search build mid-switch (issue #36360, I-7).
-        if (!indexApi.indexExists(indexName)) {
+        final String osIndexName = osTagged(indexName);
+        if (!indexApi.indexExists(osIndexName)) {
             Logger.info(this.getClass(),
                     "Site-search index '" + indexName + "' is absent on this engine; nothing to delete.");
             return;
         }
-        indexApi.deleteMultiple(new String[]{indexName});
+        indexApi.deleteMultiple(new String[]{osIndexName});
     }
 
     @Override
@@ -533,9 +542,12 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
         // Keep the default (active) site-search index.
         defaultSiteSearchIndex().ifPresent(indicesToRemove::remove);
 
-        // Keep any index that backs an alias.
-        final List<String> indicesWithAlias =
-                new ArrayList<>(indexApi.getIndexAlias(indicesToRemove).keySet());
+        // Keep any index that backs an alias. indicesToRemove holds logical names; the alias lookup
+        // runs against the .os-tagged physical names, and the returned keys are stripped back to
+        // logical so the removeAll matches (issue #36672).
+        final List<String> indicesWithAlias = indexApi.getIndexAlias(
+                        indicesToRemove.stream().map(OSSiteSearchAPI::osTagged).collect(Collectors.toList()))
+                .keySet().stream().map(IndexTag::strip).collect(Collectors.toList());
         indicesToRemove.removeAll(indicesWithAlias);
 
         // Keep indices created within the last 24 hours.
@@ -560,7 +572,8 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
         if (!indicesToRemove.isEmpty()) {
             Logger.info(this.getClass(),
                     "The following indices will be deleted: " + String.join(",", indicesToRemove));
-            indexApi.deleteMultiple(indicesToRemove.toArray(new String[0]));
+            indexApi.deleteMultiple(
+                    indicesToRemove.stream().map(OSSiteSearchAPI::osTagged).toArray(String[]::new));
         }
     }
 
@@ -795,12 +808,24 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
     // =========================================================================
 
     /**
-     * The physical index name to use against the OpenSearch client: the cluster-id prefix is applied,
-     * matching how {@link OSIndexAPIImpl} builds its requests. No {@code .os} tag is added (see the
-     * class-level "Index naming" note).
+     * The physical index name to use against the OpenSearch client: the {@code .os} tag is applied
+     * (so Site Search follows the same naming pattern as every other migrated index) and then the
+     * cluster-id prefix, matching how {@link OSIndexAPIImpl} builds its requests. Callers pass logical
+     * (untagged) names; the tag is added only here, at the physical boundary (issue #36672).
      */
     private String physicalName(final String indexName) {
-        return indexApi.getNameWithClusterIDPrefix(indexName);
+        return indexApi.getNameWithClusterIDPrefix(osTagged(indexName));
+    }
+
+    /**
+     * Adds the {@code .os} tag to a logical Site Search index name for calls into the OpenSearch
+     * {@link IndexAPI} provider, which adds only the cluster prefix — not the tag. Idempotent
+     * ({@link IndexTag#tag(String)} leaves an already-tagged name unchanged), so it is safe on any
+     * form. Keeps the physical OpenSearch index in lock-step with the {@code .os}-tagged pointer
+     * stored in {@link VersionedIndicesAPI}.
+     */
+    private static String osTagged(final String logicalName) {
+        return IndexTag.OS.tag(logicalName);
     }
 
     /** Characters OpenSearch forbids in an index name (plus the space). */
@@ -836,9 +861,12 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
         if (indexName == null) {
             indexName = defaultSiteSearchIndex().orElse(null);
         }
-        if (indexName != null && !indexApi.indexExists(indexName)) {
-            // try using it as an alias
-            indexName = indexApi.getAliasToIndexMap(listIndices()).get(indexName);
+        if (indexName != null && !indexApi.indexExists(osTagged(indexName))) {
+            // try using it as an alias: resolve against the .os-tagged physical names, then strip the
+            // matched index back to its logical form (issue #36672).
+            indexName = IndexTag.strip(indexApi.getAliasToIndexMap(
+                    listIndices().stream().map(OSSiteSearchAPI::osTagged).collect(Collectors.toList()))
+                    .get(indexName));
         }
         return indexName;
     }
@@ -848,9 +876,10 @@ public class OSSiteSearchAPI implements SiteSearchAPI {
      * (untagged) name.
      *
      * <p>{@link VersionedIndicesAPI} canonicalises stored names to the {@code .os}-tagged form, so the
-     * raw value carries the tag. Site-search indices are handled in logical space everywhere else
-     * (the physical OpenSearch index itself is created without the tag — see the class "Index naming"
-     * note), so the tag is stripped here to keep comparisons and list lookups consistent.</p>
+     * raw value carries the tag. This class works in logical (untagged) space on its API surface — the
+     * tag is (re)applied at the physical boundary by {@link #physicalName(String)} / {@link #osTagged}
+     * — so the tag is stripped here, at the DB→logical boundary, to keep comparisons and list lookups
+     * consistent (see the class "Index naming" note).</p>
      */
     private Optional<String> defaultSiteSearchIndex() {
         final Optional<String> versioned =

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndexAPIImpl.java
@@ -4,7 +4,6 @@ import static com.dotcms.content.index.IndexConfigHelper.isMigrationNotStarted;
 
 import com.dotcms.cdi.CDIUtils;
 import com.dotcms.content.elasticsearch.business.ESIndexAPI;
-import com.dotcms.content.elasticsearch.business.IndexType;
 import com.dotcms.content.index.domain.ClusterIndexHealth;
 import com.dotcms.content.index.domain.ClusterStats;
 import com.dotcms.content.index.domain.CreateIndexStatus;
@@ -438,14 +437,12 @@ public class IndexAPIImpl implements IndexAPI {
      * provider gets the bare name. This is what makes lifecycle ops (clear/open/close/replicas)
      * a faithful mirror across both engines instead of silently hitting only ES.
      *
-     * <p>Site-search indices are the exception — their OS copy is NOT {@code .os}-tagged (separate
-     * cluster, own {@code siteSearch} slot), so they stay bare on both engines.</p>
+     * <p>Applies uniformly, including site-search indices: their OpenSearch copy is now
+     * {@code .os}-tagged like every other migrated index (issue #36672), so no carve-out is needed.</p>
      */
     private String providerName(final IndexAPI provider, final String indexName) {
         final String logical = IndexTag.OS.untag(indexName);
-        return provider == router.osImpl() && !IndexType.SITE_SEARCH.is(logical)
-                ? IndexTag.OS.tag(logical)
-                : logical;
+        return provider == router.osImpl() ? IndexTag.OS.tag(logical) : logical;
     }
 
     @Override

--- a/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSSiteSearchAPIIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSSiteSearchAPIIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.dotcms.DataProviderWeldRunner;
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.content.index.IndexTag;
 import com.dotcms.content.index.domain.Aggregation;
 import com.dotcms.content.index.domain.AggregationBucket;
 import com.dotcms.content.index.domain.SearchHit;
@@ -69,6 +70,11 @@ public class OSSiteSearchAPIIntegrationTest extends IntegrationTestBase {
     private static final String IDX_ONE = "sitesearch_" + SUFFIX;
     private static final String IDX_TWO = "sitesearch_" + (Long.parseLong(SUFFIX) + 1);
 
+    // The physical OpenSearch index is .os-tagged (issue #36672); the OSSiteSearchAPI surface uses the
+    // logical (bare) names above, so raw osIndexAPI assertions must query the tagged physical name.
+    private static final String OS_IDX_ONE = IndexTag.OS.tag(IDX_ONE);
+    private static final String OS_IDX_TWO = IndexTag.OS.tag(IDX_TWO);
+
     private static final String DOC_ID = "os-ss-it-" + RUN_ID;
 
     @Inject
@@ -108,14 +114,17 @@ public class OSSiteSearchAPIIntegrationTest extends IntegrationTestBase {
      */
     @Test
     public void test_createSiteSearchIndex_shouldExistAndBeListed() throws Exception {
-        assertFalse("Pre-condition: index must not exist yet", osIndexAPI.indexExists(IDX_ONE));
+        assertFalse("Pre-condition: index must not exist yet", osIndexAPI.indexExists(OS_IDX_ONE));
 
         final boolean created = osSiteSearchAPI.createSiteSearchIndex(IDX_ONE, null, 1);
 
         assertTrue("createSiteSearchIndex must return true", created);
-        assertTrue("Index must exist in OpenSearch after creation", osIndexAPI.indexExists(IDX_ONE));
-        assertTrue("Index must be returned by listIndices",
+        assertTrue("The physical OpenSearch index must be .os-tagged after creation (issue #36672)",
+                osIndexAPI.indexExists(OS_IDX_ONE));
+        assertTrue("listIndices must return the LOGICAL (bare) name",
                 osSiteSearchAPI.listIndices().contains(IDX_ONE));
+        assertFalse("listIndices must NOT leak the .os-tagged name",
+                osSiteSearchAPI.listIndices().contains(OS_IDX_ONE));
 
         Logger.info(this, "✅ test_createSiteSearchIndex_shouldExistAndBeListed passed – index: " + IDX_ONE);
     }
@@ -127,11 +136,11 @@ public class OSSiteSearchAPIIntegrationTest extends IntegrationTestBase {
     @Test
     public void test_deleteSiteSearchIndex_shouldRemoveIt() throws Exception {
         osSiteSearchAPI.createSiteSearchIndex(IDX_ONE, null, 1);
-        assertTrue("Pre-condition: index must exist", osIndexAPI.indexExists(IDX_ONE));
+        assertTrue("Pre-condition: index must exist", osIndexAPI.indexExists(OS_IDX_ONE));
 
-        osIndexAPI.delete(IDX_ONE);
+        osIndexAPI.delete(OS_IDX_ONE);
 
-        assertFalse("Index must be gone after deletion", osIndexAPI.indexExists(IDX_ONE));
+        assertFalse("Index must be gone after deletion", osIndexAPI.indexExists(OS_IDX_ONE));
         Logger.info(this, "✅ test_deleteSiteSearchIndex_shouldRemoveIt passed");
     }
 
@@ -146,12 +155,12 @@ public class OSSiteSearchAPIIntegrationTest extends IntegrationTestBase {
      */
     @Test
     public void test_deleteIndex_absentOnThisEngine_isIdempotent() throws Exception {
-        assertFalse("Pre-condition: index must not exist", osIndexAPI.indexExists(IDX_ONE));
+        assertFalse("Pre-condition: index must not exist", osIndexAPI.indexExists(OS_IDX_ONE));
 
         // Must not throw even though the index is absent on this engine.
         osSiteSearchAPI.deleteIndex(IDX_ONE);
 
-        assertFalse("Index must still be absent", osIndexAPI.indexExists(IDX_ONE));
+        assertFalse("Index must still be absent", osIndexAPI.indexExists(OS_IDX_ONE));
         Logger.info(this, "✅ test_deleteIndex_absentOnThisEngine_isIdempotent passed");
     }
 
@@ -166,14 +175,14 @@ public class OSSiteSearchAPIIntegrationTest extends IntegrationTestBase {
     public void test_getIndexAlias_toleratesMissingIndexInBatch() throws Exception {
         final String alias = "ss_alias_" + RUN_ID;
         osSiteSearchAPI.createSiteSearchIndex(IDX_ONE, alias, 1);
-        assertFalse("Pre-condition: sibling index must not exist", osIndexAPI.indexExists(IDX_TWO));
+        assertFalse("Pre-condition: sibling index must not exist", osIndexAPI.indexExists(OS_IDX_TWO));
 
-        // IDX_TWO is absent on this engine; before the fix its presence in the batch threw
-        // index_not_found and returned an empty map.
-        final Map<String, String> aliases = osIndexAPI.getIndexAlias(List.of(IDX_ONE, IDX_TWO));
+        // OS_IDX_TWO is absent on this engine; before the fix its presence in the batch threw
+        // index_not_found and returned an empty map. Query the .os-tagged physical names (issue #36672).
+        final Map<String, String> aliases = osIndexAPI.getIndexAlias(List.of(OS_IDX_ONE, OS_IDX_TWO));
 
         assertEquals("the resolvable alias must survive a missing sibling in the same batch",
-                alias, aliases.get(IDX_ONE));
+                alias, aliases.get(OS_IDX_ONE));
         Logger.info(this, "✅ test_getIndexAlias_toleratesMissingIndexInBatch passed");
     }
 
@@ -472,7 +481,7 @@ public class OSSiteSearchAPIIntegrationTest extends IntegrationTestBase {
     // =======================================================================
 
     private synchronized void cleanupTestData() {
-        for (final String name : List.of(IDX_ONE, IDX_TWO)) {
+        for (final String name : List.of(OS_IDX_ONE, OS_IDX_TWO)) {
             try {
                 if (osIndexAPI.indexExists(name)) {
                     osIndexAPI.delete(name);


### PR DESCRIPTION
## Proposed Changes

Closes #36672.

Makes Site Search a first-class citizen of the ES→OpenSearch migration naming pattern: the **physical OpenSearch Site Search index now carries the `.os` tag**, like every other migrated index — instead of being bare while the DB pointer was already tagged.

> ⚠️ **Stacked on #36645** (base = `issue-36360-sitesearch-phase-fixes`) because it edits the same `OSSiteSearchAPI` methods. Retarget to `main` once #36645 merges.

### Why
`.os` was split across layers: the `VersionedIndices` pointer was force-tagged (`VersionedIndicesAPIImpl.saveIndices`) but the physical OS index was bare, reconciled by `strip`-on-read + a Site Search carve-out in the content lifecycle cascade. That bare-vs-`.os` asymmetry is the same class that previously broke OS index ops, and it collides on a single cluster (`esSameAsOs()`). Surfaced during the Site Search QA (#36360, finding I-4).

### What changed
- **`OSSiteSearchAPI`** works in **logical (untagged)** names on its API surface and applies the tag only at the **physical boundary** — new `osTagged()` helper + `physicalName()`. Create, mapping, put, get, delete, search and aggregations all target the tagged physical index, and every `OSIndexAPIImpl` call (`createIndex`/`createAlias`/`indexExists`/`deleteMultiple`/`getIndexAlias`/`getAliasToIndexMap`) receives the tagged name.
- **`listIndices()` / `listClosedIndices()`** strip `.os` back to logical, so the ES∪OS merge in `SiteSearchAPIImpl.listIndices()` keeps **deduplicating** and no `.os` leaks to the portlet or `$sitesearch` (**QA TC-068 preserved**).
- **DB unchanged**: the `.os` tag stays in `VersionedIndices` and Site Search rows keep `version = 3.x` — only the physical index gains the tag.
- **`IndexAPIImpl.providerName`**: removed the Site Search carve-out now that the physical OS index is tagged (the lifecycle cascade tags uniformly); dropped the now-unused `IndexType` import.

### Design note
Site Search keeps a **bare logical surface** (like content indices expose in the API), tagging only at the physical/DB boundary. This satisfies "physical is `.os`" + "DB stays tagged" + "version 3.x" without regressing the dual-write list dedup.

### Migration note
Any Site Search OS index created **bare** by a dual-write crawl *before* this change becomes unreachable (ops now target the `.os` name); a full re-crawl recreates it correctly. No action for the common separate-cluster prod topology where crawls run after this ships.

## Testing
`OSSiteSearchAPIIntegrationTest` updated (OpenSearchUpgradeSuite): create asserts the physical index is `.os`-tagged and `listIndices()` returns the **logical** name (and does not leak `.os`); delete / idempotent-delete / batch-tolerant alias tests query the tagged physical name. Core + integration test-compile green locally. **Behavioral validation requires the OpenSearch Upgrade Suite in CI** (cannot run the OS container locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36672