### PR TITLE
fix(opensearch): apply secondary category-permission filter on OS search (F7)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1706,7 +1706,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     }
 
-    void addCategoryPermissionsToQuery(StringBuffer buffy, User user, List<Role> roles, boolean respectFrontendRoles) {
+    @Override
+    public void addCategoryPermissionsToQuery(StringBuffer buffy, User user, List<Role> roles, boolean respectFrontendRoles) {
         if (!Config.getBooleanProperty("PERMISSION_SECONDARY_CATEGORY_CHECK", true)) {
             return;
         }

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSSearchAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSSearchAPIImpl.java
@@ -12,6 +12,7 @@ import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.common.model.ImmutableContentletSearch;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.StringUtils;
@@ -297,8 +298,13 @@ public class OSSearchAPIImpl implements SearchAPI {
 
         final StringBuffer perms = new StringBuffer();
         if (!isAdmin && !queryJson.has("permissions:")) {
-            APILocator.getContentletAPIImpl()
-                    .addPermissionsToQuery(perms, user, roles, respectFrontendRoles);
+            final ContentletAPI contentletAPI = APILocator.getContentletAPIImpl();
+            contentletAPI.addPermissionsToQuery(perms, user, roles, respectFrontendRoles);
+            // Secondary category-permission filter: mirror the ES path
+            // (ESContentletAPIImpl.applyPermissionsToQuery). Without this the categoryperms:
+            // clause is never added under OS, so content restricted by category read permissions
+            // leaks to users who lack the category role (Phase 3 permission-filter gap).
+            contentletAPI.addCategoryPermissionsToQuery(perms, user, roles, respectFrontendRoles);
         }
 
         if (perms.length() > 0) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -725,6 +725,21 @@ public interface ContentletAPI {
 	public void addPermissionsToQuery ( StringBuffer buffy, User user, List<Role> roles, boolean respectFrontendRoles ) throws DotSecurityException, DotDataException;
 
 	/**
+	 * Adds the secondary category-permission query fragment (the {@code categoryperms:} clause) to
+	 * the given query based on the user's roles, so results are additionally narrowed by the
+	 * category read permissions of content types that declare a category field with
+	 * {@code secondaryPermissionCheck=true}. Self-guards on {@code PERMISSION_SECONDARY_CATEGORY_CHECK}
+	 * and on admin users. Must be applied alongside {@link #addPermissionsToQuery} by every search
+	 * backend (ES and OS) to keep permission filtering consistent across the migration phases.
+	 *
+	 * @param buffy the query buffer to append to
+	 * @param user the user performing the search
+	 * @param roles the user's roles
+	 * @param respectFrontendRoles whether to include the anonymous/frontend role
+	 */
+	public void addCategoryPermissionsToQuery ( StringBuffer buffy, User user, List<Role> roles, boolean respectFrontendRoles );
+
+	/**
 	 * The search here takes a lucene query and pulls LuceneHits for you.  You can pass sortBy as null if you do not 
 	 * have a field to sort by.  limit should be 0 if no limit and the offset should be -1 is you are not paginating.
 	 * The returned list will be filtered with only the contentlets that the user can read(use).  you can of course also

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -2206,6 +2206,11 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 	}
 
 	@Override
+	public void addCategoryPermissionsToQuery ( StringBuffer buffy, User user, List<Role> roles, boolean respectFrontendRoles ) {
+		conAPI.addCategoryPermissionsToQuery( buffy, user, roles, respectFrontendRoles );
+	}
+
+	@Override
 	public void setContentletProperty(Contentlet contentlet, Field field, Object value) throws DotContentletStateException {
 		for(ContentletAPIPreHook pre : preHooks){
 			boolean preResult = pre.setContentletProperty(contentlet, field, value);


### PR DESCRIPTION
## Security fix — permission leak under Phase 3 (OS-only reads)

Found by the **Phase 3 (OS-only) integration triage** (family F7).

### Problem
Under Phase 3 the OpenSearch search path **omitted the secondary category-permission filter**, leaking content restricted by category read permissions to users who lack the category role.

- **ES path** — `ESContentletAPIImpl.applyPermissionsToQuery` (lines 1659-1661) applies **both** `addPermissionsToQuery` **and** `addCategoryPermissionsToQuery`.
- **OS path** — `OSSearchAPIImpl.executeSearch` (lines ~298-302) called **only** `addPermissionsToQuery`. The `categoryperms:` clause was never added, so any contentlet passing the base owner/role filter was returned regardless of its secondary category permissions.

Reproduced by `SecondaryCategoryPermissionTest.test_opensearch_query_respects_permissions`: `snowUser` saw **3** contentlets instead of **2** under Phase 3.

### Fix
Expose `addCategoryPermissionsToQuery` on the `ContentletAPI` interface (it was package-private) and call it from `OSSearchAPIImpl` right after `addPermissionsToQuery`, mirroring the ES path.

- `ContentletAPI` — add `addCategoryPermissionsToQuery` to the interface.
- `ESContentletAPIImpl` — package-private → `public @Override` (behavior unchanged; the ES internal path still calls it directly).
- `ContentletAPIInterceptor` — delegate to `conAPI`.
- `OSSearchAPIImpl.executeSearch` — add the category-permission call.

The method self-guards on `PERMISSION_SECONDARY_CATEGORY_CHECK` and admin users, and always appends `categoryperms:none`, so content **without** category restrictions is not over-filtered (no false negatives).

### Verification
| Run | Result |
|---|---|
| `SecondaryCategoryPermissionTest` @ **Phase 3** | **4/4** ✅ (was leaking `snowUser` 3→2) |
| `SecondaryCategoryPermissionTest` @ **Phase 0** | **4/4** ✅ (no ES regression) |
| core build | `BUILD SUCCESS` |

Fixes a real permission-filter gap for OS-only reads. Part of #36501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36501