### PR TITLE
fix(opensearch): tolerate version conflicts in OS delete-by-query on content-type removal

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
@@ -376,6 +376,13 @@ public class ContentletIndexOperationsOS implements ContentletIndexOperations {
                 final org.opensearch.client.opensearch.core.DeleteByQueryRequest deleteByQuery =
                         org.opensearch.client.opensearch.core.DeleteByQueryRequest.of(r -> r
                                 .index(physical)
+                                // Proceed past version conflicts instead of aborting: a document
+                                // updated concurrently (e.g. just published) would otherwise return
+                                // HTTP 409 version_conflict_engine_exception and fail the whole
+                                // content-type removal, which callers swallow — orphaning downstream
+                                // cleanup (e.g. the unique_fields table). Matches ES delete_by_query
+                                // tolerance and keeps the operation best-effort.
+                                .conflicts(org.opensearch.client.opensearch._types.Conflicts.Proceed)
                                 .query(q -> q.queryString(
                                         QueryStringQuery.of(qs -> qs.query(
                                                 "contenttype:" + structureName.toLowerCase())))));


### PR DESCRIPTION
## Data-consistency fix — orphaned `unique_fields` rows under Phase 3

Found by the Phase 3 (OS-only) integration triage.

### Problem (chain)
1. Deleting a content type right after publishing content: `ContentletIndexOperationsOS.removeContentFromIndexByContentType` issues an OS `_delete_by_query` **without `conflicts=proceed`**. A document whose version just changed (publish) returns **HTTP 409 `version_conflict_engine_exception`** → the removal aborts with a `DotDataException`.
2. `ContentTypeAPIImpl.internalRelocateThenDispose` **swallows** that exception, so the commit listener that fires `ContentTypeDeletedEvent` is never registered.
3. The `UniqueFieldsTableCleaner` subscriber that purges `unique_fields` never runs → **orphaned rows**.

Reproduced by `ESContentletAPIImplTest.cleanUpExtraTableAfterDeleteContentType`, which failed **only under Phase 3** (passed under Phase 0).

### Fix
Set `conflicts=Proceed` on the OS `DeleteByQueryRequest` so content-type removal is best-effort and does not abort on a concurrent version change — matching ES `delete_by_query` tolerance.

### Verification
| Run | Result |
|---|---|
| `ESContentletAPIImplTest` @ **Phase 3** | **92/0/0** — `cleanUpExtra` now passes (was failing) ✅ |
| `ESContentletAPIImplTest` @ **Phase 0** | **92/0/0** — no regression ✅ |
| core build | `BUILD SUCCESS` |

(The ~23 `duplicate key ... unique_fields_pkey` log lines are a stable baseline present identically in both phases before and after this change — they are the unique-field validation rejecting duplicates in its own dedicated tests, not orphan collisions.)

### Follow-up (separate PR)
Decouple `ContentTypeDeletedEvent` firing from index-removal success in `ContentTypeAPIImpl.internalRelocateThenDispose` so a future index error cannot again silently orphan the DB cleanup (defense-in-depth).

Part of #36501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36501