### PR TITLE
fix(content-type): index-cleanup failure must not abort content-type deletion (hardening)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/ContentTypeAPIImpl.java
@@ -283,7 +283,18 @@ public class ContentTypeAPIImpl implements ContentTypeAPI {
   @WrapInTransaction
   private void internalRelocateThenDispose(final ContentType source, final ContentType target, final boolean asyncDeleteWithJob) {
     try {
-      APILocator.getContentletIndexAPI().removeContentFromIndexByContentType(source);
+      // Removing the content type's documents from the search index is best-effort: the content
+      // type is being deleted regardless. A failure here (e.g. an OpenSearch version conflict or a
+      // missing index) must NOT abort relocation, the DB deletion, or the ContentTypeDeletedEvent
+      // that drives downstream cleanup (e.g. the unique_fields table) — otherwise a transient index
+      // error silently orphans that cleanup and leaves the content type half-deleted.
+      try {
+        APILocator.getContentletIndexAPI().removeContentFromIndexByContentType(source);
+      } catch (final Exception indexEx) {
+        Logger.error(ContentTypeFactoryImpl.class, String.format(
+            "Error removing content from index for ContentType [%s] — continuing with deletion",
+            source.variable()), indexEx);
+      }
       final Integer relocated = APILocator.getContentTypeDestroyAPI().relocateContentletsForDeletion(source, target);
 
       Logger.info(ContentTypeFactoryImpl.class, String.format("::: Relocated %d contentlets for ContentType [%s] to [%s] :::", relocated, source.variable(), target.variable()));


### PR DESCRIPTION
## What

Defense-in-depth from the Phase 3 (OS-only) triage. `ContentTypeAPIImpl.internalRelocateThenDispose` called `ContentletIndexAPI.removeContentFromIndexByContentType` inside the same `try` whose `catch` swallows `DotDataException`. If index removal threw (e.g. an OpenSearch version conflict under Phase 3, or a missing index), execution skipped **relocation, the DB deletion, and the commit listener that fires `ContentTypeDeletedEvent`** — leaving the content type half-deleted and orphaning downstream cleanup keyed off that event (e.g. the `unique_fields` table via `UniqueFieldsTableCleaner`).

## Fix

Index removal is best-effort (the content type is being deleted regardless). Isolate it in its own `try/catch` that logs and continues, so a transient index error no longer aborts relocation, DB deletion, or the `ContentTypeDeletedEvent`.

Complements the direct-trigger fix **#36680** (`conflicts=proceed` on the OS delete-by-query): #36680 stops the specific version conflict; this PR guards against **any** future index-removal error.

## Verification (on `main`, WITHOUT #36680)

| Run | Result |
|---|---|
| `ESContentletAPIImplTest` @ **Phase 3** | **92/0/0** — `cleanUpExtraTableAfterDeleteContentType` passes despite the index version conflict still occurring on this branch (proves the decoupling fixes the data-consistency bug independently) ✅ |
| `ESContentletAPIImplTest` @ **Phase 0** | **92/0/0** — no regression ✅ |
| core build | `BUILD SUCCESS` |

Part of #36501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36501