### PR TITLE
fix(cache): preserve portlet initParams across Redis cache serialization (#34435)

### DIFF
--- a/dotCMS/src/main/java/com/liferay/portal/model/Portlet.java
+++ b/dotCMS/src/main/java/com/liferay/portal/model/Portlet.java
@@ -257,6 +257,8 @@ public class Portlet extends PortletModel {
   private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
     if (this.initParams == null) {
+      Logger.warn(this, "Portlet '" + this.portletId + "' deserialized with null initParams "
+          + "(a transient field lost during cache deserialization); defaulting to an empty map.");
       this.initParams = new HashMap<>();
     }
   }

--- a/dotCMS/src/main/java/com/liferay/portal/model/Portlet.java
+++ b/dotCMS/src/main/java/com/liferay/portal/model/Portlet.java
@@ -6,6 +6,8 @@ import com.dotmarketing.util.Logger;
 import com.liferay.portal.ejb.PortletPK;
 import com.liferay.portlet.ConcretePortletWrapper;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -25,7 +27,7 @@ public class Portlet extends PortletModel {
 
   private static final long serialVersionUID = 1L;
 
-  protected transient Map<String, String> initParams;
+  protected Map<String, String> initParams;
   protected String portletId;
   protected String portletClass;
   protected String portletSource;
@@ -243,6 +245,20 @@ public class Portlet extends PortletModel {
     }
 
     return cachedInstance;
+  }
+
+  /**
+   * Custom deserialization guard. The {@code initParams} field was historically {@code transient},
+   * so any {@link Portlet} serialized by an earlier version — or by any cache provider that drops
+   * transient state (e.g. the Redis provider) — deserializes it as {@code null}. Default it to an
+   * empty map so downstream {@code PortletConfig} look-ups never throw a {@link NullPointerException}
+   * on stale cached objects that survive a container restart.
+   */
+  private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    if (this.initParams == null) {
+      this.initParams = new HashMap<>();
+    }
   }
 
 }

--- a/dotCMS/src/main/java/com/liferay/portlet/PortletConfigImpl.java
+++ b/dotCMS/src/main/java/com/liferay/portlet/PortletConfigImpl.java
@@ -73,7 +73,11 @@ public class PortletConfigImpl implements PortletConfig {
 		}
 
 		_portletCtx = portletCtx;
-		_params = params;
+		if (params == null) {
+			Logger.warn(this, "Portlet '" + _portletId + "' was loaded with null init parameters: "
+					+ "defaulting to an empty parameter map.");
+		}
+		_params = params != null ? params : CollectionFactory.getHashMap();
 		_resourceBundle = resourceBundle;
 		_portletInfo = portletInfo;
 		_bundlePool = CollectionFactory.getHashMap();

--- a/dotCMS/src/test/java/com/liferay/portal/model/PortletSerializationTest.java
+++ b/dotCMS/src/test/java/com/liferay/portal/model/PortletSerializationTest.java
@@ -1,0 +1,65 @@
+package com.liferay.portal.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Regression tests for issue #34435: when the Portlet cache is backed by a serializing provider
+ * (e.g. Redis), a cached {@link Portlet} is round-tripped through Java serialization. The
+ * {@code initParams} field used to be {@code transient}, so it came back {@code null} after
+ * deserialization and later NPE'd in {@code PortletConfigImpl.getInitParameterNames()}.
+ */
+public class PortletSerializationTest {
+
+    private static Portlet roundTrip(final Portlet portlet) throws Exception {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(portlet);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (Portlet) in.readObject();
+        }
+    }
+
+    /**
+     * A Portlet serialized and deserialized (as it is when stored in a Redis-backed cache) must
+     * preserve its init parameters rather than returning a null map.
+     */
+    @Test
+    public void test_initParams_survive_serialization_roundtrip() throws Exception {
+        final Map<String, String> initParams = new HashMap<>();
+        initParams.put("view-action", "/ext/contentlet/view_contentlets");
+        initParams.put("name", "content");
+
+        final Portlet deserialized = roundTrip(new Portlet("content", "com.liferay.portlet.StrutsPortlet", initParams));
+
+        assertNotNull("initParams must not be null after deserialization", deserialized.getInitParams());
+        assertEquals(initParams, deserialized.getInitParams());
+    }
+
+    /**
+     * Simulates an object serialized by an older version where {@code initParams} was transient (so
+     * it is absent from the stream). The {@code readObject} guard must default it to an empty map so
+     * downstream look-ups never NPE.
+     */
+    @Test
+    public void test_null_initParams_defaults_to_empty_map_after_deserialization() throws Exception {
+        final Portlet portlet = new Portlet("content", "com.liferay.portlet.StrutsPortlet", new HashMap<>());
+        // Force the pre-fix state: a Portlet whose initParams was dropped during serialization.
+        portlet.initParams = null;
+
+        final Portlet deserialized = roundTrip(portlet);
+
+        assertNotNull("Guard must replace a null initParams with an empty map", deserialized.getInitParams());
+        assertTrue("Recovered init params should be empty", deserialized.getInitParams().isEmpty());
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/cache/lettuce/LettuceCacheTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/cache/lettuce/LettuceCacheTest.java
@@ -156,24 +156,29 @@ public class LettuceCacheTest {
     public void test_portlet_initParams_survive_redis_roundtrip() {
 
         if (RedisClientFactory.getClient("cache").ping()) {
-            final String group = "portletcache";
+            // Isolated test-only group so we never pollute the real "portletcache" namespace that
+            // PortletCache and admin tooling use; RedisCache has no default TTL, so a leaked key
+            // would persist indefinitely on the shared integration Redis.
+            final String group = "portletcache_test_" + System.currentTimeMillis();
             final String key = "portlet" + System.currentTimeMillis();
-            cache.remove(group, key);
 
-            final Map<String, String> initParams = new HashMap<>();
-            initParams.put("view-action", "/ext/contentlet/view_contentlets");
-            initParams.put("name", "content");
-            final Portlet portlet = new Portlet("content", "com.liferay.portlet.StrutsPortlet", initParams);
+            try {
+                final Map<String, String> initParams = new HashMap<>();
+                initParams.put("view-action", "/ext/contentlet/view_contentlets");
+                initParams.put("name", "content");
+                final Portlet portlet = new Portlet("content", "com.liferay.portlet.StrutsPortlet", initParams);
 
-            cache.put(group, key, portlet);
+                cache.put(group, key, portlet);
 
-            final Portlet cached = (Portlet) cache.get(group, key);
-            Assert.assertNotNull("Portlet should be returned from Redis cache", cached);
-            Assert.assertNotNull("initParams must survive the Redis serialization round-trip",
-                    cached.getInitParams());
-            Assert.assertEquals(initParams, cached.getInitParams());
-
-            cache.remove(group, key);
+                final Portlet cached = (Portlet) cache.get(group, key);
+                Assert.assertNotNull("Portlet should be returned from Redis cache", cached);
+                Assert.assertNotNull("initParams must survive the Redis serialization round-trip",
+                        cached.getInitParams());
+                Assert.assertEquals(initParams, cached.getInitParams());
+            } finally {
+                // Clean up even if an assertion above fails, so no stray key is left behind.
+                cache.remove(group, key);
+            }
         }
     }
 }

--- a/dotcms-integration/src/test/java/com/dotcms/cache/lettuce/LettuceCacheTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/cache/lettuce/LettuceCacheTest.java
@@ -1,12 +1,16 @@
 package com.dotcms.cache.lettuce;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.UUIDGenerator;
+import com.liferay.portal.model.Portlet;
 
 /**
  * Test for {@link RedisCache}
@@ -20,6 +24,7 @@ public class LettuceCacheTest {
     
     @BeforeClass
     public static void startup() throws Exception {
+        IntegrationTestInitService.getInstance().init();
         cache = new RedisCache();
     }
 
@@ -137,6 +142,38 @@ public class LettuceCacheTest {
                 assert (uuid.equals(con.getIdentifier()));
                 assert (uuid.equals(con.getMap().get("testing")));
             }
+        }
+    }
+
+    /**
+     * Regression test for issue #34435: a {@link Portlet} cached in Redis is round-tripped through
+     * {@code DotObjectCodec}'s Java serialization. The {@code initParams} field used to be
+     * {@code transient}, so it came back {@code null} after a container restart and later NPE'd in
+     * {@code PortletConfigImpl.getInitParameterNames()}. This asserts the init parameters survive the
+     * real Redis put/get path (not just an in-memory ObjectStream round-trip).
+     */
+    @Test
+    public void test_portlet_initParams_survive_redis_roundtrip() {
+
+        if (RedisClientFactory.getClient("cache").ping()) {
+            final String group = "portletcache";
+            final String key = "portlet" + System.currentTimeMillis();
+            cache.remove(group, key);
+
+            final Map<String, String> initParams = new HashMap<>();
+            initParams.put("view-action", "/ext/contentlet/view_contentlets");
+            initParams.put("name", "content");
+            final Portlet portlet = new Portlet("content", "com.liferay.portlet.StrutsPortlet", initParams);
+
+            cache.put(group, key, portlet);
+
+            final Portlet cached = (Portlet) cache.get(group, key);
+            Assert.assertNotNull("Portlet should be returned from Redis cache", cached);
+            Assert.assertNotNull("initParams must survive the Redis serialization round-trip",
+                    cached.getInitParams());
+            Assert.assertEquals(initParams, cached.getInitParams());
+
+            cache.remove(group, key);
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Fixes #34435 — the Portlet cache throws a `NullPointerException` when using the Redis cache provider after a container restart.

### Root cause
`Portlet.initParams` was declared `transient`. A Redis-backed cache truly serializes cached objects (via `DotObjectCodec`, plain Java serialization), so `transient` fields come back `null` on deserialization. That null map flows into `PortletConfigImpl` and NPEs at `getInitParameterNames()` (`_params.keySet()`) when the portlet is rendered after a restart. In-memory/Caffeine providers never serialize, which is why the bug only appears under Redis.

### Changes
- **`Portlet.java`** — remove `transient` from `initParams` so it is serialized; add a `readObject` guard that defaults a `null` map to empty. The guard self-heals *stale* Portlet blobs already sitting in Redis from before this fix, which survive a restart and would otherwise still deserialize `initParams` as `null`.
- **`PortletConfigImpl.java`** — null-safe `_params` (defaults to an empty map) with a `Logger.warn` diagnostic, so a null params map degrades gracefully instead of breaking dotCMS.
- **`PortletSerializationTest.java`** *(new unit test)* — asserts `initParams` survives a Java serialization round-trip and that a null-`initParams` blob recovers to an empty map.
- **`LettuceCacheTest.java`** — add a Redis round-trip regression test through the real `RedisCache`/`DotObjectCodec` path; also add the standard `IntegrationTestInitService` bootstrap so the class can run standalone via `-Dit.test=LettuceCacheTest`, not only inside `MainSuite2b`.

### Testing
- `PortletSerializationTest` — passing (unit, no services required).
- `LettuceCacheTest#test_portlet_initParams_survive_redis_roundtrip` — runs against a live Redis (`ping()`-gated).
- Manually verified in Docker with Redis as a cache provider: the Site Browser / Search Content portlets render correctly after a dotCMS restart with Redis retaining the cached data.

### Follow-ups (filed separately, out of scope here)
- #36674 — harden the Redis cache codec (`DotObjectCodec`) against unsafe Java deserialization.
- #36689 — `LanguagesResource.getAllMessages` throws on duplicate language keys (surfaced while QA-testing this fix; unrelated subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34435