### PR TITLE
fix(rules-engine): restore session clickstream recording on live render (#36604)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
@@ -19,6 +19,7 @@ import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.factories.ClickstreamFactory;
 import com.dotmarketing.filters.CMSUrlUtil;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
 import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
@@ -142,6 +143,10 @@ public class VelocityLiveMode extends VelocityModeHandler {
         // Fire the page rules until we know we have permission.
         RulesEngine.fireRules(request, response, htmlPage, Rule.FireOn.EVERY_PAGE);
 
+        // Record this request in the session clickstream BEFORE any page-cache short-circuit so
+        // visit-history rule conditions ("Has Visited URL" / "Pages Viewed") still see the visit
+        // even when a cached copy of the page is served. Regression fix for issue #36604.
+        recordClickstream();
 
         addHeaders(htmlPage);
         processUrlMapTags(request);
@@ -268,6 +273,26 @@ public class VelocityLiveMode extends VelocityModeHandler {
 
     User getUser() {
         return PortalUtil.getUser(request);
+    }
+
+    /**
+     * Records the current request in the visitor's session clickstream so Rules Engine conditions
+     * that inspect visit history -- "Has Visited URL" ({@code VisitedUrlConditionlet}) and
+     * "Pages Viewed" ({@code PagesViewedConditionlet}) -- can evaluate against it.
+     * <p>
+     * Gated by the legacy {@code ENABLE_CLICKSTREAM_TRACKING} flag (default {@code false}),
+     * preserving pre-regression behaviour. Recording is a session-scoped, in-memory operation, so a
+     * failure here is logged and swallowed rather than allowed to break page delivery.
+     */
+    private void recordClickstream() {
+        if (!Config.getBooleanProperty("ENABLE_CLICKSTREAM_TRACKING", false)) {
+            return;
+        }
+        Logger.debug(this.getClass(), "Recording the ClickStream");
+        Try.run(() -> ClickstreamFactory.addRequest(request, response, host))
+                .onFailure(e -> Logger.warnAndDebug(VelocityLiveMode.class,
+                        "Unable to record clickstream for URI: " + request.getRequestURI()
+                                + " : " + e.getMessage(), e));
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/servlet/VelocityLiveModeTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/servlet/VelocityLiveModeTest.java
@@ -234,6 +234,104 @@ public class VelocityLiveModeTest {
                 params2.getKey().contains("originalUri:/store/456/globex/catalog/"));
     }
 
+    /**
+     * Method: {@link VelocityLiveMode#serve(java.io.OutputStream)}
+     * When: A live page is rendered while {@code ENABLE_CLICKSTREAM_TRACKING} is enabled
+     * Should: Record the visit in the visitor's session clickstream so visit-history rule
+     *         conditions ("Has Visited URL" / "Pages Viewed") can evaluate against it.
+     *         Regression test for #36604 -- the page-cache thundering-herd refactor
+     *         (393d74ff11) dropped the {@code ClickstreamFactory.addRequest} call from the live
+     *         render path, leaving those conditions with an empty clickstream so they never
+     *         matched. The conditionlet unit tests could not catch this because they seed the
+     *         clickstream themselves rather than exercising the render path.
+     */
+    @Test
+    public void renderLivePageRecordsVisitInSessionClickstreamWhenTrackingEnabled() throws Exception {
+        final boolean previous = Config.getBooleanProperty("ENABLE_CLICKSTREAM_TRACKING", false);
+        Config.setProperty("ENABLE_CLICKSTREAM_TRACKING", true);
+        try {
+            final Host host = new SiteDataGen().nextPersisted();
+            final HTMLPageAsset page = createAndPublishRenderablePage(host);
+
+            final Clickstream clickstream = new Clickstream();
+            renderLivePage(host, page, clickstream);
+
+            final String pageUri = page.getURI();
+            assertTrue("Rendering a live page must record the visit in the session clickstream",
+                    clickstream.getClickstreamRequests().stream()
+                            .anyMatch(cr -> pageUri.equals(cr.getRequestURI())));
+        } finally {
+            Config.setProperty("ENABLE_CLICKSTREAM_TRACKING", previous);
+        }
+    }
+
+    /**
+     * Method: {@link VelocityLiveMode#serve(java.io.OutputStream)}
+     * When: A live page is rendered while {@code ENABLE_CLICKSTREAM_TRACKING} is disabled (default)
+     * Should: Not record anything in the session clickstream, preserving the flag-gated behaviour.
+     */
+    @Test
+    public void renderLivePageDoesNotRecordVisitWhenTrackingDisabled() throws Exception {
+        final boolean previous = Config.getBooleanProperty("ENABLE_CLICKSTREAM_TRACKING", false);
+        Config.setProperty("ENABLE_CLICKSTREAM_TRACKING", false);
+        try {
+            final Host host = new SiteDataGen().nextPersisted();
+            final HTMLPageAsset page = createAndPublishRenderablePage(host);
+
+            final Clickstream clickstream = new Clickstream();
+            renderLivePage(host, page, clickstream);
+
+            assertTrue("Clickstream must remain empty when tracking is disabled",
+                    clickstream.getClickstreamRequests().isEmpty());
+        } finally {
+            Config.setProperty("ENABLE_CLICKSTREAM_TRACKING", previous);
+        }
+    }
+
+    /**
+     * Builds and publishes a minimal renderable live page (site content type, published container,
+     * published template and page) so it can be served through the live velocity render path.
+     */
+    private HTMLPageAsset createAndPublishRenderablePage(final Host host)
+            throws DotDataException, DotSecurityException, WebAssetException {
+        final Field field = new FieldDataGen().type(TextField.class).next();
+        final ContentType contentType = new ContentTypeDataGen().field(field).nextPersisted();
+
+        final Container container = new ContainerDataGen()
+                .site(host)
+                .withContentType(contentType, "<h1>$!{test}</h1>")
+                .nextPersisted();
+        ContainerDataGen.publish(container);
+
+        final Template template = new TemplateDataGen()
+                .site(host)
+                .withContainer(container, "1")
+                .nextPersisted();
+        TemplateDataGen.publish(template);
+
+        final HTMLPageAsset page = new HTMLPageDataGen(host, template).nextPersisted();
+        HTMLPageDataGen.publish(page);
+        return page;
+    }
+
+    /**
+     * Renders the given page through the live velocity mode handler using a mocked session that
+     * exposes the supplied clickstream, mirroring the harness used by {@link #contentSecurityPolice}.
+     */
+    private void renderLivePage(final Host host, final HTMLPageAsset page, final Clickstream clickstream)
+            throws DotDataException, DotSecurityException, WebAssetException {
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final HttpSession session = mock(HttpSession.class);
+        final DotCMSMockRequestWithSession request = new DotCMSMockRequestWithSession(session, false);
+        request.setRequestURI(page.getURI());
+        HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
+        when(session.getAttribute("clickstream")).thenReturn(clickstream);
+
+        final VelocityModeHandler handler = VelocityModeHandler.modeHandler(
+                PageMode.LIVE, request, response, page.getURI(), host);
+        handler.eval();
+    }
+
     private static class TestCase {
         String htmlCodeExpected;
         String contentSecurityPolicyHeader;


### PR DESCRIPTION
### Proposed Changes
* Restore the `ClickstreamFactory.addRequest(...)` call in `VelocityLiveMode.serve()` that the page-cache thundering-herd refactor (`393d74ff11`, ref #33287) removed. It is placed **before any page-cache short-circuit**, so the visit is recorded on every live delivery — including pages served from the page cache — via a new `recordClickstream()` helper.
* The helper stays gated by the legacy `ENABLE_CLICKSTREAM_TRACKING` flag (default `false`), preserving pre-regression behaviour, and wraps the call in `Try.run(...).onFailure(log)` so a recording failure can never break page delivery (the original let `DotDataException` propagate).
* Add `VelocityLiveModeTest` regression coverage that renders a page through the live servlet path (`eval()` → `serve()`) and asserts the visit lands in the session clickstream (flag on), and that nothing is recorded when the flag is off.

### Root cause
`VisitedUrlConditionlet` and `PagesViewedConditionlet` read the `"clickstream"` `HttpSession` attribute. Since Sept 2025, `VelocityLiveMode` no longer populated it, so both conditions were frozen on the empty-history result — `Has Visited URL | contains` (and most operators) never matched, while inverted operators (`is not`, `less than`, `equals 0`) matched for every visitor. The recording is a cheap in-session operation (DB persistence is separate), so restoring it carries no thundering-herd cost.

Why existing tests missed it: `VisitedUrlConditionletTest` / `PagesViewedConditionletTest` seed the clickstream themselves and never exercise the render-path wiring that regressed.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
* **Security:** none — restores in-session, flag-gated visit recording; no new input handling, no data exposure.
* **Follow-ups:**
  * **LTS backports (AC #5):** needs cherry-pick to `24.12.27` and `25.07.10` (regression was backported there via `c0a694316d` / `1c8980da79`).
  * **Open product decision (AC #4):** this ships the faithful flag-guarded restore. Alternative discussed on the issue: decouple recording from `ENABLE_CLICKSTREAM_TRACKING` so the conditions work out-of-the-box (now low-risk since the flag's old heavy job — DB persistence via the commented-out `ClickstreamFilter` — is dead). Left as a separate decision rather than changing a default in an LTS patch.

Refs: #36604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36604