### PR TITLE
fix(edit-ema): form selector search input and server-side pagination

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.html
@@ -1,4 +1,13 @@
-<p-table [value]="data | async" [tableStyle]="{ 'min-width': '100%' }">
+<p-iconField>
+    <p-inputIcon styleClass="pi pi-search" />
+    <input
+        pInputText
+        type="text"
+        [placeholder]="'search' | dm"
+        [formControl]="searchControl"
+        data-testid="form-search-input" />
+</p-iconField>
+<p-table [value]="$forms()" [tableStyle]="{ 'min-width': '100%' }">
     <ng-template pTemplate="header">
         <tr>
             <th id="name">{{ 'name' | dm }}</th>
@@ -18,4 +27,14 @@
             </td>
         </tr>
     </ng-template>
+    <ng-template pTemplate="emptymessage">
+        <tr>
+            <td colspan="3">{{ 'No-Results-Found' | dm }}</td>
+        </tr>
+    </ng-template>
 </p-table>
+<p-paginator
+    [rows]="perPage"
+    [totalRecords]="$totalRecords()"
+    (onPageChange)="onPageChange($event)"
+    data-testid="form-paginator" />

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.html
@@ -35,6 +35,7 @@
 </p-table>
 <p-paginator
     [rows]="perPage"
+    [first]="$first()"
     [totalRecords]="$totalRecords()"
     (onPageChange)="onPageChange($event)"
     data-testid="form-paginator" />

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.html
@@ -21,6 +21,7 @@
             <td headers="description">{{ contenttype.description }}</td>
             <td headers="action" style="min-width: fit-content; text-align: right">
                 <p-button
+                    data-testid="form-select-button"
                     (click)="selected.emit(contenttype.id)"
                     styleClass="p-button-outlined"
                     label="Select" />

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
@@ -97,7 +97,7 @@ describe('EmaFormSelectorComponent', () => {
     });
 
     it('should call getContentTypesWithPagination with filter after debounce', () => {
-        const service = spectator.inject(DotContentTypeService);
+        const service = spectator.debugElement.injector.get(DotContentTypeService);
         (service.getContentTypesWithPagination as jest.Mock).mockClear();
         spectator.component.searchControl.setValue('test form');
         jest.advanceTimersByTime(300);
@@ -107,7 +107,7 @@ describe('EmaFormSelectorComponent', () => {
     });
 
     it('should reset to page 1 and re-fetch when search changes', () => {
-        const service = spectator.inject(DotContentTypeService);
+        const service = spectator.debugElement.injector.get(DotContentTypeService);
         (service.getContentTypesWithPagination as jest.Mock).mockClear();
         spectator.component.searchControl.setValue('form');
         jest.advanceTimersByTime(300);
@@ -121,7 +121,7 @@ describe('EmaFormSelectorComponent', () => {
     });
 
     it('should show empty state when no forms are returned', () => {
-        const service = spectator.inject(DotContentTypeService);
+        const service = spectator.debugElement.injector.get(DotContentTypeService);
         (service.getContentTypesWithPagination as jest.Mock).mockReturnValue(
             of({ contentTypes: [], pagination: { totalEntries: 0, currentPage: 1, perPage: 40 } })
         );
@@ -131,7 +131,7 @@ describe('EmaFormSelectorComponent', () => {
     });
 
     it('should fetch page 2 and update $first when paginator changes', () => {
-        const service = spectator.inject(DotContentTypeService);
+        const service = spectator.debugElement.injector.get(DotContentTypeService);
         (service.getContentTypesWithPagination as jest.Mock).mockClear();
         spectator.component['onPageChange']({ page: 1, first: 40, rows: 40, pageCount: 3 });
         expect(service.getContentTypesWithPagination).toHaveBeenCalledWith(
@@ -141,7 +141,7 @@ describe('EmaFormSelectorComponent', () => {
     });
 
     it('should handle HTTP errors without terminating the stream', () => {
-        const service = spectator.inject(DotContentTypeService);
+        const service = spectator.debugElement.injector.get(DotContentTypeService);
         const errorManager = spectator.inject(DotHttpErrorManagerService);
         (service.getContentTypesWithPagination as jest.Mock).mockReturnValue(
             throwError(() => new Error('Network error'))

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
@@ -10,7 +10,11 @@ import { InputTextModule } from 'primeng/inputtext';
 import { PaginatorModule } from 'primeng/paginator';
 import { TableModule } from 'primeng/table';
 
-import { DotContentTypeService, DotHttpErrorManagerService, DotMessageService } from '@dotcms/data-access';
+import {
+    DotContentTypeService,
+    DotHttpErrorManagerService,
+    DotMessageService
+} from '@dotcms/data-access';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 
 import { EmaFormSelectorComponent } from './ema-form-selector.component';

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
@@ -1,5 +1,5 @@
-import { createComponentFactory, Spectator } from '@openng/spectator/jest';
-import { of } from 'rxjs';
+import { createComponentFactory, mockProvider, Spectator } from '@openng/spectator/jest';
+import { of, throwError } from 'rxjs';
 
 import { ReactiveFormsModule } from '@angular/forms';
 
@@ -10,7 +10,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { PaginatorModule } from 'primeng/paginator';
 import { TableModule } from 'primeng/table';
 
-import { DotContentTypeService, DotMessageService } from '@dotcms/data-access';
+import { DotContentTypeService, DotHttpErrorManagerService, DotMessageService } from '@dotcms/data-access';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 
 import { EmaFormSelectorComponent } from './ema-form-selector.component';
@@ -51,7 +51,8 @@ describe('EmaFormSelectorComponent', () => {
                             of({ contentTypes: mockForms, pagination: mockPagination })
                         )
                 }
-            }
+            },
+            mockProvider(DotHttpErrorManagerService)
         ]
     });
 
@@ -119,5 +120,34 @@ describe('EmaFormSelectorComponent', () => {
         spectator.component['fetch$'].next();
         spectator.detectChanges();
         expect(spectator.query('td[colspan="3"]')).not.toBeNull();
+    });
+
+    it('should fetch page 2 and update $first when paginator changes', () => {
+        const service = spectator.inject(DotContentTypeService);
+        (service.getContentTypesWithPagination as jest.Mock).mockClear();
+        spectator.component.onPageChange({ page: 1, first: 40, rows: 40, pageCount: 3 });
+        expect(service.getContentTypesWithPagination).toHaveBeenCalledWith(
+            expect.objectContaining({ page: 2 })
+        );
+        expect(spectator.component['$first']()).toBe(40);
+    });
+
+    it('should handle HTTP errors without terminating the stream', () => {
+        const service = spectator.inject(DotContentTypeService);
+        const errorManager = spectator.inject(DotHttpErrorManagerService);
+        (service.getContentTypesWithPagination as jest.Mock).mockReturnValue(
+            throwError(() => new Error('Network error'))
+        );
+        spectator.component['fetch$'].next();
+        spectator.detectChanges();
+        expect(errorManager.handle).toHaveBeenCalled();
+
+        // Stream must still be alive: a subsequent fetch with a good response should work
+        (service.getContentTypesWithPagination as jest.Mock).mockReturnValue(
+            of({ contentTypes: mockForms, pagination: mockPagination })
+        );
+        spectator.component['fetch$'].next();
+        spectator.detectChanges();
+        expect(spectator.component['$forms']()).toEqual(mockForms);
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
@@ -1,9 +1,13 @@
-import { byText, createComponentFactory, Spectator } from '@openng/spectator/jest';
+import { createComponentFactory, Spectator } from '@openng/spectator/jest';
 import { of } from 'rxjs';
 
-import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
+import { IconFieldModule } from 'primeng/iconfield';
+import { InputIconModule } from 'primeng/inputicon';
+import { InputTextModule } from 'primeng/inputtext';
+import { PaginatorModule } from 'primeng/paginator';
 import { TableModule } from 'primeng/table';
 
 import { DotContentTypeService, DotMessageService } from '@dotcms/data-access';
@@ -11,50 +15,64 @@ import { MockDotMessageService } from '@dotcms/utils-testing';
 
 import { EmaFormSelectorComponent } from './ema-form-selector.component';
 
+const mockForms = [{ id: '1', name: 'Test Form', description: 'Description' }];
+const mockPagination = { totalEntries: 1, currentPage: 1, perPage: 40 };
+
 describe('EmaFormSelectorComponent', () => {
     let spectator: Spectator<EmaFormSelectorComponent>;
-    let mockDotContentTypeService: Partial<DotContentTypeService>;
     const createComponent = createComponentFactory({
         component: EmaFormSelectorComponent,
-        imports: [CommonModule, TableModule, ButtonModule],
-        mocks: [DotContentTypeService],
+        imports: [
+            TableModule,
+            ButtonModule,
+            IconFieldModule,
+            InputIconModule,
+            InputTextModule,
+            PaginatorModule,
+            ReactiveFormsModule
+        ],
         providers: [
             {
                 provide: DotMessageService,
                 useValue: new MockDotMessageService({
                     name: 'Name',
                     description: 'Description',
-                    Actions: 'Actions'
+                    Actions: 'Actions',
+                    search: 'Search',
+                    'No-Results-Found': 'No results found'
                 })
+            },
+            {
+                provide: DotContentTypeService,
+                useValue: {
+                    getContentTypesWithPagination: jest
+                        .fn()
+                        .mockReturnValue(
+                            of({ contentTypes: mockForms, pagination: mockPagination })
+                        )
+                }
             }
         ]
     });
 
     beforeEach(() => {
-        // Mock the DotContentTypeService and its methods
-        mockDotContentTypeService = {
-            getByTypes: jest
-                .fn()
-                .mockReturnValue(of([{ id: '1', name: 'Test Type', description: 'Description' }]))
-        };
+        jest.useFakeTimers();
+        spectator = createComponent();
+        spectator.detectChanges();
+    });
 
-        spectator = createComponent({
-            providers: [{ provide: DotContentTypeService, useValue: mockDotContentTypeService }]
-        });
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     it('should have table headers', () => {
         const tableHeaders = spectator.queryAll('th');
         expect(tableHeaders.length).toBeGreaterThan(0);
-        expect(byText('Name')).not.toBeNull();
-        expect(byText('Description')).not.toBeNull();
     });
 
     it('should display content types in the table', () => {
         const tableRows = spectator.queryAll('tr');
-        expect(tableRows.length).toBeGreaterThan(1); // More than the header row
-        expect(byText('Test Type')).not.toBeNull();
-        expect(byText('Description')).not.toBeNull();
+        expect(tableRows.length).toBeGreaterThan(1);
     });
 
     it('should emit selected event when button is clicked', () => {
@@ -62,5 +80,44 @@ describe('EmaFormSelectorComponent', () => {
         const selectButton = spectator.query('p-button');
         spectator.click(selectButton);
         expect(spectator.component.selected.emit).toHaveBeenCalledWith('1');
+    });
+
+    it('should render search input', () => {
+        expect(spectator.query('[data-testid="form-search-input"]')).not.toBeNull();
+    });
+
+    it('should call getContentTypesWithPagination with filter after debounce', () => {
+        const service = spectator.inject(DotContentTypeService);
+        const searchInput = spectator.query<HTMLInputElement>('[data-testid="form-search-input"]');
+        spectator.typeInElement('test form', searchInput);
+        jest.advanceTimersByTime(300);
+        expect(service.getContentTypesWithPagination).toHaveBeenCalledWith(
+            expect.objectContaining({ filter: 'test form', page: 1 })
+        );
+    });
+
+    it('should reset to page 1 and re-fetch when search changes', () => {
+        const service = spectator.inject(DotContentTypeService);
+        (service.getContentTypesWithPagination as jest.Mock).mockClear();
+        const searchInput = spectator.query<HTMLInputElement>('[data-testid="form-search-input"]');
+        spectator.typeInElement('form', searchInput);
+        jest.advanceTimersByTime(300);
+        expect(service.getContentTypesWithPagination).toHaveBeenCalledWith(
+            expect.objectContaining({ filter: 'form', page: 1 })
+        );
+    });
+
+    it('should render paginator', () => {
+        expect(spectator.query('[data-testid="form-paginator"]')).not.toBeNull();
+    });
+
+    it('should show empty state when no forms are returned', () => {
+        const service = spectator.inject(DotContentTypeService);
+        (service.getContentTypesWithPagination as jest.Mock).mockReturnValue(
+            of({ contentTypes: [], pagination: { totalEntries: 0, currentPage: 1, perPage: 40 } })
+        );
+        spectator.component['fetch$'].next();
+        spectator.detectChanges();
+        expect(spectator.query('td[colspan="3"]')).not.toBeNull();
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.spec.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, mockProvider, Spectator } from '@openng/spectator/jest';
+import { createComponentFactory, Spectator } from '@openng/spectator/jest';
 import { of, throwError } from 'rxjs';
 
 import { ReactiveFormsModule } from '@angular/forms';
@@ -47,6 +47,12 @@ describe('EmaFormSelectorComponent', () => {
                 })
             },
             {
+                provide: DotHttpErrorManagerService,
+                useValue: { handle: jest.fn() }
+            }
+        ],
+        componentProviders: [
+            {
                 provide: DotContentTypeService,
                 useValue: {
                     getContentTypesWithPagination: jest
@@ -55,8 +61,7 @@ describe('EmaFormSelectorComponent', () => {
                             of({ contentTypes: mockForms, pagination: mockPagination })
                         )
                 }
-            },
-            mockProvider(DotHttpErrorManagerService)
+            }
         ]
     });
 
@@ -82,8 +87,8 @@ describe('EmaFormSelectorComponent', () => {
 
     it('should emit selected event when button is clicked', () => {
         jest.spyOn(spectator.component.selected, 'emit');
-        const selectButton = spectator.query('p-button');
-        spectator.click(selectButton);
+        const btn = spectator.query('[data-testid="form-select-button"]')?.querySelector('button');
+        spectator.click(btn as HTMLElement);
         expect(spectator.component.selected.emit).toHaveBeenCalledWith('1');
     });
 
@@ -93,8 +98,8 @@ describe('EmaFormSelectorComponent', () => {
 
     it('should call getContentTypesWithPagination with filter after debounce', () => {
         const service = spectator.inject(DotContentTypeService);
-        const searchInput = spectator.query<HTMLInputElement>('[data-testid="form-search-input"]');
-        spectator.typeInElement('test form', searchInput);
+        (service.getContentTypesWithPagination as jest.Mock).mockClear();
+        spectator.component.searchControl.setValue('test form');
         jest.advanceTimersByTime(300);
         expect(service.getContentTypesWithPagination).toHaveBeenCalledWith(
             expect.objectContaining({ filter: 'test form', page: 1 })
@@ -104,8 +109,7 @@ describe('EmaFormSelectorComponent', () => {
     it('should reset to page 1 and re-fetch when search changes', () => {
         const service = spectator.inject(DotContentTypeService);
         (service.getContentTypesWithPagination as jest.Mock).mockClear();
-        const searchInput = spectator.query<HTMLInputElement>('[data-testid="form-search-input"]');
-        spectator.typeInElement('form', searchInput);
+        spectator.component.searchControl.setValue('form');
         jest.advanceTimersByTime(300);
         expect(service.getContentTypesWithPagination).toHaveBeenCalledWith(
             expect.objectContaining({ filter: 'form', page: 1 })
@@ -129,7 +133,7 @@ describe('EmaFormSelectorComponent', () => {
     it('should fetch page 2 and update $first when paginator changes', () => {
         const service = spectator.inject(DotContentTypeService);
         (service.getContentTypesWithPagination as jest.Mock).mockClear();
-        spectator.component.onPageChange({ page: 1, first: 40, rows: 40, pageCount: 3 });
+        spectator.component['onPageChange']({ page: 1, first: 40, rows: 40, pageCount: 3 });
         expect(service.getContentTypesWithPagination).toHaveBeenCalledWith(
             expect.objectContaining({ page: 2 })
         );

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.ts
@@ -1,3 +1,5 @@
+import { Subject, of } from 'rxjs';
+
 import {
     ChangeDetectionStrategy,
     Component,
@@ -9,8 +11,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+
 
 import { ButtonModule } from 'primeng/button';
 import { IconFieldModule } from 'primeng/iconfield';
@@ -19,7 +20,9 @@ import { InputTextModule } from 'primeng/inputtext';
 import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 import { TableModule } from 'primeng/table';
 
-import { DotContentTypeService } from '@dotcms/data-access';
+import { catchError, debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+
+import { DotContentTypeService, DotHttpErrorManagerService } from '@dotcms/data-access';
 import { DotCMSContentType } from '@dotcms/dotcms-models';
 import { DotMessagePipe } from '@dotcms/ui';
 
@@ -46,12 +49,14 @@ export class EmaFormSelectorComponent {
     @Output() selected = new EventEmitter<string>();
 
     private readonly contentTypesService = inject(DotContentTypeService);
+    private readonly httpErrorManager = inject(DotHttpErrorManagerService);
     private readonly destroyRef = inject(DestroyRef);
 
     protected readonly perPage = PER_PAGE;
     protected readonly searchControl = new FormControl('', { nonNullable: true });
     protected readonly $forms = signal<DotCMSContentType[]>([]);
     protected readonly $totalRecords = signal(0);
+    protected readonly $first = signal(0);
 
     private currentPage = 1;
     private readonly fetch$ = new Subject<void>();
@@ -60,12 +65,19 @@ export class EmaFormSelectorComponent {
         this.fetch$
             .pipe(
                 switchMap(() =>
-                    this.contentTypesService.getContentTypesWithPagination({
-                        type: 'form',
-                        filter: this.searchControl.value,
-                        page: this.currentPage,
-                        per_page: PER_PAGE
-                    })
+                    this.contentTypesService
+                        .getContentTypesWithPagination({
+                            type: 'form',
+                            filter: this.searchControl.value,
+                            page: this.currentPage,
+                            per_page: PER_PAGE
+                        })
+                        .pipe(
+                            catchError((error) => {
+                                this.httpErrorManager.handle(error);
+                                return of({ contentTypes: [], pagination: null });
+                            })
+                        )
                 ),
                 takeUntilDestroyed(this.destroyRef)
             )
@@ -80,12 +92,14 @@ export class EmaFormSelectorComponent {
             .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
             .subscribe(() => {
                 this.currentPage = 1;
+                this.$first.set(0);
                 this.fetch$.next();
             });
     }
 
     protected onPageChange(event: PaginatorState): void {
         this.currentPage = (event.page ?? 0) + 1;
+        this.$first.set(event.first ?? 0);
         this.fetch$.next();
     }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.ts
@@ -1,15 +1,42 @@
-import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, EventEmitter, Output, inject } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    DestroyRef,
+    EventEmitter,
+    Output,
+    inject,
+    signal
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 
 import { ButtonModule } from 'primeng/button';
+import { IconFieldModule } from 'primeng/iconfield';
+import { InputIconModule } from 'primeng/inputicon';
+import { InputTextModule } from 'primeng/inputtext';
+import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 import { TableModule } from 'primeng/table';
 
 import { DotContentTypeService } from '@dotcms/data-access';
+import { DotCMSContentType } from '@dotcms/dotcms-models';
 import { DotMessagePipe } from '@dotcms/ui';
+
+const PER_PAGE = 40;
 
 @Component({
     selector: 'dot-ema-form-selector',
-    imports: [TableModule, ButtonModule, DotMessagePipe, AsyncPipe],
+    imports: [
+        ButtonModule,
+        DotMessagePipe,
+        IconFieldModule,
+        InputIconModule,
+        InputTextModule,
+        PaginatorModule,
+        ReactiveFormsModule,
+        TableModule
+    ],
     templateUrl: './ema-form-selector.component.html',
     styleUrls: ['./ema-form-selector.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -19,6 +46,46 @@ export class EmaFormSelectorComponent {
     @Output() selected = new EventEmitter<string>();
 
     private readonly contentTypesService = inject(DotContentTypeService);
+    private readonly destroyRef = inject(DestroyRef);
 
-    data = this.contentTypesService.getByTypes('form');
+    protected readonly perPage = PER_PAGE;
+    protected readonly searchControl = new FormControl('', { nonNullable: true });
+    protected readonly $forms = signal<DotCMSContentType[]>([]);
+    protected readonly $totalRecords = signal(0);
+
+    private currentPage = 1;
+    private readonly fetch$ = new Subject<void>();
+
+    constructor() {
+        this.fetch$
+            .pipe(
+                switchMap(() =>
+                    this.contentTypesService.getContentTypesWithPagination({
+                        type: 'form',
+                        filter: this.searchControl.value,
+                        page: this.currentPage,
+                        per_page: PER_PAGE
+                    })
+                ),
+                takeUntilDestroyed(this.destroyRef)
+            )
+            .subscribe(({ contentTypes, pagination }) => {
+                this.$forms.set(contentTypes);
+                this.$totalRecords.set(pagination?.totalEntries ?? 0);
+            });
+
+        this.fetch$.next();
+
+        this.searchControl.valueChanges
+            .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
+            .subscribe(() => {
+                this.currentPage = 1;
+                this.fetch$.next();
+            });
+    }
+
+    protected onPageChange(event: PaginatorState): void {
+        this.currentPage = (event.page ?? 0) + 1;
+        this.fetch$.next();
+    }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/ema-form-selector/ema-form-selector.component.ts
@@ -12,7 +12,6 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
-
 import { ButtonModule } from 'primeng/button';
 import { IconFieldModule } from 'primeng/iconfield';
 import { InputIconModule } from 'primeng/inputicon';


### PR DESCRIPTION
## Summary

- Fixes the non-functional search input in the \"Search Form\" dialog: replaces the static `getByTypes('form')` call with a reactive `FormControl` + 300ms debounce that passes a `filter` param to `getContentTypesWithPagination`
- Fixes the hard-capped result list: adds a `<p-paginator>` wired to server-side page fetches so every permissioned form is reachable
- Adds a PrimeNG `<p-iconField>` search input and an `emptymessage` template for the zero-results case
- Cancels in-flight requests on rapid input via `switchMap` on a private `Subject<void>`

Closes #35706

## Test plan

- [ ] Open the page editor, add a Form widget to a container — the \"Search Form\" dialog now shows a search input and a paginator
- [ ] Type a substring into the search input — the list filters after ~300ms with results matching the query
- [ ] Type a string with no matches — the table shows the empty-state message instead of an arbitrary subset
- [ ] Navigate pages via the paginator — each page returns the next batch of 40 forms
- [ ] Run unit tests: `cd core-web && pnpm nx test portlets-edit-ema-portlet --testPathPattern=ema-form-selector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35706