### PR TITLE
feat(edit-content): update layout styles for Edit Content form

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -51,16 +51,16 @@
             @let isSingleColumnTab = isSingleColumnLayout(tab.layout);
             <div class="p-4">
                 <div
-                    [class]="isSingleColumnTab ? 'mx-auto max-w-206' : 'mx-auto max-w-286'"
+                    [class]="isSingleColumnTab ? 'mx-auto max-w-206' : 'mx-auto max-w-343'"
                     data-testId="tab-layout-container">
                     @for (row of tab.layout; track row) {
                         <div
-                            class="mb-5 grid auto-cols-fr grid-flow-col gap-5 last:mb-0"
+                            class="mb-5 grid auto-cols-fr grid-flow-col gap-9 last:mb-0"
                             [class.hidden]="row.columns.some(c => c.fields.length > 0) && row.columns.every(c => c.fields.every(f => hiddenFields[f.variable]))"
                             data-testId="row">
                             @for (column of row.columns; track column) {
                                 <div
-                                    class="flex flex-col gap-5"
+                                    class="flex flex-col gap-8"
                                     [class.hidden]="column.fields.length > 0 && column.fields.every(f => hiddenFields[f.variable])"
                                     data-testId="column">
                                     @for (field of column.fields; track field) {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -332,15 +332,15 @@ describe('DotFormComponent', () => {
             spectator.detectChanges();
 
             const container = spectator.query(byTestId('tab-layout-container'));
-            expect(container?.classList.contains('max-w-286')).toBe(true);
+            expect(container?.classList.contains('max-w-343')).toBe(true);
             expect(container?.classList.contains('max-w-206')).toBe(false);
             expect(container?.classList.contains('mx-auto')).toBe(true);
 
             const row = spectator.query(byTestId('row'));
             const column = spectator.query(byTestId('column'));
-            expect(row?.classList.contains('gap-5')).toBe(true);
+            expect(row?.classList.contains('gap-9')).toBe(true);
             expect(row?.classList.contains('mb-5')).toBe(true);
-            expect(column?.classList.contains('gap-5')).toBe(true);
+            expect(column?.classList.contains('gap-8')).toBe(true);
         });
 
         it('should apply the narrower max-width for a single-column layout (every row has exactly one column)', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
@@ -63,9 +63,12 @@
              (severity="info") like the sibling banners so it stays theme-aware and
              inherits the top bar's shared banner sizing. -->
         @if (relatingTrail.length >= 2) {
+            @let betaMessageVisible = isEnabledNewContentEditor && showBetaMessage;
             <p-message
                 severity="secondary"
                 class="edit-content-layout__relating-content"
+                [class.border-t]="betaMessageVisible"
+                [class.border-gray-300]="betaMessageVisible"
                 data-testId="edit-content-layout__relating-content">
                 <ng-template #container>
                     <div class="flex w-full items-center gap-3 text-gray-700">


### PR DESCRIPTION
### Description

Follow-up feedback on #36615 (originally implemented in #36644):

- **Multi-column layout spacing**: increased the form's max-width (`max-w-286` → `max-w-343`) and the row/column gaps (`gap-5` → `gap-9` row, `gap-5` → `gap-8` column) — the original 18px/1000px values felt too tight once reviewed against real content, so this widens the layout and adds more breathing room between fields.
- **Relating content banner separator**: added a conditional top border (`border-t border-gray-300`) to the "relating content" `p-message` banner, shown only when the beta message banner is also visible above it, so the two banners read as visually distinct sections instead of blending together.

### Proposed Changes
* Widen multi-column max-width and increase row/column field gaps in `dot-edit-content-form.component.html`
* Add conditional top border separator between the beta message and relating-content banners in `dot-edit-content.layout.component.html`

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
No security or translation implications — purely presentational/layout changes.

This PR fixes: #36615

This PR fixes: #36615