### PR TITLE
fix(uve): coerce Quick Edit optimistic values to field dataType

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.spec.ts
@@ -466,6 +466,53 @@ describe('quick-edit-form-builder', () => {
             expect(result).toEqual({ price: 9.99 });
         });
 
+        it('re-joins MULTI_SELECT arrays into a comma string', () => {
+            const result = toPageAssetProperties(
+                [field({ variable: 'tags', clazz: DotCMSClazzes.MULTI_SELECT })],
+                { tags: ['a', 'b', 'c'] }
+            );
+            expect(result).toEqual({ tags: 'a,b,c' });
+        });
+
+        it('re-joins CHECKBOX-with-options arrays into a comma string', () => {
+            const result = toPageAssetProperties(
+                [
+                    field({
+                        variable: 'opts',
+                        clazz: DotCMSClazzes.CHECKBOX,
+                        options: [
+                            { label: 'A', value: 'a' },
+                            { label: 'B', value: 'b' }
+                        ]
+                    })
+                ],
+                { opts: ['a', 'b'] }
+            );
+            expect(result).toEqual({ opts: 'a,b' });
+        });
+
+        it('joins a single-element multi-value array without a trailing comma', () => {
+            const result = toPageAssetProperties(
+                [field({ variable: 'tags', clazz: DotCMSClazzes.MULTI_SELECT })],
+                { tags: ['only'] }
+            );
+            expect(result).toEqual({ tags: 'only' });
+        });
+
+        it('leaves a binary CHECKBOX boolean untouched (not treated as multi-value)', () => {
+            const result = toPageAssetProperties(
+                [
+                    field({
+                        variable: 'flag',
+                        clazz: DotCMSClazzes.CHECKBOX,
+                        dataType: DotCMSDataTypes.BOOLEAN
+                    })
+                ],
+                { flag: true }
+            );
+            expect(result).toEqual({ flag: true });
+        });
+
         it('leaves untouched typed fields coerced too (not just the edited one)', () => {
             const result = toPageAssetProperties(
                 [

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.spec.ts
@@ -221,6 +221,79 @@ describe('quick-edit-form-builder', () => {
                 );
                 expect(value).toBe('');
             });
+
+            it('maps a boolean value to the matching Yes|1/No|0 option string', () => {
+                const boolField = field({
+                    variable: 'flag',
+                    clazz: DotCMSClazzes.RADIO,
+                    dataType: DotCMSDataTypes.BOOLEAN,
+                    options: [
+                        { label: 'Yes', value: '1' },
+                        { label: 'No', value: '0' }
+                    ]
+                });
+                expect(coerceFieldValue(boolField, contentlet({ flag: true }))).toBe('1');
+                expect(coerceFieldValue(boolField, contentlet({ flag: false }))).toBe('0');
+            });
+        });
+
+        describe('SELECT', () => {
+            const selectBool = (over = {}) =>
+                field({
+                    variable: 'live',
+                    clazz: DotCMSClazzes.SELECT,
+                    dataType: DotCMSDataTypes.BOOLEAN,
+                    options: [
+                        { label: 'Yes', value: '1' },
+                        { label: 'No', value: '0' }
+                    ],
+                    ...over
+                });
+
+            it('maps a real boolean from the Page API to the matching option string', () => {
+                expect(coerceFieldValue(selectBool(), contentlet({ live: true }))).toBe('1');
+                expect(coerceFieldValue(selectBool(), contentlet({ live: false }))).toBe('0');
+            });
+
+            it('matches boolean options declared as Yes|true / No|false', () => {
+                const f = selectBool({
+                    options: [
+                        { label: 'Yes', value: 'true' },
+                        { label: 'No', value: 'false' }
+                    ]
+                });
+                expect(coerceFieldValue(f, contentlet({ live: true }))).toBe('true');
+                expect(coerceFieldValue(f, contentlet({ live: false }))).toBe('false');
+            });
+
+            it('stringifies a numeric value so it matches string options', () => {
+                const f = field({
+                    variable: 'level',
+                    clazz: DotCMSClazzes.SELECT,
+                    dataType: DotCMSDataTypes.INTEGER,
+                    options: [
+                        { label: 'One', value: '1' },
+                        { label: 'Two', value: '2' }
+                    ]
+                });
+                expect(coerceFieldValue(f, contentlet({ level: 2 }))).toBe('2');
+            });
+
+            it('returns a matching string value untouched', () => {
+                const f = field({
+                    variable: 'color',
+                    clazz: DotCMSClazzes.SELECT,
+                    options: [
+                        { label: 'Red', value: 'red' },
+                        { label: 'Blue', value: 'blue' }
+                    ]
+                });
+                expect(coerceFieldValue(f, contentlet({ color: 'blue' }))).toBe('blue');
+            });
+
+            it('returns empty string when the contentlet has no value', () => {
+                expect(coerceFieldValue(selectBool(), contentlet())).toBe('');
+            });
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.spec.ts
@@ -2,12 +2,13 @@ import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 
 import { FormBuilder } from '@angular/forms';
 
-import { DotCMSClazzes, DotCMSContentlet } from '@dotcms/dotcms-models';
+import { DotCMSClazzes, DotCMSDataTypes, DotCMSContentlet } from '@dotcms/dotcms-models';
 
 import {
     buildQuickEditFormGroup,
     buildValidators,
     coerceFieldValue,
+    coerceValueToDataType,
     toPageAssetProperties
 } from './quick-edit-form-builder';
 import { ContentletField } from './types';
@@ -343,6 +344,128 @@ describe('quick-edit-form-builder', () => {
                 photo: { identifier: 'p1' },
                 title: 'hi'
             });
+        });
+
+        it('coerces BOOL option strings ("1"/"0") to real booleans', () => {
+            const result = toPageAssetProperties(
+                [
+                    field({
+                        variable: 'live',
+                        clazz: DotCMSClazzes.SELECT,
+                        dataType: DotCMSDataTypes.BOOLEAN
+                    }),
+                    field({
+                        variable: 'archived',
+                        clazz: DotCMSClazzes.RADIO,
+                        dataType: DotCMSDataTypes.BOOLEAN
+                    })
+                ],
+                { live: '1', archived: '0' }
+            );
+            expect(result).toEqual({ live: true, archived: false });
+        });
+
+        it('coerces INTEGER string values to numbers', () => {
+            const result = toPageAssetProperties(
+                [
+                    field({
+                        variable: 'count',
+                        clazz: DotCMSClazzes.TEXT,
+                        dataType: DotCMSDataTypes.INTEGER
+                    })
+                ],
+                { count: '5' }
+            );
+            expect(result).toEqual({ count: 5 });
+        });
+
+        it('coerces FLOAT string values to numbers', () => {
+            const result = toPageAssetProperties(
+                [
+                    field({
+                        variable: 'price',
+                        clazz: DotCMSClazzes.TEXT,
+                        dataType: DotCMSDataTypes.FLOAT
+                    })
+                ],
+                { price: '9.99' }
+            );
+            expect(result).toEqual({ price: 9.99 });
+        });
+
+        it('leaves untouched typed fields coerced too (not just the edited one)', () => {
+            const result = toPageAssetProperties(
+                [
+                    field({
+                        variable: 'featured',
+                        clazz: DotCMSClazzes.SELECT,
+                        dataType: DotCMSDataTypes.BOOLEAN
+                    }),
+                    field({ variable: 'title', clazz: DotCMSClazzes.TEXT })
+                ],
+                { featured: '0', title: 'edited' }
+            );
+            expect(result).toEqual({ featured: false, title: 'edited' });
+        });
+    });
+
+    describe('coerceValueToDataType', () => {
+        // Mirrors commons-lang3 BooleanUtils.toBoolean(String) (3.18.0):
+        // true set (case-insensitive) = true, yes, y, t, on, 1.
+        it('maps the commons-lang3 true tokens to boolean true for BOOL', () => {
+            for (const token of ['true', 'TRUE', 'yes', 'Yes', 'y', 't', 'on', 'ON', '1']) {
+                expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, token)).toBe(true);
+            }
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, 1)).toBe(true);
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, true)).toBe(true);
+        });
+
+        it('maps everything outside the true set to boolean false for BOOL', () => {
+            for (const token of ['0', 'false', 'no', 'n', 'f', 'off', '2', '10', 'maybe', '']) {
+                expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, token)).toBe(false);
+            }
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, 0)).toBe(false);
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, false)).toBe(false);
+        });
+
+        it('does not trim BOOL values (matching commons-lang3)', () => {
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, ' 1')).toBe(false);
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, '1 ')).toBe(false);
+        });
+
+        it('parses INTEGER and FLOAT strings to numbers', () => {
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, '42')).toBe(42);
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, '-7')).toBe(-7);
+            expect(coerceValueToDataType(DotCMSDataTypes.FLOAT, '3.14')).toBe(3.14);
+            expect(coerceValueToDataType(DotCMSDataTypes.FLOAT, '  9.99  ')).toBe(9.99);
+        });
+
+        it('leaves numbers as-is when already numeric', () => {
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, 7)).toBe(7);
+            expect(coerceValueToDataType(DotCMSDataTypes.FLOAT, 1.5)).toBe(1.5);
+        });
+
+        it('does not coerce INTEGER strings that Long.parseLong would reject', () => {
+            // decimals, trailing garbage, and whitespace all throw server-side
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, '5.9')).toBe('5.9');
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, '5abc')).toBe('5abc');
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, ' 5')).toBe(' 5');
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, '')).toBe('');
+        });
+
+        it('returns TEXT and unknown dataTypes unchanged', () => {
+            expect(coerceValueToDataType(DotCMSDataTypes.TEXT, 'hello')).toBe('hello');
+            expect(coerceValueToDataType(undefined, 'hello')).toBe('hello');
+        });
+
+        it('leaves null, undefined, and array values untouched', () => {
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, null)).toBeNull();
+            expect(coerceValueToDataType(DotCMSDataTypes.BOOLEAN, undefined)).toBeUndefined();
+            expect(coerceValueToDataType(DotCMSDataTypes.INTEGER, ['a'])).toEqual(['a']);
+        });
+
+        it('returns the original value when a FLOAT string cannot be parsed', () => {
+            expect(coerceValueToDataType(DotCMSDataTypes.FLOAT, 'abc')).toBe('abc');
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.ts
@@ -253,11 +253,16 @@ export function coerceValueToDataType(dataType: string | undefined, value: unkno
 
 /**
  * Reconstruct the page-asset-compatible properties for the optimistic
- * update path. Two normalizations happen here:
+ * update path. Three normalizations happen here:
  *
  * 1. IMAGE/FILE/BINARY: the form stores identifier strings; the page asset
  *    stores objects keyed by `identifier` (image/file) or `idPath` (binary).
- * 2. Scalar fields: coerce each value to the primitive its `dataType`
+ * 2. CHECKBOX (with options) / MULTI_SELECT: the form stores an array of
+ *    selected values, but the Page API represents them as a comma-joined
+ *    string ("a,b,c"). Re-join so the iframe doesn't receive an array where
+ *    the headless app expects a string (arrays interpolate without commas,
+ *    e.g. "a,b,c" → "abc").
+ * 3. Scalar fields: coerce each value to the primitive its `dataType`
  *    implies (BOOL → boolean, INTEGER/FLOAT → number) so the iframe
  *    receives the same types the Page API returns instead of raw strings.
  *
@@ -275,15 +280,20 @@ export function toPageAssetProperties(
             continue;
         }
 
+        const value = formValues[field.variable];
+
         if (field.clazz === DotCMSClazzes.IMAGE || field.clazz === DotCMSClazzes.FILE) {
-            result[field.variable] = { identifier: formValues[field.variable] };
+            result[field.variable] = { identifier: value };
         } else if (field.clazz === DotCMSClazzes.BINARY) {
-            result[field.variable] = { idPath: formValues[field.variable] };
+            result[field.variable] = { idPath: value };
+        } else if (
+            (field.clazz === DotCMSClazzes.CHECKBOX ||
+                field.clazz === DotCMSClazzes.MULTI_SELECT) &&
+            Array.isArray(value)
+        ) {
+            result[field.variable] = value.join(',');
         } else {
-            result[field.variable] = coerceValueToDataType(
-                field.dataType,
-                formValues[field.variable]
-            );
+            result[field.variable] = coerceValueToDataType(field.dataType, value);
         }
     }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.ts
@@ -70,6 +70,49 @@ export function coerceFieldValue(
         return '';
     }
 
+    // SELECT / RADIO: p-select and p-radioButton match the control value
+    // against string option values (`optionValue="value"`). The Page API
+    // can return a real boolean (BOOL-backed field) or a number, neither of
+    // which `===` a string option — so the control shows its placeholder
+    // while `showClear` still sees a truthy value (the stray "X"). Map the
+    // raw value back to its matching option's string value.
+    if (field.clazz === DotCMSClazzes.SELECT || field.clazz === DotCMSClazzes.RADIO) {
+        return matchOptionValue(field, value);
+    }
+
+    return value;
+}
+
+/**
+ * Normalize a single-select value (SELECT / RADIO) so it matches one of
+ * the field's string option values. Options are always strings (parsed
+ * from `label|value`), but the Page API may return a real boolean for a
+ * BOOL-backed field or a number. Boolean values are matched through the
+ * same `toBoolean` semantics the backend uses (so `true` selects the
+ * `Yes|1` option); numbers fall back to string comparison. Values that
+ * are already strings (or arrays) are returned untouched.
+ */
+function matchOptionValue(
+    field: ContentletField,
+    value: string | string[] | boolean | DotCMSContentlet
+): string | string[] | boolean | DotCMSContentlet {
+    if (typeof value === 'string' || Array.isArray(value)) {
+        return value;
+    }
+
+    const options = field.options ?? [];
+
+    if (typeof value === 'boolean') {
+        const match = options.find((option) => commonsLangToBoolean(option.value) === value);
+        return match ? match.value : String(value);
+    }
+
+    if (typeof value === 'number') {
+        const asString = String(value);
+        const match = options.find((option) => option.value === asString);
+        return match ? match.value : asString;
+    }
+
     return value;
 }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/quick-edit-form-builder.ts
@@ -1,6 +1,6 @@
 import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
 
-import { DotCMSClazzes, DotCMSContentlet } from '@dotcms/dotcms-models';
+import { DotCMSClazzes, DotCMSDataTypes, DotCMSContentlet } from '@dotcms/dotcms-models';
 
 import { ContentletField } from './types';
 
@@ -132,11 +132,94 @@ export function buildQuickEditFormGroup(
 }
 
 /**
- * Reconstruct the page-asset-compatible properties for IMAGE/FILE/BINARY
- * fields. The form stores identifier strings; the page asset stores
- * objects keyed by `identifier` (image/file) or `idPath` (binary).
- * Used by the optimistic-update path to push form values back into
- * the iframe's page tree.
+ * Values commons-lang3 `BooleanUtils.toBoolean(String)` treats as `true`
+ * (compared case-insensitively). Everything else — `"0"`, `"false"`,
+ * `"off"`, `"2"`, untrimmed `" 1"`, `""` — is `false`.
+ */
+const BOOLEAN_TRUE_TOKENS = new Set(['true', 'yes', 'y', 't', 'on', '1']);
+
+/**
+ * Faithful port of `org.apache.commons.lang3.BooleanUtils.toBoolean(String)`
+ * (commons-lang3 3.18.0). The backend `booleanStrategy` runs every saved
+ * value through this on check-in, so mirroring it makes the optimistic
+ * preview match exactly what the Page API returns after save.
+ *
+ * Note: commons-lang3 does NOT trim, so neither do we — `" 1"` is `false`.
+ */
+function commonsLangToBoolean(value: string): boolean {
+    return BOOLEAN_TRUE_TOKENS.has(value.toLowerCase());
+}
+
+/**
+ * Coerce a raw form-control value to the primitive type its `dataType`
+ * implies, so the optimistic page-asset value matches what the Page API
+ * returns for the same contentlet.
+ *
+ * Angular form controls hold strings (`pInputText`) or the option's
+ * `value` string (`p-select` / `p-radioButton` with `optionValue`), so a
+ * BOOL field configured `Yes|1 / No|0` arrives as `"1"`/`"0"` and an
+ * INTEGER field as `"5"`. Pushing those raw into the iframe stringifies
+ * types the server would return as real booleans/numbers — and the string
+ * `"0"` is truthy in JS, breaking type-sensitive conditional rendering.
+ *
+ * Each branch mirrors the matching backend write strategy in
+ * `FieldHandlerStrategyFactory` so the preview equals the post-save value:
+ * - BOOL → commons-lang3 `BooleanUtils.toBoolean` (see above).
+ * - INTEGER → `Long.parseLong` (strict: optional sign + digits, no
+ *   whitespace, no decimals). Non-integer strings are left as-is — a save
+ *   would itself throw and roll back.
+ * - FLOAT → `Float.parseFloat` (trims, accepts decimals/scientific).
+ *
+ * `null`/`undefined`/array (multi-value) values are always left untouched.
+ */
+export function coerceValueToDataType(dataType: string | undefined, value: unknown): unknown {
+    if (value === null || value === undefined || Array.isArray(value)) {
+        return value;
+    }
+
+    switch (dataType) {
+        case DotCMSDataTypes.BOOLEAN:
+            // Backend keeps real Booleans as-is and runs everything else
+            // (including numbers, stringified) through toBoolean.
+            return typeof value === 'boolean' ? value : commonsLangToBoolean(String(value));
+
+        case DotCMSDataTypes.INTEGER: {
+            if (typeof value === 'number') {
+                return value;
+            }
+            const str = String(value);
+            return /^[+-]?\d+$/.test(str) ? Number(str) : value;
+        }
+
+        case DotCMSDataTypes.FLOAT: {
+            if (typeof value === 'number') {
+                return value;
+            }
+            const str = String(value).trim();
+            if (str === '') {
+                return value;
+            }
+            const parsed = Number(str);
+            return Number.isFinite(parsed) ? parsed : value;
+        }
+
+        default:
+            return value;
+    }
+}
+
+/**
+ * Reconstruct the page-asset-compatible properties for the optimistic
+ * update path. Two normalizations happen here:
+ *
+ * 1. IMAGE/FILE/BINARY: the form stores identifier strings; the page asset
+ *    stores objects keyed by `identifier` (image/file) or `idPath` (binary).
+ * 2. Scalar fields: coerce each value to the primitive its `dataType`
+ *    implies (BOOL → boolean, INTEGER/FLOAT → number) so the iframe
+ *    receives the same types the Page API returns instead of raw strings.
+ *
+ * Used by the optimistic-update path to push form values back into the
+ * iframe's page tree.
  */
 export function toPageAssetProperties(
     fields: ContentletField[],
@@ -145,11 +228,7 @@ export function toPageAssetProperties(
     const result: Record<string, unknown> = { ...formValues };
 
     for (const field of fields) {
-        if (
-            field.clazz !== DotCMSClazzes.IMAGE &&
-            field.clazz !== DotCMSClazzes.FILE &&
-            field.clazz !== DotCMSClazzes.BINARY
-        ) {
+        if (!(field.variable in formValues)) {
             continue;
         }
 
@@ -157,6 +236,11 @@ export function toPageAssetProperties(
             result[field.variable] = { identifier: formValues[field.variable] };
         } else if (field.clazz === DotCMSClazzes.BINARY) {
             result[field.variable] = { idPath: formValues[field.variable] };
+        } else {
+            result[field.variable] = coerceValueToDataType(
+                field.dataType,
+                formValues[field.variable]
+            );
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Fixes #36710. Three related field-type bugs in the UVE **Quick Edit** form, all caused by mismatches between the Angular form-control value shapes and the correctly-typed Page API values. All are **display-only** (optimistic preview) — persistence was always correct.

### 1. Booleans/numbers stringified in the optimistic preview (`uve-set-page-data`)

On a **headless (non-traditional) page**, the optimistic push sent raw form values without normalizing to the field's `dataType`:
- **Boolean** fields arrived as `"0"`/`"1"` instead of real `true`/`false`. Since `"0"` is **truthy** in JS, `@if (field)` rendering flipped — the customer's "fields not updating properly" symptom.
- **Whole-Number** fields arrived as strings.

Affected **untouched** fields too (the whole form value is pushed).

**Fix:** `toPageAssetProperties()` coerces each value via `coerceValueToDataType()`, faithfully mirroring the backend write strategies in `FieldHandlerStrategyFactory` so the preview equals the post-save Page API value:

| dataType | Backend strategy | Frontend mirror |
|---|---|---|
| `BOOL` | `BooleanUtils.toBoolean(String)` (commons-lang3 3.18.0) | true set (case-insensitive) `true/yes/y/t/on/1`, no trimming, else `false`; real booleans unchanged |
| `INTEGER` | `Long.parseLong` | strict `^[+-]?\d+$`; rejects left as-is (save would throw & roll back) |
| `FLOAT` | `Float.parseFloat` | trims, accepts decimals/scientific |

### 2. SELECT/RADIO showed placeholder despite having a value

A `p-select`/`p-radioButton` field with a value loaded **empty** (placeholder) while still rendering the `showClear` **X**. `coerceFieldValue()` returned the raw Page API value — a real boolean for a `Yes|1 / No|0` field, or a number — which never `===` a string option value.

**Fix:** `coerceFieldValue()` normalizes single-select values to the matching option string — booleans via the same `toBoolean` semantics (`true` → the `Yes|1` option), numbers via string comparison. Strings/arrays untouched.

### 3. Multi-value fields lost their commas after a Quick Edit

`CHECKBOX`-with-options and `MULTI_SELECT` are held as arrays in the form, but the Page API represents them as a comma-joined string (`"a,b,c"`). The optimistic push sent the raw array, so the headless app interpolated it without separators — `"Value,CA,MX"` rendered as `"ValueCAMX"`.

**Fix:** `toPageAssetProperties()` re-joins those arrays with `,` to match the Page API shape. Binary checkboxes (boolean, not array) are unaffected and still flow through the BOOL coercion.

Traditional (JSP) pages are unaffected by the optimistic-push bugs — they skip that branch and reload from the server.


## Videos

https://github.com/user-attachments/assets/e38b8c34-551a-4c8d-8314-c479ffc92395

https://github.com/user-attachments/assets/cb2cfc33-cb10-459a-8ee0-4773bcb67295

https://github.com/user-attachments/assets/62a2ab10-d38c-4c60-adae-c0db69184fae

## Checklist

- [x] `BOOL` → real boolean, `INTEGER`/`FLOAT` → number in the `uve-set-page-data` payload
- [x] SELECT/RADIO fields show their current selection on load (no stray clear-X on a placeholder)
- [x] MULTI_SELECT / CHECKBOX preserve their comma-joined form in the preview
- [x] Untouched fields corrected too; preview types match the Page API output
- [x] Traditional-page behavior unchanged
- [x] Unit tests in `quick-edit-form-builder.spec.ts` (true/false token tables, no-trim, integer-reject, SELECT/RADIO boolean & numeric matching, multi-value re-join)

## Testing

`pnpm nx test portlets-edit-ema-portlet --testPathPatterns=quick-edit-form-builder` — 55 passing. Lint clean.

### Out of scope

- Block-field support in Quick Edit (customer side question) — separate feature request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36710