### PR TITLE
feat(workflows): Add Claude AI SDK breaking change check workflow

### DIFF
--- a/.github/workflows/ai_claude-sdk-breaking-change.yml
+++ b/.github/workflows/ai_claude-sdk-breaking-change.yml
@@ -1,0 +1,119 @@
+name: Claude AI SDK Breaking Change Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  # Security gate: Check if user is dotCMS organization member
+  #
+  # REQUIREMENTS FOR CLAUDE ACCESS:
+  # 1. Must be a member of the dotCMS organization
+  # 2. Membership must be set to PUBLIC visibility
+  #
+  # TROUBLESHOOTING: If blocked, visit https://github.com/orgs/dotCMS/people
+  # and ensure your membership is public (click "Make public" if needed)
+  security-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read           # Allow repository checkout
+      # Note: Organization membership checking uses fine-grained token
+      # so no additional GITHUB_TOKEN permissions needed for that API
+    outputs:
+      authorized: ${{ steps.membership-check.outputs.is_member }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check organization membership
+        id: membership-check
+        uses: ./.github/actions/security/org-membership-check
+        with:
+          username: ${{ github.event.pull_request.user.login || github.actor }}
+
+      - name: Log security decision
+        run: |
+          if [ "${{ steps.membership-check.outputs.is_member }}" = "true" ]; then
+            echo "✅ Access granted: User is a dotCMS organization member"
+          else
+            echo "❌ Access denied: User failed dotCMS organization membership check"
+            echo ""
+            echo "📋 TROUBLESHOOTING: If you are a dotCMS team member:"
+            echo "   1. Visit https://github.com/orgs/dotCMS/people"
+            echo "   2. Ensure your membership is set to 'Public'"
+            echo "   3. If you're not listed, contact an organization owner"
+            echo ""
+            echo "::warning::Unauthorized user attempted to trigger Claude workflow: ${{ github.event.pull_request.user.login || github.actor }}"
+          fi
+
+  # SDK breaking-change analysis — runs on every PR push. Single label design: the AI only
+  # ever ADDS "SDK Breaking Change" when it detects a break; it never removes it. Removing
+  # the label (because a human disagrees with the AI's call, or because a later push fixed
+  # the issue) is always a manual human action — no separate "Human: ..." label needed, and
+  # no preflight step to clear/protect anything: a human's removal simply stands until the
+  # AI sees reason to re-add it on some future push.
+  claude-sdk-breaking-change-check:
+    needs: security-check
+    # Cancel in-progress check when a new push arrives — always analyze latest state
+    concurrency:
+      group: claude-sdk-breaking-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    if: needs.security-check.outputs.authorized == 'true'
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      issues: write
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
+    with:
+      model_id: ${{ vars.BEDROCK_MODEL_ID }}
+      bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
+      trigger_mode: automatic
+      prompt: |
+        You are a dotCMS SDK-compatibility analyst. Determine whether the changes in this PR
+        break compatibility for `@dotcms/*` SDK consumers (`@dotcms/client`, `@dotcms/react`,
+        `@dotcms/angular`, `@dotcms/uve`) — i.e. whether an SDK version built against the
+        server contract *before* this change would misbehave against the server *after* this
+        change.
+
+        STEP 1 — Read the SDK breaking-change categories reference:
+          cat docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md
+
+        STEP 2 — Get the full PR diff:
+          git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+        STEP 3 — Analyze the diff against EVERY category in the reference document.
+          Focus on: GraphQL schema surface reachable via the page API's graphql.page /
+          graphql.content extension (new required fields/args, removed/renamed types or
+          fields), REST response shape changes to /api/v1/page/*, /api/v1/content, and
+          /api/v1/nav, changes to the UVE/editor postMessage protocol (message names or
+          payload shapes in DotCMSUVEAction / __DOTCMS_UVE_EVENT__), and changes to the
+          SdkVersionWebInterceptor / X-DotCMS-Version / X-DotCMS-Min-SDK headers or the
+          compareVersions() comparison contract in sdk-compatibility.ts. Ignore pure admin-UI
+          (dotcms-ui) changes, test-only changes, or documentation changes unless they touch
+          one of the above surfaces.
+
+        STEP 4 — If the changes break SDK compatibility, post this comment on the PR
+        using: gh pr comment ${{ github.event.pull_request.number }} --body "..."
+
+          Format:
+          SDK Breaking Change Detected!!!
+          - Category: <category ID and name, e.g. "G-1 — Removing or Renaming a Reachable GraphQL Type/Field">
+          - Why it breaks compatibility: <specific explanation tied to the actual code changed>
+          - Code that makes it breaking: <file path(s) and the specific lines or block>
+          - Safer alternative (if possible): <the safer alternative from the reference, adapted to this change>
+
+          If multiple categories match, repeat the block for each one.
+
+          Then add the label (only if it isn't already on the PR):
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "SDK Breaking Change"
+
+        If the changes do NOT break SDK compatibility, do nothing — no comment, no label, and
+        do NOT remove an existing "SDK Breaking Change" label even if you disagree with it.
+        Removing that label is a human-only decision.
+
+        Be specific: quote actual file names and code lines, not generic descriptions.
+      claude_args: '--allowedTools "Bash(git diff*),Bash(git log*),Bash(cat docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md),Bash(gh pr comment*),Bash(gh pr edit*)"'
+      timeout_minutes: 15
+      runner: ubuntu-latest
+      enable_mention_detection: false

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -333,6 +333,15 @@ jobs:
 
       - name: Bump MinSdkVersion.VALUE and open PR
         id: bump
+        # Notify-but-don't-fail: cicd_comp_finalize-phase.yml scans every job in the run via
+        # the GitHub API (not just finalize's own `needs`), so without this a transient
+        # git/gh error here — after the release has already fully shipped — would mark the
+        # whole release run red over a best-effort housekeeping PR. The failure Slack step
+        # below still fires (it checks the step's own outcome, not the job-level
+        # failure()/success() context functions, which continue-on-error would otherwise
+        # mask) — same pattern already applied to the SDK next-tag publish job in
+        # cicd_3-trunk.yml.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
           CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER || 'github-actions[bot]' }}
@@ -411,7 +420,11 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Slack Notification (bump PR failure)
-        if: failure()
+        # Checks the bump step's own outcome directly rather than the job-level
+        # failure()/success() context functions — those reflect conclusion (which
+        # continue-on-error masks to "success"), not outcome, so failure() would never
+        # fire here once that step has continue-on-error: true.
+        if: steps.bump.outcome == 'failure'
         continue-on-error: true
         uses: ./.github/actions/core-cicd/notification/notify-slack
         with:

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -59,6 +59,11 @@ on:
         type: boolean
         default: true
         required: false
+      bump_min_sdk_version:
+        description: 'Does this release include a change that breaks SDK compatibility? If true, opens a post-release PR bumping MinSdkVersion.VALUE and notifies Slack for human review. Ignored for LTS releases.'
+        type: boolean
+        default: false
+        required: false
       java-version:
         description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open). Compiler release auto-defaults to Java major version.'
         type: string
@@ -99,6 +104,79 @@ jobs:
             echo "::error::skip_latest must be blank (update the latest tag) or exactly 'DO NOT UPDATE LATEST' (skip it). Got: '${SKIP_LATEST}'. Re-run with a valid value."
             exit 1
           fi
+
+      # Closes the "forgot to check" gap for MinSdkVersion (see #36698): if a PR merged since
+      # the last standard release carries an SDK-breaking-change label but this run left
+      # bump_min_sdk_version false, fail loudly here rather than silently under-reporting the
+      # compatibility floor after the release ships. Read-only (no mutation), so it's safe to
+      # run before release-prepare even exists — deliberately plain `gh`/bash, not the
+      # release-qa-status TS tool, since we only need a label check, not QA-verdict aggregation.
+      - name: Validate bump_min_sdk_version against merged PR labels
+        env:
+          GH_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          BUMP_MIN_SDK_VERSION: ${{ github.event.inputs.bump_min_sdk_version }}
+        run: |
+          set -euo pipefail
+
+          # Only standard (non-LTS) releases carry the -## suffix; LTS patch releases don't
+          # participate in the @latest SDK contract, so skip entirely.
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2}-[0-9]{1,2}$ ]]; then
+            echo "Non-standard release version '${RELEASE_VERSION}' (LTS or custom) — skipping SDK breaking-change validation."
+            exit 0
+          fi
+
+          THIS_TAG="v${RELEASE_VERSION}"
+
+          # Resolve the previous standard release tag the same way release-qa-status does
+          # (same STANDARD_RELEASE_PATTERN, kept in sync on purpose).
+          PREV_TAG=$(gh api "repos/${REPO}/releases?per_page=100" --paginate \
+            --jq '[.[] | select(.tag_name | test("^v[0-9]{2}\\.[0-9]{2}\\.[0-9]{2}-[0-9]{1,2}$"))] | .[].tag_name' \
+            | grep -v -F -- "${THIS_TAG}" | sort -V | tail -1 || true)
+
+          if [ -z "${PREV_TAG}" ]; then
+            echo "::warning::No previous standard release tag found — skipping SDK breaking-change validation (nothing to compare against)."
+            exit 0
+          fi
+
+          echo "Comparing ${PREV_TAG}...main for merged PRs since the last release."
+
+          # release-prepare hasn't created this release's tag yet at this point in the
+          # pipeline — main is the correct proxy for "what's about to ship" (release_commit
+          # defaults to main's tip the same way).
+          PR_NUMBERS=$(gh api "repos/${REPO}/compare/${PREV_TAG}...main" --paginate \
+            --jq '.commits[].commit.message' \
+            | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+' | sort -un || true)
+
+          BREAKING_PRS=()
+          for pr in ${PR_NUMBERS}; do
+            LABELS=$(gh pr view "${pr}" --repo "${REPO}" --json labels --jq '.labels[].name' 2>/dev/null || true)
+            if echo "${LABELS}" | grep -qxF 'SDK Breaking Change'; then
+              BREAKING_PRS+=("#${pr}")
+            fi
+          done
+
+          if [ "${#BREAKING_PRS[@]}" -gt 0 ] && [ "${BUMP_MIN_SDK_VERSION}" != "true" ]; then
+            echo "::error::This release (${THIS_TAG}) includes PR(s) labeled 'SDK Breaking Change' (${BREAKING_PRS[*]}) since ${PREV_TAG}, but 'bump_min_sdk_version' was left false. Re-run with bump_min_sdk_version=true, or remove the label from those PRs first if none of them actually break SDK compatibility."
+            exit 1
+          fi
+
+          if [ "${#BREAKING_PRS[@]}" -eq 0 ] && [ "${BUMP_MIN_SDK_VERSION}" = "true" ]; then
+            echo "::warning::bump_min_sdk_version=true but no merged PR since ${PREV_TAG} carries an SDK-breaking label. Proceeding, since a human explicitly opted in — but double-check this is intentional."
+          fi
+
+          # Non-fatal nudge: a stale, unmerged bump PR from a previous release won't be caught
+          # by this run's own dedupe (different branch name, keyed on this release's version).
+          # `gh pr list --head` only matches an exact branch name, not a prefix, so this has
+          # to go through the REST API directly and filter on head.ref with startswith().
+          STALE_PR=$(gh api "repos/${REPO}/pulls?state=open&base=main" --paginate \
+            --jq '.[] | select(.head.ref | startswith("sdk/bump-min-sdk-version-")) | .html_url' | head -1 || true)
+          if [ -n "${STALE_PR}" ]; then
+            echo "::warning::An unmerged MinSdkVersion bump PR from a previous release is still open: ${STALE_PR}. Consider merging it before this release ships another one."
+          fi
+
+          echo "SDK breaking-change validation passed (${#BREAKING_PRS[@]} breaking PR(s) found, bump_min_sdk_version=${BUMP_MIN_SDK_VERSION})."
 
   # Initialize - standard initialization phase (always first)
   initialize:
@@ -222,6 +300,130 @@ jobs:
             uv run evergreen-tracks promote --repo "${repo}" --tracks latest --apply
           done
 
+  # Bump MinSdkVersion.java on main — only after a full green release, and only when the
+  # operator explicitly flagged this release as SDK-compatibility-breaking (see #36698).
+  # Never a direct push to main: opens a PR and asks a human to merge it (main has no
+  # auto-merge and requires a PR for any change, confirmed via the retired
+  # cicd_manual-release-sdks.yml's identical "Open post-release PR" precedent).
+  #
+  # A sibling job here (not a step in the generic, reusable cicd_comp_release-phase.yml)
+  # so this dotCMS-core-specific concern doesn't leak into a phase other callers reuse.
+  bump-min-sdk-version:
+    name: Bump MinSdkVersion.java
+    needs: [ release-prepare, build, deployment ]
+    # Strict success() gate (not the always()-based idiom used by build/deployment/release):
+    # a release that fails after release-prepare must NEVER cause main to advertise a
+    # stricter MIN_SDK_VERSION for a dotCMS version that was never actually shipped.
+    if: >-
+      success()
+      && github.event.inputs.bump_min_sdk_version == 'true'
+      && github.ref_name == 'main'
+      && needs.release-prepare.outputs.is_lts != 'true'
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout core
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
+
+      - name: Bump MinSdkVersion.VALUE and open PR
+        id: bump
+        env:
+          GH_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
+          CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER || 'github-actions[bot]' }}
+          RELEASE_VERSION: ${{ needs.release-prepare.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          git config user.name "${CI_MACHINE_USER}"
+          git config user.email "${CI_MACHINE_USER}@users.noreply.github.com"
+
+          FILE="dotCMS/src/main/java/com/dotcms/rest/config/MinSdkVersion.java"
+          PR_BRANCH="sdk/bump-min-sdk-version-${RELEASE_VERSION}"
+
+          # Idempotency (a): main is already at this version — nothing to do. Covers both a
+          # true no-op release and a retried workflow whose bump PR already merged.
+          CURRENT=$(grep -oP '(?<=VALUE = ")[^"]+' "${FILE}")
+          if [ "${CURRENT}" = "${RELEASE_VERSION}" ]; then
+            echo "MinSdkVersion.VALUE is already ${RELEASE_VERSION} on main — nothing to bump."
+            echo "skipped=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git fetch origin main
+          git checkout -B "${PR_BRANCH}" origin/main
+
+          sed -i "s/VALUE = \"[^\"]*\"/VALUE = \"${RELEASE_VERSION}\"/" "${FILE}"
+
+          # Verify the substitution actually landed. If the file's VALUE = "..." literal
+          # ever gets reformatted (different spacing, wrapped differently, etc.), sed
+          # silently matches nothing instead of erroring — without this check we'd fall
+          # through to "nothing to commit" and still push/open an empty, misleading PR.
+          NEW_VALUE=$(grep -oP '(?<=VALUE = ")[^"]+' "${FILE}")
+          if [ "${NEW_VALUE}" != "${RELEASE_VERSION}" ]; then
+            echo "::error::Failed to bump MinSdkVersion.VALUE — expected '${RELEASE_VERSION}' after the edit but found '${NEW_VALUE}'. The VALUE = \"...\" literal in ${FILE} may have been reformatted; update the sed pattern above to match its current shape."
+            exit 1
+          fi
+
+          git add "${FILE}"
+
+          if git diff --cached --quiet; then
+            echo "No diff after edit — nothing to commit."
+          else
+            git commit -m "chore(sdk): bump MinSdkVersion.VALUE to ${RELEASE_VERSION}"
+          fi
+
+          git push --force origin "${PR_BRANCH}"
+
+          # Idempotency (b): reuse an already-open PR for this exact version/branch instead
+          # of opening a duplicate on a retried run.
+          EXISTING_PR=$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${PR_BRANCH}" --base main --json url --jq '.[0].url' 2>/dev/null || true)
+          if [ -n "${EXISTING_PR}" ]; then
+            echo "PR already exists: ${EXISTING_PR}"
+            PR_URL="${EXISTING_PR}"
+          else
+            PR_URL=$(gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "chore(sdk): bump MinSdkVersion.VALUE to ${RELEASE_VERSION}" \
+              --body "Automated post-release bump. Release \`${RELEASE_VERSION}\` was flagged (via \`bump_min_sdk_version\`) as containing an SDK-breaking change. This raises the compatibility floor advertised via the \`X-DotCMS-Min-SDK\` header to \`${RELEASE_VERSION}\`. Please review and merge — this does not auto-merge." \
+              --base main \
+              --head "${PR_BRANCH}")
+          fi
+          echo "pr_url=${PR_URL}" >> "${GITHUB_OUTPUT}"
+          echo "skipped=false" >> "${GITHUB_OUTPUT}"
+
+      - name: Slack Notification (bump PR ready for review)
+        if: success() && steps.bump.outputs.skipped == 'false'
+        continue-on-error: true
+        uses: ./.github/actions/core-cicd/notification/notify-slack
+        with:
+          channel-id: "log-sdk-libs"
+          payload: |
+            > :large_orange_circle: *Attention dotters:* dotCMS `${{ needs.release-prepare.outputs.release_version }}` was released with an SDK-breaking change.
+            >
+            > A PR bumping `MinSdkVersion.VALUE` to `${{ needs.release-prepare.outputs.release_version }}` is open on `main`.
+            > *Please review and merge the post-release PR ASAP:* <${{ steps.bump.outputs.pr_url }}|View PR>
+            > <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Slack Notification (bump PR failure)
+        if: failure()
+        continue-on-error: true
+        uses: ./.github/actions/core-cicd/notification/notify-slack
+        with:
+          channel-id: "log-sdk-libs"
+          payload: |
+            > :red_circle: *MinSdkVersion bump FAILED!*
+            >
+            > Release `${{ needs.release-prepare.outputs.release_version }}` succeeded, but opening the post-release PR to bump `MinSdkVersion.VALUE` failed.
+            > *Triggered by:* `${{ github.actor }}`
+            > <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run — check logs for details>
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
   # Release - release-specific operations (Artifactory, Javadocs, Plugins, SBOM, Labels)
   # Waits for deployment to complete to safely update labels only if both succeed
   release:
@@ -264,7 +466,7 @@ jobs:
   finalize:
     name: Finalize
     if: always()
-    needs: [ initialize, build, deployment, release ]
+    needs: [ initialize, build, deployment, release, bump-min-sdk-version ]
     uses: ./.github/workflows/cicd_comp_finalize-phase.yml
     with:
       artifact-run-id: ${{ github.run_id }}

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -145,8 +145,15 @@ jobs:
           # release-prepare hasn't created this release's tag yet at this point in the
           # pipeline — main is the correct proxy for "what's about to ship" (release_commit
           # defaults to main's tip the same way).
+          # Only the commit SUBJECT (first line) — the full multi-line message's body
+          # routinely has prose or footnotes ending in "(#N)" that reference an unrelated,
+          # often much older PR/issue (confirmed: ~20 real examples in this repo's last 3000
+          # commits). Scanning the full message would treat those stray references as PRs in
+          # this release's range, risking both a false block (an old referenced PR happens to
+          # carry the label) and an unwarranted floor bump if the operator reruns with
+          # bump_min_sdk_version=true to "fix" it.
           PR_NUMBERS=$(gh api "repos/${REPO}/compare/${PREV_TAG}...main" --paginate \
-            --jq '.commits[].commit.message' \
+            --jq '.commits[].commit.message | split("\n")[0]' \
             | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+' | sort -un || true)
 
           BREAKING_PRS=()
@@ -361,6 +368,16 @@ jobs:
             echo "MinSdkVersion.VALUE is already ${RELEASE_VERSION} on main — nothing to bump."
             echo "skipped=true" >> "${GITHUB_OUTPUT}"
             exit 0
+          fi
+
+          # Monotonicity guard: MinSdkVersion.VALUE is a compatibility floor that must only
+          # move forward. Without this, re-running/backfilling an older release with
+          # bump_min_sdk_version=true would silently LOWER an already-higher floor on main
+          # (the equality check above only short-circuits the exact-match case).
+          HIGHEST=$(printf '%s\n%s\n' "${CURRENT}" "${RELEASE_VERSION}" | sort -V | tail -1)
+          if [ "${HIGHEST}" != "${RELEASE_VERSION}" ]; then
+            echo "::error::Refusing to bump MinSdkVersion.VALUE backward: main is already at '${CURRENT}', which is newer than this release's version '${RELEASE_VERSION}'. This would loosen the SDK compatibility floor. If this is an intentional backfill of an older release, this automated job only ever moves the floor forward — handle it manually instead."
+            exit 1
           fi
 
           git fetch origin main

--- a/docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md
+++ b/docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md
@@ -1,0 +1,301 @@
+# SDK Breaking Change Categories — Developer Reference
+
+>**Purpose:** Help developers (and the automated PR checker) decide whether a change breaks
+>compatibility with already-published `@dotcms/client`, `@dotcms/react`, `@dotcms/angular`, and
+>`@dotcms/uve` SDK versions — i.e. whether `MinSdkVersion.VALUE` needs to move.
+>
+>**Rule of thumb:** a change is SDK-breaking if an SDK built against the server contract *before*
+>this change would misbehave (throw, silently drop data, or misinterpret a message) against the
+>server *after* this change — with no fallback path in the SDK for the old shape.
+
+Unlike [`ROLLBACK_UNSAFE_CATEGORIES.md`](ROLLBACK_UNSAFE_CATEGORIES.md), this reference doesn't use a
+CRITICAL/HIGH/MEDIUM/LOW risk scale — this doc answers a single binary question for a single
+purpose (does `MinSdkVersion.VALUE` need to move), not a graded operational-risk assessment. Each
+category below is either **Breaking** or **Conditionally breaking** (breaks only if a specific
+additional condition holds, called out explicitly).
+
+---
+
+## Quick Reference — Decision Card
+
+```
+Is my change a...
+
+Removed/renamed GraphQL type or field reachable            → Breaking       (G-1)
+  via graphql.page / graphql.content?
+New REQUIRED argument on an existing GraphQL field/query    → Breaking       (G-2)
+  used by the page API's query builder?
+Changed GraphQL structured-error extensions.code semantics  → Breaking       (G-3)
+  (NOT_FOUND, PERMISSION_DENIED) that page-api.ts branches on?
+Renamed/removed JSON field in /api/v1/nav or                → Breaking       (R-1)
+  /api/v1/content response shapes the SDK types model?
+Removed or renamed an inbound postMessage name the SDK      → Breaking       (U-1)
+  listens for (__DOTCMS_UVE_EVENT__)?
+Changed the payload shape of an outbound postMessage the    → Breaking       (U-2)
+  editor consumes (DotCMSUVEAction) without a compat shape?
+Changed X-DotCMS-Version / X-DotCMS-Min-SDK header names,   → Breaking       (H-1)
+  casing assumptions, or the version-comparison contract?
+
+New OPTIONAL GraphQL field/query, additive REST field,      → ✅ Not breaking
+  new postMessage type old SDKs simply never send/receive,
+  internal refactor with no wire-format change, admin-UI
+  (dotcms-ui) only change
+```
+
+---
+
+# G — GraphQL Page/Content API Surface
+
+The Page API (`core-web/libs/sdk/client/src/lib/client/page/page-api.ts`) builds and sends GraphQL
+queries via `buildPageQuery`/`buildQuery`, and the Content API's collection builder does the same for
+`XCollection(...)`-style queries. Both are SDK-authored queries sent to the server's GraphQL schema.
+
+## G-1 — Removing or Renaming a Reachable GraphQL Type/Field
+
+**Direction:** Breaking
+
+### Context
+
+SDK consumers write GraphQL fragments referencing schema types/fields directly in their own code
+(see `PageClient.get()`'s `graphql.page` / `graphql.content` / `graphql.fragments` parameters). These
+fragments are compiled into the request the SDK sends — the SDK itself doesn't know the schema
+shape ahead of time; it trusts the server contract.
+
+### Why it breaks compatibility
+
+If a field or type an already-deployed customer application's fragment references is removed or
+renamed, the customer's next request fails GraphQL query validation entirely — `response.data` comes
+back `null` (see `page-api.ts`'s "BAD QUERY" branch), and the whole page load throws a `DotErrorPage`.
+There's no partial degradation; the entire query fails.
+
+### Signals to watch for in code review
+
+- A field or type removed from a GraphQL schema definition that's part of the public content/page
+  surface (not an internal-only type)
+- A field renamed without a `@deprecated`-and-kept-working transition period
+
+### Safer alternative
+
+- Add the new field/type alongside the old one; deprecate the old one for at least one release cycle
+  before removing it
+- If a rename is unavoidable, keep the old field as an alias resolving to the same value
+
+---
+
+## G-2 — New Required Argument on an Existing GraphQL Field/Query
+
+**Direction:** Breaking
+
+### Context
+
+`buildPageQuery`/`buildQuery` in `page-api.ts` construct queries with a fixed, SDK-known set of
+arguments (e.g. the page query's `url`, `languageId`, `mode`, `personaId`, etc., built from
+`DotCMSPageRequestParams`).
+
+### Why it breaks compatibility
+
+If the server adds a new **required** (non-nullable, no default) argument to a field the SDK already
+queries, every request from an SDK built before that change omits it — GraphQL query validation
+rejects the request outright.
+
+### Signals to watch for in code review
+
+- A new argument added to an existing GraphQL field/query definition with no default value
+- Any change to the page or content query root that isn't purely additive-and-optional
+
+### Safer alternative
+
+- New arguments must be optional with a server-side default that preserves today's behavior
+
+---
+
+## G-3 — Structured GraphQL Error Contract Change
+
+**Direction:** Breaking
+
+### Context
+
+`page-api.ts` branches explicitly on `error.extensions?.code` (`NOT_FOUND` → 404 + specific message,
+`PERMISSION_DENIED` → 403 + specific message, anything else → generic 400) to build a typed
+`DotErrorPage`. This is a contract the SDK actively parses, not just logs.
+
+### Why it breaks compatibility
+
+If the server stops setting `extensions.code`, renames the code strings, or changes when they're
+emitted, the SDK's error classification silently falls through to the generic/wrong branch — a
+"page not found" could get misreported as a generic 400, breaking any consumer code that branches on
+`DotErrorPage`'s `status`/`code`.
+
+### Signals to watch for in code review
+
+- Changes to how GraphQL resolvers set `extensions.code` on errors
+- Renaming or removing the `NOT_FOUND` / `PERMISSION_DENIED` extension codes
+
+### Safer alternative
+
+- Treat `extensions.code` values as a versioned public contract — add new codes freely, never rename
+  or remove existing ones
+
+---
+
+# R — REST Response Shape Changes
+
+## R-1 — REST Response Field Removed or Renamed
+
+**Direction:** Breaking
+
+### Context
+
+`NavigationClient.get()` (`navigation-api.ts`) calls `GET {dotcmsUrl}/api/v1/nav{path}` and reads the
+response as `{ entity: DotCMSNavigationItem[] }` directly off `response.entity` — no defensive
+parsing. The Content API's collection builder similarly expects a fixed response envelope.
+
+### Why it breaks compatibility
+
+A renamed or removed field in the REST response (e.g. `entity` renamed, or a `DotCMSNavigationItem`
+field like `href`/`title` renamed) means the SDK either reads `undefined` silently (TypeScript types
+lie about runtime shape) or the whole navigation tree fails to render, with no clear error since
+there's no schema validation at the boundary.
+
+### Signals to watch for in code review
+
+- Renaming a JSON field in `/api/v1/nav`, `/api/v1/content`, or `/api/v1/page/*` responses
+- Changing the response envelope structure (e.g. `entity` wrapper removed or restructured)
+
+### Safer alternative
+
+- Add new fields additively; never rename or remove a field already returned in these endpoints
+  without a deprecation window
+- Prefer `@JsonProperty` aliasing on the Java side so both old and new field names resolve
+
+---
+
+# U — UVE/Editor `postMessage` Protocol
+
+The Universal Visual Editor communicates with the SDK via `window.postMessage` in both directions.
+Inbound (editor → SDK) messages are dispatched by name via `__DOTCMS_UVE_EVENT__` constants and
+consumed in `core-web/libs/sdk/uve/src/internal/events.ts` (e.g. `onContentChanges`, `onPageReload`,
+`onAutoBounds`, `onIframeScroll`, `onScrollToSection`, `onContentletClicked` — matching message names
+`UVE_SET_PAGE_DATA`, `UVE_RELOAD_PAGE`, `UVE_FLUSH_BOUNDS`, `UVE_SCROLL_INSIDE_IFRAME`,
+`UVE_SCROLL_TO_SECTION`, `UVE_SELECTION_CLEARED`). Outbound (SDK → editor) messages are named via the
+`DotCMSUVEAction` enum in `core-web/libs/sdk/types/src/lib/editor/public.ts` (e.g. `set-url`,
+`set-bounds`, `set-contentlet`, `set-selected-contentlet`, `scroll`).
+
+## U-1 — Inbound Message Name or Payload Removed/Renamed
+
+**Direction:** Breaking
+
+### Context
+
+An old SDK's `events.ts` listeners match on an exact `event.data.name` string. There is no version
+negotiation in the protocol itself — it's a bare string match.
+
+### Why it breaks compatibility
+
+If the editor stops sending a message name an already-deployed SDK listens for (or renames it, or
+changes the payload shape a listener destructures), that SDK's corresponding feature goes silently
+dead — no error, the callback just never fires (e.g. `onAutoBounds`'s drag-flush channel, or
+`onScrollToSection`'s section-jump handling).
+
+### Signals to watch for in code review
+
+- A message name constant in `__DOTCMS_UVE_EVENT__` removed or renamed
+- A payload shape change for an existing message (e.g. `event.data.sectionIndex` renamed or
+  restructured in `onScrollToSection`)
+
+### Safer alternative
+
+- Add new message names/payloads alongside old ones; dual-emit both shapes for at least one release
+  cycle before removing the old one
+
+---
+
+## U-2 — Outbound Message Payload Shape Change
+
+**Direction:** Breaking
+
+### Context
+
+The editor's own listeners parse `DotCMSUVEAction` payloads sent by the SDK (e.g. `set-bounds`,
+`set-selected-contentlet`). An older editor session (cached admin UI, or a customer running an
+older dotCMS version against a newer SDK in a mixed-version scenario) expects the payload shape it
+was built against.
+
+### Why it breaks compatibility
+
+If the SDK-side payload shape changes (fields renamed/removed on the object sent via
+`window.parent.postMessage`) without the editor also updating in lockstep, the editor either
+misreads the payload or ignores it — selection overlays, bounds, or hover state stop updating
+correctly with no visible error.
+
+### Signals to watch for in code review
+
+- A payload shape change on any `DotCMSUVEAction` message (`set-bounds`, `set-contentlet`,
+  `set-selected-contentlet`, `set-url`, `scroll`, etc.)
+- Renaming a `DotCMSUVEAction` enum value's string (the wire value, not just the enum key)
+
+### Safer alternative
+
+- Keep the wire-level string values of `DotCMSUVEAction` stable even if the TS enum key changes
+- Add new fields to a payload additively; never remove/rename a field an existing editor build reads
+
+---
+
+# H — SDK Compatibility Headers Themselves
+
+## H-1 — Compatibility Handshake Mechanism Change
+
+**Direction:** Breaking (most severe category — breaks the detection mechanism itself)
+
+### Context
+
+`SdkVersionWebInterceptor` sets `X-DotCMS-Version` (from `ReleaseInfo.getVersion()`) and
+`X-DotCMS-Min-SDK` (from `MinSdkVersion.VALUE`) on every response. `sdk-compatibility.ts`'s
+`checkSdkCompatibility()` reads them case-insensitively via `Headers.get()`, and `compareVersions()`
+parses both as numeric, dot/dash-separated segments (`parseVersionSegments`), returning `null` (fail
+open, no warning) for anything that doesn't parse as plain integers — including LTS-shaped strings
+like `26.7.14_lts_v1`.
+
+### Why it breaks compatibility
+
+This is the mechanism this entire document exists to protect. If a change alters the header names,
+their casing-sensitivity assumptions, or the version-string shape/comparison semantics
+`compareVersions()` depends on (e.g. switching away from date-lockstep numeric segments to something
+`parseVersionSegments` can't parse), the compatibility check silently stops working for every SDK
+version at once — not just for one release's floor value.
+
+### Signals to watch for in code review
+
+- Any change to `X-DotCMS-Version` / `X-DotCMS-Min-SDK` header names in `SdkVersionWebInterceptor`
+- Any change to `compareVersions()` / `parseVersionSegments()` in `sdk-compatibility.ts`
+- Bumping `MinSdkVersion.VALUE` to a non-numeric-segment (e.g. LTS-shaped) string — this doesn't just
+  fail to gate correctly, it silently disables the check entirely for that comparison
+
+### Safer alternative
+
+- Treat this mechanism itself as doubly-reviewed: any change here should be treated as breaking by
+  default unless proven otherwise, since a bug here is invisible (fails open, no warning, no error)
+
+---
+
+## Non-Breaking Examples (for calibration)
+
+- Admin UI (`dotcms-ui`) only changes — not consumed by any SDK
+- Adding a new **optional** GraphQL field/query (existing SDK queries simply don't request it)
+- Adding a new REST response field (additive — old SDK code ignores fields it doesn't read)
+- Adding a new inbound/outbound `postMessage` type that old SDKs simply never send/receive
+- Internal refactors with no change to any wire format (GraphQL schema, REST JSON shape, or
+  `postMessage` payload)
+- Test-only or documentation-only changes
+
+---
+
+## A Note on This Document's Maturity
+
+Unlike `ROLLBACK_UNSAFE_CATEGORIES.md` (grounded in years of real dotCMS incident history), this
+document starts with no real-world track record of an actual SDK-breaking release. Categories above
+are derived from reading the current SDK source, not from a postmortem. Treat the automated AI check
+built on this document as an aid to human review, not a substitute for it, until it accumulates a
+track record — the same posture the rollback-safety check already takes via its `Human: ...`
+override labels. Expect this document to gain real "Examples from dotCMS history" entries over time
+as actual breaking changes occur and get retroactively categorized here.

--- a/dotCMS/src/main/java/com/dotcms/rest/config/MinSdkVersion.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/config/MinSdkVersion.java
@@ -5,20 +5,34 @@ package com.dotcms.rest.config;
  * to clients via the {@code X-DotCMS-Min-SDK} response header (see
  * {@link com.dotcms.filters.interceptor.meta.SdkVersionWebInterceptor}).
  *
- * <p>This value is <strong>manually maintained</strong>, not computed. Under date-lockstep
- * SDK versioning (ADR-0019: {@code platform-adrs/decisions/0019-sdk-cms-date-lockstep-versioning.md})
+ * <p>This value is maintained via a human-reviewed automated PR, not by hand. Under
+ * date-lockstep SDK versioning (ADR-0019: {@code platform-adrs/decisions/0019-sdk-cms-date-lockstep-versioning.md})
  * most dotCMS releases never change the SDK contract, so this constant does not need to
  * move on every release — only bump it when a change actually breaks compatibility with
- * older {@code @dotcms/*} SDK versions (e.g. a newly-required GraphQL field, a changed
- * {@code postMessage} editor protocol message, a REST response shape the SDK depends on).
+ * older {@code @dotcms/*} SDK versions. See {@code docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md}
+ * for concrete categories (removed/renamed GraphQL fields, changed {@code postMessage}
+ * editor protocol messages, REST response shape changes, etc.).
  *
- * <p><strong>Bump procedure:</strong> when your PR breaks SDK compatibility, set
- * {@link #VALUE} to whatever {@code @dotcms/client} version is already published on npm
- * as {@code latest} at the time you write the PR. Do not try to guess the exact future
- * dotCMS release version this change will ship in — that date-based version number is
- * only assigned when the release is actually cut, so it isn't known yet at PR time. The
- * goal of this value is only to correctly gate SDKs older than what's needed, not to
- * match the eventual release number exactly.
+ * <p><strong>Bump procedure (automated):</strong> do not edit {@link #VALUE} directly in a
+ * PR. Instead:
+ * <ol>
+ *   <li>Get your PR labeled {@code SDK Breaking Change} — an automated check
+ *       ({@code ai_claude-sdk-breaking-change.yml}) evaluates every PR's diff against
+ *       {@code docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md} and adds the label (with an
+ *       explanatory comment) when it detects a break. The check only ever adds this label,
+ *       never removes it — if you disagree with its verdict, remove the label yourself.</li>
+ *   <li>At release time, the operator running {@code cicd_6-release.yml} sets its
+ *       {@code bump_min_sdk_version} input to {@code true} for a release that includes
+ *       such a PR. The release's {@code verify-branch} job fails outright if a
+ *       breaking-change-labeled PR merged since the last release is in range and this
+ *       input was left {@code false} — forgetting is a loud pipeline failure, not a
+ *       silent gap.</li>
+ *   <li>Once the release fully succeeds (build AND deployment green — never eagerly),
+ *       a dedicated job opens a PR against {@code main} bumping {@link #VALUE} to that
+ *       release's version and pings Slack asking a human to review and merge it.
+ *       {@code main} is never pushed to directly, and nothing changes on {@code main} if
+ *       the release fails partway through — there is nothing to roll back.</li>
+ * </ol>
  */
 public final class MinSdkVersion {
 


### PR DESCRIPTION
# Automate `MinSdkVersion.VALUE` maintenance via the release pipeline

Closes #36698

## Problem

Follow-up to #36609 / #36678 (the SDK compatibility handshake). That work shipped
`MinSdkVersion.java` — a constant read by `SdkVersionWebInterceptor` and sent to every
`@dotcms/*` SDK consumer via the `X-DotCMS-Min-SDK` response header — but left its maintenance
fully manual: a developer had to remember to edit the constant by hand in their PR whenever a
change broke SDK compatibility ("Option A" from the original ticket: set it to whatever
`@dotcms/client` version was currently `latest` on npm at PR time).

That's fragile in two ways:
- Nothing stops a developer from simply forgetting.
- The "npm latest at PR time" heuristic has a known gap when the breaking change also needs an
  SDK-side fix — the version that's `latest` at PR time necessarily predates that fix.

This PR replaces the manual edit with a release-pipeline-driven mechanism with a safety net at
both ends: PR-time detection and release-time enforcement.

## What this ships

1. **`SDK Breaking Change` label + AI detector** (`ai_claude-sdk-breaking-change.yml`) — runs on
   every PR, evaluates the diff against a new reference doc, and labels PRs that break SDK
   compatibility.
2. **`docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md`** — the reference doc the AI (and human
   reviewers) use to judge what counts as SDK-breaking, grounded in the actual `@dotcms/client`
   surface (GraphQL page/content API, REST responses, the UVE `postMessage` protocol, the
   compatibility headers themselves).
3. **A new `bump_min_sdk_version` release input** on `cicd_6-release.yml` — "does this release
   include an SDK-breaking change?"
4. **A release-time validation gate** — fails the release outright if a merged PR since the last
   release carries the label but the operator left the checkbox unchecked.
5. **A post-release bump job** — once the release fully succeeds, opens a PR (never a direct
   push) bumping `MinSdkVersion.VALUE` to the release version and pings Slack for human review.
6. Updated Javadoc on `MinSdkVersion.java` describing this procedure.

## Design decisions worth knowing about for review

**Why the bump happens *after* the release succeeds, not during `release-prepare`.**
The obvious-looking approach — folding the bump into `release-prepare`'s existing automated
commit (the same one that already updates `LICENSE` and `.mvn/maven.config`) — is wrong for this
value specifically. That commit only ever lives on the disposable `release-${version}` branch,
which is never merged back to `main`. That's *fine* for `LICENSE`, because
`update-license-date.sh` recomputes the date fresh from "today" on every run — it never depends
on prior state. `MinSdkVersion.VALUE` is the opposite: it's a ratchet that must persist forward
across releases. If it only ever lived on the release branch, the next release-prepare run would
silently start again from `main`'s stale value.

That in turn means **timing matters**: the bump can only safely happen once we *know* the release
shipped (build + deployment both green). If we bumped `main` eagerly in `release-prepare` and the
release then failed downstream, `main` would advertise a stricter compatibility floor for a
dotCMS version that customers never actually received — breaking currently-valid SDK installs for
nothing.

**Why it's a PR, never a direct push to `main`.**
Confirmed via the exact historical precedent for this same problem: the now-retired
`cicd_manual-release-sdks.yml` had to persist a version bump (`core-web/libs/sdk/VERSION`) onto
`main` after a release, and its solution was a dedicated "Open post-release PR to bump VERSION on
main" step — never a direct push. The PR it produced (#36563) was opened by `github-actions[bot]`
but merged by a human. There's no auto-merge anywhere in this repo's workflows to lean on instead.

**Why one label, not four.**
An earlier draft of this mechanism mirrored `ai_claude-rollback-safety.yml`'s label scheme
exactly: `AI: X` / `AI: Not X` / `Human: X` / `Human: Not X`. For rollback-safety that split earns
its keep — a "clear stale AI labels on every push" preflight needs to not clobber a human's
deliberate override. For this mechanism we simplified to a single label, **`SDK Breaking
Change`**:
- The AI only ever *adds* it when it detects a break (with an explanatory PR comment). It never
  removes it.
- Removing the label — because a human disagrees with the AI's verdict — is a plain manual
  action, available to anyone with write access. No separate `Human: ...` label needed.
- A human can just as easily *add* the label manually — covering both a false negative from the
  AI, and PRs from external contributors, where the AI never runs at all (the org-membership
  security gate blocks it).
- Net effect: no "stale label" preflight step needed, no risk of the AI clobbering a human
  decision on the next push, one label to reason about.

## How it works end to end

### 1. PR time
Every PR triggers `ai_claude-sdk-breaking-change.yml`:
- `security-check` — gates on dotCMS org membership (same mechanism as rollback-safety).
- `claude-sdk-breaking-change-check` — reads `docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md`, diffs
  the PR, and either:
  - posts a comment explaining which category matched + adds `SDK Breaking Change`, or
  - does nothing (no label, no comment) if it judges the change non-breaking.

A human reviewer can add or remove the label manually at any time regardless of the AI's verdict.

### 2. Release time — the checkbox is forgotten
Say a PR merged with the `SDK Breaking Change` label (correctly, from the AI or a human), two
more unrelated PRs merge after it, and then someone cuts a release *without* checking
`bump_min_sdk_version`. The very first job, `verify-branch`, runs a new step
(`Validate bump_min_sdk_version against merged PR labels`) that:
- resolves the previous standard release tag,
- pulls every PR merged since that tag (via squash-merge commit messages, same convention the
  existing `release-qa-status` tool relies on),
- checks each one's labels,
- and if any carries `SDK Breaking Change` while `bump_min_sdk_version` is `false`, **fails the
  release immediately**, before `release-prepare` even creates a branch or tag:

  > `::error::This release (v26.10.01-1) includes PR(s) labeled 'SDK Breaking Change' (#36800)
  > since v26.7.14-1, but 'bump_min_sdk_version' was left false. Re-run with
  > bump_min_sdk_version=true, or remove the label from those PRs first if none of them actually
  > break SDK compatibility.`

The operator sees the error, realizes what happened, and re-runs with the checkbox checked.

If the checkbox is checked but *no* labeled PR is found in range, the release still proceeds — it
just prints a non-fatal warning, since a human explicitly opted in and may know something the
labels don't capture:

> `::warning::bump_min_sdk_version=true but no merged PR since v26.7.14-1 carries an SDK-breaking
> label. Proceeding, since a human explicitly opted in — but double-check this is intentional.`

LTS releases (`_lts_v##`) skip this validation entirely — `@dotcms/*` SDKs track the `@latest` npm
cadence, not LTS patch cadence.

### 3. Release time — the release fails partway through
Say the checkbox *was* checked correctly, but the release fails during `build` or `deployment`
for unrelated reasons. The new `bump-min-sdk-version` job is gated with a strict `success()` on
`needs: [release-prepare, build, deployment]` — not the `always() && !failure() && !cancelled()`
idiom used by sibling jobs. If any of those three didn't fully succeed, this job **doesn't run at
all**:
- `MinSdkVersion.VALUE` is not touched.
- No PR is opened.
- No Slack message fires (the job never starts).

Nothing needs to be rolled back, because nothing was ever written. Once the operator fixes the
issue and re-runs the same release successfully, the bump job runs then instead.

### 4. Release time — the release succeeds
Once `release-prepare`, `build`, and `deployment` are all green, `bump-min-sdk-version` runs:
- Checks out fresh `main`.
- **Idempotency check #1**: if `MinSdkVersion.VALUE` already equals this release's version
  (already-bumped, or a retry after a previous bump PR already merged), it no-ops — no duplicate
  commit, no duplicate PR.
- Otherwise, creates branch `sdk/bump-min-sdk-version-<version>` off `main`, edits the constant,
  and **verifies the edit actually took effect** (guards against the `VALUE = "..."` literal
  silently failing to match if the file is ever reformatted — in which case it fails loudly
  instead of quietly opening an empty PR).
- Commits, force-pushes the branch.
- **Idempotency check #2**: reuses an already-open PR for the same branch/version instead of
  opening a duplicate on a retried run.
- Opens the PR (title: `chore(sdk): bump MinSdkVersion.VALUE to <version>`, body explains why),
  and posts to Slack (`log-sdk-libs` channel):

  > :large_orange_circle: **Attention dotters:** dotCMS `26.10.01-1` was released with an
  > SDK-breaking change.
  >
  > A PR bumping `MinSdkVersion.VALUE` to `26.10.01-1` is open on `main`.
  > **Please review and merge the post-release PR ASAP:** [View PR]
  > [View workflow run]

  If the job itself fails partway (e.g. `gh pr create` errors), a separate failure message goes
  to the same channel instead. The PR does **not** auto-merge — a human always reviews and merges
  it manually, same as the retired SDK-VERSION-bump precedent.

## Test scenarios walked through during design (not yet live-fire tested — see Known limitations)

| # | Scenario | Expected outcome | Confirmed by |
|---|----------|-------------------|--------------|
| 1 | AI detects a breaking change; human agrees and leaves the label | Label stays; release-time gate later catches it if the checkbox is forgotten | Design walkthrough + exact error message traced above |
| 2 | AI flags a PR as breaking; human disagrees | Human removes `SDK Breaking Change` manually; no separate label needed, no re-add risk since the AI never removes/re-adds on its own | Confirmed the AI check only ever *adds*, per the workflow's own prompt instructions |
| 3 | AI misses a real breaking change (false negative), or PR is from an external contributor (AI never runs — blocked by the org-membership gate) | A human adds `SDK Breaking Change` manually; the release-time gate treats it identically to an AI-applied label | Confirmed via the gate's label check (`grep -qxF 'SDK Breaking Change'`) — no distinction by origin |
| 4 | Dev forgets `bump_min_sdk_version` on a release that includes a labeled PR | Release fails immediately in `verify-branch`, before any release branch/tag is created | Exact `::error::` message traced above |
| 5 | Dev checks `bump_min_sdk_version` but release fails in `build`/`deployment` | `bump-min-sdk-version` job doesn't run at all — nothing written, nothing to roll back | Confirmed via the job's strict `success()` gate semantics (cross-checked against this repo's own `promote-latest` job, which relies on the same implicit behavior) |
| 6 | Release succeeds with the checkbox checked | PR opens against `main`, Slack notification fires to `log-sdk-libs` | Exact PR title/body and Slack message traced above |
| 7 | Same release re-run after a transient failure, or bump PR already merged | No duplicate PR, no duplicate commit (idempotency checks #1 and #2) | Traced through the exact `grep`/`gh pr list` dedupe logic |
| 8 | `VALUE = "..."` literal gets reformatted some day | Job fails loudly with a clear error instead of silently opening an empty, misleading PR | Locally simulated a reformatted file against the `sed` + verify logic — confirmed the mismatch is caught |
| 9 | Interaction with the existing `next` npm dist-tag publish job (`cicd_3-trunk.yml`) | No interference — `MinSdkVersion.java` falls under the `backend` change-detection filter, not `sdk_libs`, so merging the bump PR never triggers `publish-sdk-next` | Verified directly against `.github/filters.yaml` |

## Known limitations / accepted risk (not fixed here, flagged for awareness)

- **Two releases in flight at once**, both flagged as SDK-breaking, would open two separate bump
  PRs (different branch names, keyed by version) — no collision, but a human merging both should
  merge the later version last.
- **A stale, unmerged bump PR from a previous release** isn't caught by this run's own dedupe
  (different branch name). The validation step does emit a non-fatal `::warning::` if it finds an
  already-open `sdk/bump-min-sdk-version-*` PR against `main`, nudging the operator to merge it
  first.
- **Squash-merge dependency**: both this mechanism's PR-label lookup and the existing
  `release-qa-status` tool assume squash-merge commit messages (`... (#12345)`) to map commits back
  to PR numbers. If the repo's merge policy ever changes, both silently stop finding PR numbers —
  fails safe (never blocks a release), but a real breaking PR could then slip through undetected.
  Pre-existing repo-wide assumption, not new to this PR.
- **This has not yet been live-fire tested against a real GitHub Actions run in this repo** (only
  reasoned through carefully and unit-tested locally where possible — e.g. the `sed`/`grep`
  verification logic). A parallel attempt to validate this end-to-end in the disposable
  `core-workflow-test` fork hit an org-level branch-protection wall (a required status check that
  neither `--admin` merge nor a direct push could bypass with the available token permissions), so
  the AI-labeling behavior, the release-time gate, and the bump job's real GitHub Actions execution
  should be watched closely on this repo's first real usage.

## Files changed

- `.github/workflows/cicd_6-release.yml` — new `bump_min_sdk_version` input, new validation step
  in `verify-branch`, new `bump-min-sdk-version` job.
- `.github/workflows/ai_claude-sdk-breaking-change.yml` (new).
- `docs/core/SDK_BREAKING_CHANGE_CATEGORIES.md` (new).
- `dotCMS/src/main/java/com/dotcms/rest/config/MinSdkVersion.java` — Javadoc updated to describe
  the automated procedure.

## One-time setup already done

The `SDK Breaking Change` label has been created on this repo (color `#b60205`).

This PR fixes: #36698