### PR TITLE
feat(content-drive): dynamic Show In List table columns (#36736)

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter-menu/dot-content-drive-field-filter-menu.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter-menu/dot-content-drive-field-filter-menu.component.spec.ts
@@ -62,6 +62,7 @@ describe('DotContentDriveFieldFilterMenuComponent', () => {
                 userSearchableActive: signal<string[]>([]),
                 addUserSearchableField: jest.fn(),
                 setUserSearchableFields: jest.fn(),
+                setShowInListFields: jest.fn(),
                 clearUserSearchableFilters: jest.fn()
             }),
             mockProvider(DotHttpErrorManagerService),
@@ -180,5 +181,40 @@ describe('DotContentDriveFieldFilterMenuComponent', () => {
 
         expect(httpErrorManager.handle).toHaveBeenCalled();
         expect(store.setUserSearchableFields).toHaveBeenCalledWith([]);
+    });
+
+    it('should populate the Show In List fields from the content type listed fields', () => {
+        contentTypeService.getContentType.mockReturnValue(
+            of({
+                id: 'blog',
+                fields: [
+                    field({ variable: 'title', name: 'Title' }), // not listed
+                    field({ variable: 'summary', name: 'Summary', listed: true }),
+                    field({ variable: 'author', name: 'Author', listed: true })
+                ]
+            } as DotCMSContentType)
+        );
+        store.getFilterValue.mockReturnValue(['blog']);
+
+        spectator.detectChanges();
+
+        expect(store.setShowInListFields).toHaveBeenCalledWith([
+            expect.objectContaining({ variable: 'summary' }),
+            expect.objectContaining({ variable: 'author' })
+        ]);
+    });
+
+    it('should clear the Show In List fields when the single content-type selection is removed', () => {
+        const contentType = signal<string[] | undefined>(['blog']);
+        store.getFilterValue.mockImplementation((key: string) =>
+            key === 'contentType' ? contentType() : undefined
+        );
+
+        spectator.detectChanges();
+
+        contentType.set(undefined);
+        spectator.detectChanges();
+
+        expect(store.setShowInListFields).toHaveBeenLastCalledWith([]);
     });
 });

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter-menu/dot-content-drive-field-filter-menu.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter-menu/dot-content-drive-field-filter-menu.component.ts
@@ -66,7 +66,7 @@ export class DotContentDriveFieldFilterMenuComponent {
 
     protected readonly $loading = signal(false);
 
-    /** Monotonic cache of eligible fields per content-type variable, to avoid refetching. */
+    /** Monotonic cache of the raw fields per content-type variable, to avoid refetching. */
     readonly #fieldsCache = signal<Record<string, DotCMSContentTypeField[]>>({});
 
     /** The previously-active single content-type variable, used to detect real changes. */
@@ -109,13 +109,13 @@ export class DotContentDriveFieldFilterMenuComponent {
                     return this.#contentTypeService.getContentType(contentTypeVar).pipe(
                         take(1),
                         map((contentType: DotCMSContentType) => {
-                            const eligible = this.#eligibleFields(contentType?.fields ?? []);
+                            const raw = contentType?.fields ?? [];
                             this.#fieldsCache.update((cache) => ({
                                 ...cache,
-                                [contentTypeVar]: eligible
+                                [contentTypeVar]: raw
                             }));
 
-                            return eligible;
+                            return raw;
                         }),
                         catchError((error) => {
                             this.#httpErrorManager.handle(error);
@@ -127,7 +127,10 @@ export class DotContentDriveFieldFilterMenuComponent {
                 takeUntilDestroyed(this.#destroyRef)
             )
             .subscribe((fields) => {
-                this.#store.setUserSearchableFields(fields);
+                // One fetch feeds two consumers: the field-filter chips (searchable + indexed
+                // fields) and the results table's extra columns ("Show In List" fields).
+                this.#store.setUserSearchableFields(this.#eligibleFields(fields));
+                this.#store.setShowInListFields(fields.filter((field) => field.listed));
                 this.$loading.set(false);
             });
 
@@ -158,6 +161,7 @@ export class DotContentDriveFieldFilterMenuComponent {
 
         if (active === null) {
             this.#store.setUserSearchableFields([]);
+            this.#store.setShowInListFields([]);
 
             return;
         }

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.html
@@ -37,6 +37,7 @@
         [items]="$items()"
         [loading]="$loading()"
         [totalItems]="$totalItems()"
+        [extraColumns]="$extraColumns()"
         [offset]="$offset()"
         (paginate)="onPaginate($event)"
         (sort)="onSort($event)"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -2029,5 +2029,20 @@ describe('DotContentDriveShellComponent', () => {
                 expect.objectContaining({ field: 'noidx', sortable: false })
             ]);
         });
+
+        it('should map Image/Binary/File fields to the image (thumbnail) column type', () => {
+            showInListFieldsSignal.set([
+                { variable: 'photo', name: 'Photo', dataType: 'SYSTEM', fieldType: 'Image' },
+                { variable: 'doc', name: 'Doc', dataType: 'SYSTEM', fieldType: 'Binary' },
+                { variable: 'attach', name: 'Attach', dataType: 'SYSTEM', fieldType: 'File' }
+            ] as DotCMSContentTypeField[]);
+            spectator.detectChanges();
+
+            expect(spectator.component.$extraColumns()).toEqual([
+                expect.objectContaining({ field: 'photo', type: 'image' }),
+                expect.objectContaining({ field: 'doc', type: 'image' }),
+                expect.objectContaining({ field: 'attach', type: 'image' })
+            ]);
+        });
     });
 });

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -2004,5 +2004,30 @@ describe('DotContentDriveShellComponent', () => {
 
             expect(spectator.component.$extraColumns()).toEqual([]);
         });
+
+        it('should mark a column sortable only when the field is indexed', () => {
+            showInListFieldsSignal.set([
+                {
+                    variable: 'idx',
+                    name: 'Indexed',
+                    dataType: 'TEXT',
+                    fieldType: 'Text',
+                    indexed: true
+                },
+                {
+                    variable: 'noidx',
+                    name: 'Not indexed',
+                    dataType: 'TEXT',
+                    fieldType: 'Text',
+                    indexed: false
+                }
+            ] as DotCMSContentTypeField[]);
+            spectator.detectChanges();
+
+            expect(spectator.component.$extraColumns()).toEqual([
+                expect.objectContaining({ field: 'idx', sortable: true }),
+                expect.objectContaining({ field: 'noidx', sortable: false })
+            ]);
+        });
     });
 });

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -31,6 +31,7 @@ import {
 import { LoggerService, StringUtils } from '@dotcms/dotcms-js';
 import {
     DotCMSContentlet,
+    DotCMSContentTypeField,
     DotContentDriveFolder,
     DotContentDriveItem
 } from '@dotcms/dotcms-models';
@@ -80,6 +81,8 @@ describe('DotContentDriveShellComponent', () => {
     let statusSignal: ReturnType<typeof signal<DotContentDriveStatus>>;
     // Reactive so the shell's syncDialogEffect reacts (mirrors the real SignalStore signal).
     let dialogSignal: WritableSignal<DotContentDriveDialog | undefined>;
+    // Reactive so the shell's $extraColumns computed recomputes when the fields change.
+    let showInListFieldsSignal: WritableSignal<DotCMSContentTypeField[]>;
 
     const createComponent = createComponentFactory({
         component: DotContentDriveShellComponent,
@@ -132,6 +135,7 @@ describe('DotContentDriveShellComponent', () => {
         filtersSignal = signal({});
         statusSignal = signal(DotContentDriveStatus.LOADING);
         dialogSignal = signal<DotContentDriveDialog | undefined>(undefined);
+        showInListFieldsSignal = signal<DotCMSContentTypeField[]>([]);
 
         spectator = createComponent({
             providers: [
@@ -181,7 +185,9 @@ describe('DotContentDriveShellComponent', () => {
                     setShowAddToBundle: jest.fn(),
                     userSearchableFields: jest.fn().mockReturnValue([]),
                     userSearchableActive: jest.fn().mockReturnValue([]),
+                    showInListFields: showInListFieldsSignal,
                     setUserSearchableFields: jest.fn(),
+                    setShowInListFields: jest.fn(),
                     addUserSearchableField: jest.fn(),
                     clearUserSearchableFilters: jest.fn()
                 }),
@@ -1965,6 +1971,38 @@ describe('DotContentDriveShellComponent', () => {
             spectator.triggerEventHandler(folderListView, 'scroll', new Event('scroll'));
 
             expect(store.resetContextMenu).toHaveBeenCalled();
+        });
+    });
+
+    describe('extra columns (Show In List)', () => {
+        beforeEach(() => spectator.detectChanges());
+
+        it('should map Show In List fields to typed table columns by data/field type', () => {
+            showInListFieldsSignal.set([
+                { variable: 'summary', name: 'Summary', dataType: 'TEXT', fieldType: 'Text' },
+                { variable: 'count', name: 'Count', dataType: 'INTEGER', fieldType: 'Text' },
+                { variable: 'active', name: 'Active', dataType: 'BOOL', fieldType: 'Checkbox' },
+                { variable: 'pub', name: 'Published', dataType: 'DATE', fieldType: 'Date' },
+                { variable: 'evt', name: 'Event', dataType: 'DATE', fieldType: 'Date-and-Time' },
+                { variable: 'clock', name: 'Clock', dataType: 'DATE', fieldType: 'Time' }
+            ] as DotCMSContentTypeField[]);
+            spectator.detectChanges();
+
+            expect(spectator.component.$extraColumns()).toEqual([
+                expect.objectContaining({ field: 'summary', header: 'Summary', type: 'text' }),
+                expect.objectContaining({ field: 'count', type: 'number' }),
+                expect.objectContaining({ field: 'active', type: 'boolean' }),
+                expect.objectContaining({ field: 'pub', type: 'date' }),
+                expect.objectContaining({ field: 'evt', type: 'datetime' }),
+                expect.objectContaining({ field: 'clock', type: 'time' })
+            ]);
+        });
+
+        it('should expose no extra columns when there are no Show In List fields', () => {
+            showInListFieldsSignal.set([]);
+            spectator.detectChanges();
+
+            expect(spectator.component.$extraColumns()).toEqual([]);
         });
     });
 });

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
@@ -33,6 +33,7 @@ import {
     ContextMenuData,
     DotCMSContentTypeField,
     DotCMSDataTypes,
+    DotCMSFieldTypes,
     DotContentDriveFolder,
     DotContentDriveItem,
     DotContentDrivePaginateEvent
@@ -57,8 +58,6 @@ import { DotContentDriveToolbarComponent } from '../components/dot-content-drive
 import { DotFolderListViewContextMenuComponent } from '../components/dot-folder-list-context-menu/dot-folder-list-context-menu.component';
 import {
     DIALOG_TYPE,
-    FIELD_FILTER_DATE_TIME_TYPE,
-    FIELD_FILTER_TIME_ONLY_TYPE,
     SORT_ORDER,
     SUCCESS_MESSAGE_LIFE,
     WARNING_MESSAGE_LIFE,
@@ -225,21 +224,15 @@ export class DotContentDriveShellComponent {
     );
 
     /**
-     * Picks the display type + a readable column width for a field, so numeric/boolean columns stay
-     * compact and long-text columns get room. Date, Date-and-Time and Time all share `dataType`
-     * DATE, so the date sub-type is resolved from `fieldType` first (to keep the time part). Widths
-     * sum into the table's horizontal scroll, so values stay readable instead of being squeezed.
-     */
-    /**
      * Maps a content-type field to the table's generic display type. Date, Date-and-Time and Time
      * all share `dataType` DATE, so the date sub-type is resolved from `fieldType` first (to keep
      * the time part). The table decides each column's width from this type + its own row values.
      */
     #columnTypeForField(field: DotCMSContentTypeField): DotFolderListViewColumn['type'] {
-        if (field.fieldType === FIELD_FILTER_DATE_TIME_TYPE) {
+        if (field.fieldType === DotCMSFieldTypes.DATE_AND_TIME) {
             return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME;
         }
-        if (field.fieldType === FIELD_FILTER_TIME_ONLY_TYPE) {
+        if (field.fieldType === DotCMSFieldTypes.TIME) {
             return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TIME;
         }
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
@@ -217,7 +217,10 @@ export class DotContentDriveShellComponent {
         this.#store.showInListFields().map((field, index) => ({
             field: field.variable,
             header: field.name,
-            sortable: false,
+            // Sortable follows the field's `indexed` flag: the backend sorts via `sortBy` on the
+            // index, so a non-indexed (but listed) field can't be sorted. The schema has no explicit
+            // `sortable`; `indexed` is the determinant.
+            sortable: field.indexed,
             order: index,
             type: this.#columnTypeForField(field)
         }))

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
@@ -31,13 +31,17 @@ import {
 } from '@dotcms/data-access';
 import {
     ContextMenuData,
+    DotCMSContentTypeField,
+    DotCMSDataTypes,
     DotContentDriveFolder,
     DotContentDriveItem,
     DotContentDrivePaginateEvent
 } from '@dotcms/dotcms-models';
 import {
     DotFolderListViewComponent,
+    DOT_FOLDER_LIST_VIEW_COLUMN_TYPE,
     DotContentDriveUploadFiles,
+    DotFolderListViewColumn,
     DotFolderTreeNodeData,
     DotContentDriveMoveItems
 } from '@dotcms/portlets/content-drive/ui';
@@ -53,6 +57,8 @@ import { DotContentDriveToolbarComponent } from '../components/dot-content-drive
 import { DotFolderListViewContextMenuComponent } from '../components/dot-folder-list-context-menu/dot-folder-list-context-menu.component';
 import {
     DIALOG_TYPE,
+    FIELD_FILTER_DATE_TIME_TYPE,
+    FIELD_FILTER_TIME_ONLY_TYPE,
     SORT_ORDER,
     SUCCESS_MESSAGE_LIFE,
     WARNING_MESSAGE_LIFE,
@@ -201,6 +207,54 @@ export class DotContentDriveShellComponent {
     });
 
     readonly $loading = computed(() => this.#store.status() === DotContentDriveStatus.LOADING);
+
+    /**
+     * Extra table columns for the current selection: the selected single content type's "Show In
+     * List" fields mapped to the list-view column shape, with a display type and width derived from
+     * each field's data type. Empty when 0 or >1 content types are selected; the table appends
+     * these after the fixed Type column.
+     */
+    readonly $extraColumns = computed<DotFolderListViewColumn[]>(() =>
+        this.#store.showInListFields().map((field, index) => ({
+            field: field.variable,
+            header: field.name,
+            sortable: false,
+            order: index,
+            type: this.#columnTypeForField(field)
+        }))
+    );
+
+    /**
+     * Picks the display type + a readable column width for a field, so numeric/boolean columns stay
+     * compact and long-text columns get room. Date, Date-and-Time and Time all share `dataType`
+     * DATE, so the date sub-type is resolved from `fieldType` first (to keep the time part). Widths
+     * sum into the table's horizontal scroll, so values stay readable instead of being squeezed.
+     */
+    /**
+     * Maps a content-type field to the table's generic display type. Date, Date-and-Time and Time
+     * all share `dataType` DATE, so the date sub-type is resolved from `fieldType` first (to keep
+     * the time part). The table decides each column's width from this type + its own row values.
+     */
+    #columnTypeForField(field: DotCMSContentTypeField): DotFolderListViewColumn['type'] {
+        if (field.fieldType === FIELD_FILTER_DATE_TIME_TYPE) {
+            return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME;
+        }
+        if (field.fieldType === FIELD_FILTER_TIME_ONLY_TYPE) {
+            return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TIME;
+        }
+
+        switch (field.dataType) {
+            case DotCMSDataTypes.DATE:
+                return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATE;
+            case DotCMSDataTypes.BOOLEAN:
+                return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.BOOLEAN;
+            case DotCMSDataTypes.INTEGER:
+            case DotCMSDataTypes.FLOAT:
+                return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.NUMBER;
+            default:
+                return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TEXT;
+        }
+    }
 
     readonly $fileInput = viewChild<ElementRef>('fileInput');
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
@@ -227,11 +227,19 @@ export class DotContentDriveShellComponent {
     );
 
     /**
-     * Maps a content-type field to the table's generic display type. Date, Date-and-Time and Time
-     * all share `dataType` DATE, so the date sub-type is resolved from `fieldType` first (to keep
-     * the time part). The table decides each column's width from this type + its own row values.
+     * Maps a content-type field to the table's generic display type. Image/Binary/File fields render
+     * as a thumbnail of the field's own asset. Date, Date-and-Time and Time all share `dataType`
+     * DATE, so the date sub-type is resolved from `fieldType` first (to keep the time part). The
+     * table decides each column's width from this type + its own row values.
      */
     #columnTypeForField(field: DotCMSContentTypeField): DotFolderListViewColumn['type'] {
+        if (
+            field.fieldType === DotCMSFieldTypes.IMAGE ||
+            field.fieldType === DotCMSFieldTypes.BINARY ||
+            field.fieldType === DotCMSFieldTypes.FILE
+        ) {
+            return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.IMAGE;
+        }
         if (field.fieldType === DotCMSFieldTypes.DATE_AND_TIME) {
             return DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME;
         }

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/models.ts
@@ -166,6 +166,12 @@ export interface DotContentDriveState extends DotContentDriveInit {
      * hold the first search until fields load, instead of firing one that drops the `us.*` values.
      */
     userSearchableFieldsLoaded: boolean;
+    /**
+     * "Show In List" fields (`field.listed`) of the currently-selected single content type.
+     * Populated from the same content-type fetch as {@link userSearchableFields}; empty when 0 or
+     * >1 content types are selected. Consumed by the results table as extra columns.
+     */
+    showInListFields: DotCMSContentTypeField[];
 }
 
 /**

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/dot-content-drive.store.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/dot-content-drive.store.spec.ts
@@ -961,4 +961,22 @@ describe('DotContentDriveStore - Content Loading Effect', () => {
             expect(store.userSearchableActive()).toEqual(['title', 'tags']);
         });
     });
+
+    describe('Show In List fields', () => {
+        it('should set and expose the Show In List fields', () => {
+            const fields = [createFakeTextField({ variable: 'summary' })];
+
+            store.setShowInListFields(fields);
+
+            expect(store.showInListFields()).toEqual(fields);
+        });
+
+        it('should clear the Show In List fields when field filters are cleared', () => {
+            store.setShowInListFields([createFakeTextField({ variable: 'summary' })]);
+
+            store.clearUserSearchableFilters();
+
+            expect(store.showInListFields()).toEqual([]);
+        });
+    });
 });

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/dot-content-drive.store.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/dot-content-drive.store.ts
@@ -64,7 +64,8 @@ const initialState: DotContentDriveState = {
     pages: [DEFAULT_PAGE],
     userSearchableFields: [],
     userSearchableActive: [],
-    userSearchableFieldsLoaded: false
+    userSearchableFieldsLoaded: false,
+    showInListFields: []
 };
 
 export const DotContentDriveStore = signalStore(
@@ -250,6 +251,13 @@ export const DotContentDriveStore = signalStore(
                 });
             },
             /**
+             * Sets the "Show In List" fields of the active content type (empty when 0 or >1 are
+             * selected). Consumed by the results table to render extra columns after the Type column.
+             */
+            setShowInListFields(fields: DotCMSContentTypeField[]) {
+                patchState(store, { showInListFields: fields });
+            },
+            /**
              * Shows a field-filter chip by adding it to the active list only — NOT to `filters`.
              * This keeps the search request unchanged (no reload/flicker); a `us.*` entry lands in
              * `filters` only once the chip has a value.
@@ -280,6 +288,7 @@ export const DotContentDriveStore = signalStore(
                     userSearchableFields: [],
                     userSearchableActive: [],
                     userSearchableFieldsLoaded: false,
+                    showInListFields: [],
                     pagination: { ...store.pagination(), offset: 0, page: 1 },
                     pages: [DEFAULT_PAGE]
                 });

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -134,6 +134,11 @@
                         @if (!isFolder) {
                             @let value = item[column.field];
                             @switch (column.type) {
+                                <!-- Date/time content fields render as ABSOLUTE values on purpose.
+                                     Intentionally NOT the `dotRelativeDate` pipe used for `modDate`
+                                     below: that shows relative text ("3 days ago") which suits an
+                                     audit timestamp but would misrepresent an arbitrary content
+                                     date field (e.g. an event date shown as "in 2 days"). -->
                                 @case (COLUMN_TYPE.DATE) {
                                     {{ value ? (value | date: 'MM/dd/yyyy') : '' }}
                                 }

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -169,7 +169,7 @@
                                          Non-image assets fall back to a file-type icon. No click. -->
                                     @if (value) {
                                         <div
-                                            class="h-14 max-h-14 bg-(--color-palette-primary-100) p-1">
+                                            class="h-14 max-h-14 w-18 bg-(--color-palette-primary-100) p-1">
                                             <dot-content-thumbnail
                                                 [contentlet]="item"
                                                 [options]="{ fieldVariable: column.field }"

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -35,6 +35,7 @@
             @for (column of $columns(); track column.field) {
                 @if (column.sortable) {
                     <th
+                        class="whitespace-nowrap"
                         [pSortableColumn]="column.field"
                         [style.width]="column.width"
                         data-testId="header-column-sortable">

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -162,15 +162,14 @@
                                     }
                                 }
                                 @case (COLUMN_TYPE.IMAGE) {
-                                    <!-- Identical treatment to the row's leading title thumbnail,
-                                         only pointed at the field's OWN asset (fieldVariable) so a
-                                         secondary/gallery image shows its own thumbnail instead of
-                                         the contentlet's title image. Non-image assets fall back to
-                                         a file-type icon. -->
+                                    <!-- Same size/styling as the row's leading title thumbnail (fixed
+                                         box + tint + padding, 36px icon), only pointed at the field's
+                                         OWN asset (fieldVariable) so a secondary/gallery image shows
+                                         its own thumbnail instead of the contentlet's title image.
+                                         Non-image assets fall back to a file-type icon. No click. -->
                                     @if (value) {
                                         <div
-                                            class="h-14 max-h-14 cursor-pointer bg-(--color-palette-primary-100) p-1"
-                                            (click)="onDoubleClick(item); $event.stopPropagation()">
+                                            class="h-14 max-h-14 bg-(--color-palette-primary-100) p-1">
                                             <dot-content-thumbnail
                                                 [contentlet]="item"
                                                 [options]="{ fieldVariable: column.field }"

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -161,6 +161,27 @@
                                         </i>
                                     }
                                 }
+                                @case (COLUMN_TYPE.IMAGE) {
+                                    <!-- Identical treatment to the row's leading title thumbnail,
+                                         only pointed at the field's OWN asset (fieldVariable) so a
+                                         secondary/gallery image shows its own thumbnail instead of
+                                         the contentlet's title image. Non-image assets fall back to
+                                         a file-type icon. -->
+                                    @if (value) {
+                                        <div
+                                            class="h-14 max-h-14 cursor-pointer bg-(--color-palette-primary-100) p-1"
+                                            (click)="onDoubleClick(item); $event.stopPropagation()">
+                                            <dot-content-thumbnail
+                                                [contentlet]="item"
+                                                [options]="{ fieldVariable: column.field }"
+                                                iconSize="36px"
+                                                [attr.data-testid]="
+                                                    'item-extra-image-' + column.field
+                                                "
+                                                [attr.data-table-id]="item.identifier" />
+                                        </div>
+                                    }
+                                }
                                 @default {
                                     {{ value }}
                                 }

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -32,7 +32,7 @@
             <th [style.width]="'3rem'">
                 <p-tableHeaderCheckbox data-testId="header-checkbox" />
             </th>
-            @for (column of HEADER_COLUMNS; track column.field) {
+            @for (column of $columns(); track column.field) {
                 @if (column.sortable) {
                     <th
                         [pSortableColumn]="column.field"
@@ -129,6 +129,40 @@
                 <td data-testId="item-content-type">
                     {{ (isFolder ? 'Folder' : item.contentType) | dm }}
                 </td>
+                @for (column of $safeExtraColumns(); track column.field) {
+                    <td class="truncate" [attr.data-testid]="'item-extra-' + column.field">
+                        @if (!isFolder) {
+                            @let value = item[column.field];
+                            @switch (column.type) {
+                                @case (COLUMN_TYPE.DATE) {
+                                    {{ value ? (value | date: 'MM/dd/yyyy') : '' }}
+                                }
+                                @case (COLUMN_TYPE.DATETIME) {
+                                    {{ value ? (value | date: 'MM/dd/yyyy h:mm a') : '' }}
+                                }
+                                @case (COLUMN_TYPE.TIME) {
+                                    {{ value ? (value | date: 'h:mm a') : '' }}
+                                }
+                                @case (COLUMN_TYPE.BOOLEAN) {
+                                    <!-- Only render for an actual boolean value; a missing value
+                                         (null/undefined/empty) stays blank so it doesn't read as false. -->
+                                    @if (value !== null && value !== undefined && value !== '') {
+                                        <i
+                                            class="material-symbols-outlined text-[1.25rem]! leading-none"
+                                            [class.text-green-600]="value"
+                                            [class.text-gray-500]="!value"
+                                            data-testId="item-extra-bool">
+                                            {{ value ? 'check_circle' : 'cancel' }}
+                                        </i>
+                                    }
+                                }
+                                @default {
+                                    {{ value }}
+                                }
+                            }
+                        }
+                    </td>
+                }
                 <td data-testId="item-mod-user-name">
                     {{ (isFolder ? item.owner : item.modUserName) ?? 'Unknown' }}
                 </td>
@@ -150,7 +184,7 @@
     <ng-template pTemplate="emptymessage">
         @if (!$loading()) {
             <tr class="h-max hover:bg-transparent!">
-                <td colspan="7" class="h-full border-none p-6 text-center">
+                <td [attr.colspan]="$columnSpan()" class="h-full border-none p-6 text-center">
                     <div class="mx-auto flex max-w-100 flex-col items-center gap-4">
                         <div class="flex size-20 items-center justify-center rounded-full">
                             <i class="pi pi-folder-open text-6xl! text-(--surface-500)"></i>
@@ -181,7 +215,7 @@
                 <p-skeleton height="1.5rem" width="1.5rem" />
             </span>
         </td>
-        @for (column of HEADER_COLUMNS; track column.field) {
+        @for (column of $columns(); track column.field) {
             <td [style.width]="column.width">
                 <span class="flex h-full items-center justify-center first:text-left">
                     <p-skeleton height="1.5rem" width="100%" />

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.spec.ts
@@ -1460,4 +1460,138 @@ describe('DotFolderListViewComponent', () => {
             expect(() => spectator.component.ngOnDestroy()).not.toThrow();
         });
     });
+
+    describe('Extra columns', () => {
+        const rows = [
+            {
+                identifier: '1',
+                type: 'content',
+                title: 'A',
+                contentType: 'Blog',
+                myText: 'hello',
+                myBool: true,
+                myDate: 1700000000000,
+                myDateTime: 1700000000000
+            },
+            {
+                identifier: '2',
+                type: 'content',
+                title: 'B',
+                contentType: 'Blog',
+                myText: 'a longer value here',
+                myBool: false,
+                myDate: 1700000000000,
+                myDateTime: 1700000000000
+            }
+        ] as unknown as (typeof mockItems)[number][];
+
+        const notSortableHeaders = () =>
+            spectator.queryAll(byTestId('header-column-not-sortable')) as HTMLElement[];
+        const headerByLabel = (label: string) =>
+            notSortableHeaders().find((th) => th.textContent?.trim() === label);
+
+        beforeEach(() => {
+            spectator.setInput('items', rows);
+            spectator.setInput('loading', false);
+        });
+
+        it('should render the extra column header and a cell per row after the Type column', () => {
+            spectator.setInput('extraColumns', [
+                { field: 'myText', header: 'My Text', order: 0, type: 'text' }
+            ]);
+            spectator.detectChanges();
+
+            expect(headerByLabel('My Text')).toBeTruthy();
+
+            const cells = spectator.queryAll(byTestId('item-extra-myText'));
+            expect(cells.length).toBe(2);
+            expect(cells[0].textContent?.trim()).toBe('hello');
+
+            // Sits right after the Type cell in the row.
+            const firstRowCells = Array.from(
+                spectator.query(byTestId('item-row'))?.querySelectorAll('td') ?? []
+            );
+            const typeIdx = firstRowCells.findIndex(
+                (td) => td.getAttribute('data-testid') === 'item-content-type'
+            );
+            expect(firstRowCells[typeIdx + 1].getAttribute('data-testid')).toBe(
+                'item-extra-myText'
+            );
+        });
+
+        it('should drop an extra column whose field key collides with a fixed column', () => {
+            spectator.setInput('extraColumns', [
+                { field: 'title', header: 'Dup', order: 0, type: 'text' }
+            ]);
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('item-extra-title'))).toBeFalsy();
+            expect(headerByLabel('Dup')).toBeFalsy();
+        });
+
+        it('should render distinct boolean icons for true/false and stay blank when absent', () => {
+            spectator.setInput('items', [
+                { identifier: '1', type: 'content', title: 'A', myBool: true },
+                { identifier: '2', type: 'content', title: 'B', myBool: false },
+                { identifier: '3', type: 'content', title: 'C' } // no value → blank, not "false"
+            ] as unknown as (typeof mockItems)[number][]);
+            spectator.setInput('extraColumns', [
+                { field: 'myBool', header: 'Bool', order: 0, type: 'boolean' }
+            ]);
+            spectator.detectChanges();
+
+            const cells = spectator.queryAll(byTestId('item-extra-myBool'));
+            expect(
+                cells[0].querySelector('[data-testId="item-extra-bool"]')?.textContent?.trim()
+            ).toBe('check_circle');
+            expect(
+                cells[1].querySelector('[data-testId="item-extra-bool"]')?.textContent?.trim()
+            ).toBe('cancel');
+            expect(cells[2].querySelector('[data-testId="item-extra-bool"]')).toBeFalsy();
+        });
+
+        it('should include the time for datetime but not for date', () => {
+            spectator.setInput('extraColumns', [
+                { field: 'myDate', header: 'D', order: 0, type: 'date' },
+                { field: 'myDateTime', header: 'DT', order: 1, type: 'datetime' }
+            ]);
+            spectator.detectChanges();
+
+            const dateText = spectator.query(byTestId('item-extra-myDate'))?.textContent ?? '';
+            const dateTimeText =
+                spectator.query(byTestId('item-extra-myDateTime'))?.textContent ?? '';
+            expect(dateText).not.toContain(':');
+            expect(dateTimeText).toContain(':');
+        });
+
+        it('should size a text column by content (ch) and a date column with a fixed width', () => {
+            spectator.setInput('extraColumns', [
+                { field: 'myText', header: 'T', order: 0, type: 'text' },
+                { field: 'myDate', header: 'D', order: 1, type: 'date' }
+            ]);
+            spectator.detectChanges();
+
+            expect(headerByLabel('T')?.style.width).toMatch(/ch$/);
+            expect(headerByLabel('D')?.style.width).toBe('12rem');
+        });
+
+        it('should clamp a text column width to the max for very long values', () => {
+            spectator.setInput('items', [
+                { identifier: '1', type: 'content', title: 'A', long: 'x'.repeat(200) }
+            ] as unknown as (typeof mockItems)[number][]);
+            spectator.setInput('extraColumns', [
+                { field: 'long', header: 'L', order: 0, type: 'text' }
+            ]);
+            spectator.detectChanges();
+
+            expect(headerByLabel('L')?.style.width).toBe('32ch');
+        });
+
+        it('should leave the table unchanged when no extra columns are provided', () => {
+            spectator.setInput('extraColumns', []);
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('item-extra-myText'))).toBeFalsy();
+        });
+    });
 });

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.spec.ts
@@ -1529,6 +1529,24 @@ describe('DotFolderListViewComponent', () => {
             expect(headerByLabel('Dup')).toBeFalsy();
         });
 
+        it('should render a thumbnail cell for an image column (per-field asset)', () => {
+            spectator.setInput('items', [
+                {
+                    identifier: '1',
+                    type: 'content',
+                    title: 'A',
+                    contentType: 'Blog',
+                    photo: '/dA/abc/photo/pic.png'
+                }
+            ] as unknown as (typeof mockItems)[number][]);
+            spectator.setInput('extraColumns', [
+                { field: 'photo', header: 'Photo', order: 0, type: 'image' }
+            ]);
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('item-extra-image-photo'))).toBeTruthy();
+        });
+
         it('should render distinct boolean icons for true/false and stay blank when absent', () => {
             spectator.setInput('items', [
                 { identifier: '1', type: 'content', title: 'A', myBool: true },

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
@@ -1,6 +1,6 @@
 import { patchState, signalState } from '@ngrx/signals';
 
-import { NgTemplateOutlet } from '@angular/common';
+import { DatePipe, NgTemplateOutlet } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -39,6 +39,7 @@ import {
 } from '@dotcms/ui';
 
 import { DOT_DRAG_ITEM, HEADER_COLUMNS } from '../shared/constants';
+import { DOT_FOLDER_LIST_VIEW_COLUMN_TYPE, DotFolderListViewColumn } from '../shared/models';
 
 @Component({
     selector: 'dot-folder-list-view',
@@ -52,7 +53,8 @@ import { DOT_DRAG_ITEM, HEADER_COLUMNS } from '../shared/constants';
         SkeletonModule,
         TableModule,
         DotLocaleTagPipe,
-        NgTemplateOutlet
+        NgTemplateOutlet,
+        DatePipe
     ],
     templateUrl: './dot-folder-list-view.component.html',
     styleUrls: ['./dot-folder-list-view.component.scss'],
@@ -96,6 +98,15 @@ export class DotFolderListViewComponent implements OnInit {
      * @alias offset
      */
     $offset = input<number>(0, { alias: 'offset' });
+
+    /**
+     * Extra, caller-provided columns appended after the fixed "type" column. Agnostic of how they
+     * are sourced (Content Drive derives them from the selected content type's "Show In List" fields).
+     *
+     * @type {InputSignal<DotFolderListViewColumn[]>}
+     * @alias extraColumns
+     */
+    $extraColumns = input<DotFolderListViewColumn[]>([], { alias: 'extraColumns' });
 
     /**
      * An output that emits the selected items.
@@ -179,8 +190,78 @@ export class DotFolderListViewComponent implements OnInit {
 
     readonly MIN_ROWS_PER_PAGE = 20;
     protected readonly rowsPerPageOptions = [this.MIN_ROWS_PER_PAGE, 40, 60];
-    protected readonly HEADER_COLUMNS = HEADER_COLUMNS;
-    protected readonly SKELETON_SPAN = HEADER_COLUMNS.length + 1;
+
+    /**
+     * Extra columns after de-duplication by `field` key: drops any that collide with a fixed column
+     * (e.g. a "title" field) or repeat another extra. Header, body and colspan all consume this so
+     * they never drift. De-dupe is by field key, not label.
+     */
+    protected readonly $safeExtraColumns = computed<DotFolderListViewColumn[]>(() => {
+        const seen = new Set(HEADER_COLUMNS.map((column) => column.field));
+
+        return this.$extraColumns().filter((column) => {
+            if (seen.has(column.field)) {
+                return false;
+            }
+            seen.add(column.field);
+
+            return true;
+        });
+    });
+
+    /** Character-count clamps for content-based (text/number) column widths, in `ch`. */
+    private readonly EXTRA_COL_MIN_CH = 8;
+    private readonly EXTRA_COL_MAX_CH = 32;
+    private readonly EXTRA_COL_PAD_CH = 3;
+    /** Column types exposed to the template's `@switch`, so cases aren't magic strings. */
+    protected readonly COLUMN_TYPE = DOT_FOLDER_LIST_VIEW_COLUMN_TYPE;
+
+    /** Fixed widths per non-text column type (predictable, so no measuring needed). */
+    private readonly EXTRA_COL_TYPE_WIDTH: Partial<
+        Record<DotFolderListViewColumn['type'], string>
+    > = {
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATE]: '12rem',
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME]: '16rem',
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TIME]: '9rem',
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.BOOLEAN]: '7rem'
+    };
+
+    /**
+     * De-duplicated extra columns with a resolved width. The table sizes them itself so consumers
+     * only pass field/header/type: an explicit `width` wins; otherwise text/number columns size to
+     * their content (from the current rows), and other types use a fixed per-type width.
+     */
+    protected readonly $sizedExtraColumns = computed<DotFolderListViewColumn[]>(() => {
+        const items = this.$items();
+
+        return this.$safeExtraColumns().map((column) => ({
+            ...column,
+            width: this.#resolveExtraColumnWidth(column, items)
+        }));
+    });
+
+    /**
+     * Full column set the header/skeleton render: the fixed columns with the (de-duplicated, sized)
+     * extra columns spliced in right after the "type" column. The body keeps its hardcoded cells and
+     * renders only the extra cells generically in the same position.
+     */
+    protected readonly $columns = computed<DotFolderListViewColumn[]>(() => {
+        const extras = this.$sizedExtraColumns();
+        if (!extras.length) {
+            return HEADER_COLUMNS;
+        }
+
+        const columns = [...HEADER_COLUMNS];
+        const typeIndex = columns.findIndex((column) => column.field === 'contentType');
+        const insertAt = typeIndex === -1 ? columns.length : typeIndex + 1;
+        columns.splice(insertAt, 0, ...extras);
+
+        return columns;
+    });
+
+    /** Total column count including the leading checkbox column — drives colspan/skeleton span. */
+    protected readonly $columnSpan = computed(() => this.$columns().length + 1);
+
     protected readonly $showPagination = computed(
         () => this.$totalItems() > this.MIN_ROWS_PER_PAGE
     );
@@ -190,14 +271,24 @@ export class DotFolderListViewComponent implements OnInit {
     /**
      * Computed pass-through configuration for empty table.
      */
-    readonly $ptConfig = computed(() => ({
-        table: {
-            style: {
-                'table-layout': 'fixed',
-                ...(this.$items().length === 0 && { height: '100%', width: '100%' })
+    readonly $ptConfig = computed(() => {
+        const extras = this.$sizedExtraColumns();
+
+        return {
+            table: {
+                style: {
+                    'table-layout': 'fixed',
+                    // Grow the table past the container by the sum of the extra columns' widths, so
+                    // each keeps its readable width and the results scroll horizontally instead of
+                    // squeezing every column.
+                    ...(extras.length > 0 && {
+                        'min-width': `calc(100% + ${extras.map((column) => column.width).join(' + ')})`
+                    }),
+                    ...(this.$items().length === 0 && { height: '100%', width: '100%' })
+                }
             }
-        }
-    }));
+        };
+    });
 
     /**
      * State of the component.
@@ -220,6 +311,46 @@ export class DotFolderListViewComponent implements OnInit {
      * Bound scroll handler to ensure the same reference is used for add/remove event listener
      */
     private readonly boundScrollHandler = this.scrollHandler.bind(this);
+
+    /**
+     * Resolves an extra column's width. Explicit width wins; otherwise text/number columns size to
+     * their content — the average value length across the current rows (never narrower than the
+     * header), padded and clamped, in `ch` so it scales with the cell font. Other types use a fixed
+     * per-type width. Average (not max) keeps one long outlier from blowing the column out; overflow
+     * truncates and the table scrolls horizontally.
+     */
+    #resolveExtraColumnWidth(
+        column: DotFolderListViewColumn,
+        items: DotContentDriveItem[]
+    ): string {
+        if (column.width) {
+            return column.width;
+        }
+
+        const fixed = column.type && this.EXTRA_COL_TYPE_WIDTH[column.type];
+        if (fixed) {
+            return fixed;
+        }
+
+        const lengths = items
+            .map((item) => (item as Record<string, unknown>)?.[column.field])
+            .filter((value) => value !== null && value !== undefined && value !== '')
+            .map((value) => String(value).length);
+
+        const averageLength = lengths.length
+            ? Math.round(lengths.reduce((sum, length) => sum + length, 0) / lengths.length)
+            : 0;
+
+        const chars = Math.min(
+            Math.max(
+                Math.max(column.header?.length ?? 0, averageLength) + this.EXTRA_COL_PAD_CH,
+                this.EXTRA_COL_MIN_CH
+            ),
+            this.EXTRA_COL_MAX_CH
+        );
+
+        return `${chars}ch`;
+    }
 
     ngOnInit(): void {
         // We should be getting this from the Global Store

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
@@ -224,8 +224,9 @@ export class DotFolderListViewComponent implements OnInit {
         [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME]: '16rem',
         [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TIME]: '9rem',
         [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.BOOLEAN]: '7rem',
-        // Fixed thumbnail column — sized to the thumbnail box, never measured from content.
-        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.IMAGE]: '6rem'
+        // Fixed thumbnail column — wider than the 4.5rem thumbnail box so a sortable header
+        // (label + sort icon) fits on one line; never measured from content.
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.IMAGE]: '9rem'
     };
 
     /**

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
@@ -223,7 +223,9 @@ export class DotFolderListViewComponent implements OnInit {
         [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATE]: '12rem',
         [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME]: '16rem',
         [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TIME]: '9rem',
-        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.BOOLEAN]: '7rem'
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.BOOLEAN]: '7rem',
+        // Fixed thumbnail column — sized to the thumbnail box, never measured from content.
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.IMAGE]: '6rem'
     };
 
     /**

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/shared/models.ts
@@ -16,7 +16,9 @@ export const DOT_FOLDER_LIST_VIEW_COLUMN_TYPE = {
     BOOLEAN: 'boolean',
     DATE: 'date',
     DATETIME: 'datetime',
-    TIME: 'time'
+    TIME: 'time',
+    /** Image/binary/file field: renders the field's own asset as a thumbnail. */
+    IMAGE: 'image'
 } as const;
 
 export type DotFolderListViewColumnType =

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/shared/models.ts
@@ -5,12 +5,36 @@ import type { TreeNode } from 'primeng/api';
  * @interface DotFolderListViewColumn
  * @description Column configuration for the folder list view
  */
+/**
+ * Generic display types for a column's cell value. Kept agnostic of any domain field system so the
+ * table can format and size values (dates, booleans, numbers) without knowing where the column came
+ * from. Callers map their own field/data types onto these.
+ */
+export const DOT_FOLDER_LIST_VIEW_COLUMN_TYPE = {
+    TEXT: 'text',
+    NUMBER: 'number',
+    BOOLEAN: 'boolean',
+    DATE: 'date',
+    DATETIME: 'datetime',
+    TIME: 'time'
+} as const;
+
+export type DotFolderListViewColumnType =
+    (typeof DOT_FOLDER_LIST_VIEW_COLUMN_TYPE)[keyof typeof DOT_FOLDER_LIST_VIEW_COLUMN_TYPE];
+
 export interface DotFolderListViewColumn {
     field: string;
     header: string;
-    width: string;
+    /**
+     * Explicit width (any CSS length). Optional for caller-provided extra columns: when omitted the
+     * table sizes the column itself — by content for text/number, by a sensible default per type
+     * otherwise. Fixed columns set it explicitly.
+     */
+    width?: string;
     sortable?: boolean;
     order: number;
+    /** How the cell value is rendered and sized. Defaults to `text` when omitted. */
+    type?: DotFolderListViewColumnType;
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

Implements #36736 (under epic #33280): the Content Drive results table shows extra columns after the **Type** column, derived from the selected single content type's **"Show In List"** (`field.listed`) fields. Frontend only.

- **Agnostic table** (`dot-folder-list-view`): new `extraColumns` input, spliced in right after the Type column in the header, body, and skeleton, with a dynamic `colspan`. Fixed columns are untouched. Columns are **de-duplicated by field key** (so a `title` field can't double the name column). The table **owns sizing**: an explicit width wins, otherwise text/number columns size to the **average value length** of the current rows (in `ch`, header-floored, clamped 8–32) and other types get a fixed per-type width; the widths sum into the table's `min-width` for **horizontal scroll** instead of squeezing. Column display types are an `as const` (`DOT_FOLDER_LIST_VIEW_COLUMN_TYPE`) — no magic strings.
- **Type-aware cells**: `date` → `MM/dd/yyyy`, `datetime` → `MM/dd/yyyy h:mm a`, `time` → `h:mm a` (Angular `DatePipe`, **absolute** on purpose — not the relative `modDate` pipe); `boolean` → Material `check_circle` / `cancel`, and **blank when the value is absent** (a missing boolean doesn't read as `false`); `image` → a **thumbnail of the field's own asset** (see below); folders render blank.
- **Image / Binary / File columns**: render a `dot-content-thumbnail` pointed at the field via `[options]="{ fieldVariable }"`, so a secondary/gallery image shows **its own** picture rather than the contentlet's title image (non-image assets fall back to a file-type icon). Same size/styling as the row's leading title thumbnail (fixed `4.5rem × 3.5rem` box, no click). Fixed column width — never measured from content.
- **Sortable columns**: a Show-In-List column is sortable when its field is `indexed` (the `(sort)` → `store.setSort` → `sortBy` pipeline was already wired). The sortable header keeps its label + sort icon on one line.
- **Reuses the User Searchable fetch**: one `getContentType(variable)` response now feeds both the searchable-field chips and the new `showInListFields` store signal (filtered by `field.listed`). Cleared when the single-content-type selection changes/clears.
- **Shell**: maps each field's `fieldType`/`dataType` to the generic column type using the canonical `DotCMSFieldTypes` enum — Image/Binary/File → `image`, Date-and-Time/Time resolved from `fieldType` (they share `dataType` DATE), the rest from `dataType`.

## Review follow-ups (in this PR)

Addressing @nicobytes' review:
- Column typing **decoupled** from the field-filter constants → canonical `DotCMSFieldTypes` enum (no behavior change).
- Date/time columns **documented** as intentionally absolute (vs. the relative `modDate` pipe).
- **Sortable** Show-In-List columns (was hardcoded `sortable:false`).
- **Image support** — Image/Binary/File fields showed raw text; they now render the field's own thumbnail.
- Header sort-icon wrap fixed (`whitespace-nowrap`); stale/duplicated JSDoc removed.

**Deferred (not here):** convergence of the relationship field's tables onto the Content Drive table (as a constrained subset) — tracked in **#36749** (near-term: add single/multi-select to the Content Drive table); a dev-warning for `$safeExtraColumns` when it drops a field-key collision.

## Testing

- `content-drive-ui`: 186 passing · `portlets-content-drive`: 810 passing. Lint clean.
- New unit tests: table (render/order after Type, dedupe by key, boolean true/false/absent, date vs datetime, `ch` vs fixed width, clamp, no-extras, **image thumbnail cell**); store (`setShowInListFields` set/clear); field-filter menu (populate from `listed`, clear on deselect); shell (field→type mapping, **Image/Binary/File → image**, **sortable-when-indexed**).

## Notes

- The extra-column mechanism is agnostic; only the Content Drive derivation is wired here.
- `item[field]` renders the raw value for text/number; rich rendering of complex field types (relationship/block) is out of scope.

Closes #36736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36736