### PR TITLE
fix(security): remove repackaged dot.commons-io dependency (CVE-2024-47554)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -207,11 +207,6 @@
             </dependency>
             <dependency>
                 <groupId>com.dotcms.lib</groupId>
-                <artifactId>dot.commons-io</artifactId>
-                <version>2.0.1_2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.dotcms.lib</groupId>
                 <artifactId>dot.commons-jci-core</artifactId>
                 <version>1.0.406301_2</version>
             </dependency>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -159,10 +159,6 @@
         </dependency>
         <dependency>
             <groupId>com.dotcms.lib</groupId>
-            <artifactId>dot.commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.commons-httpclient</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Proposed Changes
* Remove the `com.dotcms.lib:dot.commons-io:2.0.1_2` dependency from `dotCMS/pom.xml`.
* Remove its `dependencyManagement` entry from `bom/application/pom.xml`.

This eliminates `dot.commons-io-2.0.1_2.jar` — a namespace-shaded copy of Apache Commons IO **2.0.1** (`com.dotcms.repackage.org.apache.commons.io.*`) that still contains the vulnerable `XmlStreamReader`, causing OWASP Dependency Check to flag **CVE-2024-47554**. The standard `commons-io:commons-io:2.14.0` (already on the classpath, bumped in #35236) covers all real usage. Completes the outstanding commons-io action item from #35235.

No code migration was required: nothing in the repo imports the shaded namespace (verified across source, other `com.dotcms.lib` repackaged jars via bytecode scan, and OSGi/Felix export config — 0 references), and the shaded jar has **0 class overlap** with `commons-io:commons-io:2.14.0`, so removing it cannot break the modern library.

### Checklist
- [x] Tests — `./mvnw install -pl :dotcms-core --am -DskipTests` BUILD SUCCESS; verified `dot.commons-io-*.jar` gone from assembled webapp and `commons-io-2.14.0.jar` retained; local runtime smoke test (startup + navigation) clean
- [ ] Translations — n/a
- [x] Security Implications Contemplated — removes a jar flagged for CVE-2024-47554 (CVSS 4.3, CWE-400). Residual risk: reflective use of the shaded namespace by a custom OSGi plugin — none found in-repo; smoke-tested commons-io-heavy paths.

### Additional Info
- Closes #36739
- Origin: #35235 (OKR: Security & Privacy); related PRs #35236 (commons-io bump) and #35315 (analogous `dot.guava` removal)
- Reported via support ticket 36256
- **Backport:** needs cherry-pick to the LTS lines that ship the flagged jar — confirm 24.07 / 24.12 / 25.07 coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)