### PR TITLE
fix(ci): restore changelog-site-publish job lost in #36606 merge-conflict resolution

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -260,6 +260,28 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
 
+  # Changelog Site Publish - deliver the changelog entry to dev.dotcms.com/docs/changelogs.
+  # Runs after release-notes, current-track GA only (reusing release-prepare's is_latest —
+  # the same deliberate CLI/LTS exclusion the promote-latest job uses, not reinvented here).
+  # Non-blocking (allow_failure: true) so a changelog publish failure never fails the
+  # software release (FR-008). Additive: existing phases are untouched.
+  changelog-site-publish:
+    name: Changelog Site Publish
+    needs: [ release-prepare, deployment, release-notes ]
+    if: >-
+      needs.release-prepare.outputs.is_latest == 'true'
+      && github.repository == 'dotcms/core'
+    uses: ./.github/workflows/cicd_comp_changelog-site-publish-phase.yml
+    with:
+      release_tag: ${{ needs.release-prepare.outputs.release_tag }}
+      release_version: ${{ needs.release-prepare.outputs.release_version }}
+      docker_tags: ${{ needs.deployment.outputs.docker_tags }}
+      allow_failure: true
+    secrets:
+      DOTCMS_DEVSITE_RELEASENOTES_TOKEN: ${{ secrets.DOTCMS_DEVSITE_RELEASENOTES_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+
   # Finalize - standard finalization phase (required for phase pattern)
   finalize:
     name: Finalize


### PR DESCRIPTION
## What

Restores the `changelog-site-publish` job in `cicd_6-release.yml` — the trigger wiring for the changelog auto-publish feature (#36606), which was accidentally erased during that PR's merge-conflict resolution (main's version of the file was taken wholesale over the branch's additive change). Everything else from #36606 is on main and intact (phase workflow, `changelog-publisher` package, shared prompt template, secrets/vars); without this block the feature simply never runs — confirmed on `v26.07.27-01`, whose run had no such job in its graph.

The block is byte-identical to what was reviewed and approved in #36606 (job after `release-notes`, `is_latest`-gated, `continue-on-error` via allow_failure, renamed `DOTCMS_DEVSITE_RELEASENOTES_TOKEN` secret).

Closes: #36742

🤖 Generated with [Claude Code](https://claude.com/claude-code)


This PR fixes: #36742