### PR TITLE
fix(ci): docker cache-export flake must not fail release deployments

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -219,5 +219,8 @@ runs:
         pull: true
         push: ${{ inputs.do_deploy }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # ignore-error: a transient GHA cache-service failure on this WRITE (pure build-speed
+        # optimization) must never fail a release deployment — it skipped Promote-latest,
+        # Release-Notes, and the changelog publish on v26.07.27-01 (#36744).
+        cache-to: type=gha,mode=max,ignore-error=true
         build-args: ${{ inputs.build_args }}


### PR DESCRIPTION
One line: `cache-to: type=gha,mode=max,ignore-error=true` in the shared `deploy-docker` composite (all pipeline images build through it). On `v26.07.27-01` (run 30285041675) a transient GHA cache-service `not_found` on the cache WRITE — after every image push had succeeded — failed the deployment job and cascaded: `Promote latest tag` skipped (latest still points at 26.07.21-01), `Release Notes` skipped (empty release body), changelog publish skipped. A build-speed optimization should never be able to do that.

Closes: #36744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ogYXVeZsBVUHkwzdStYPJ

This PR fixes: #36744