### PR TITLE
fix(test): make CleanUpFieldReferencesJobTest resolvable by Weld (#36753)

### DIFF
--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/CleanUpFieldReferencesJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/CleanUpFieldReferencesJobTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
+import com.dotcms.DataProviderWeldRunner;
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.FieldAPI;
@@ -29,13 +30,13 @@ import com.dotmarketing.util.Config;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
 import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +44,8 @@ import org.junit.runner.RunWith;
 /**
  * @author nollymar
  */
-@RunWith(DataProviderRunner.class)
+@ApplicationScoped
+@RunWith(DataProviderWeldRunner.class)
 public class CleanUpFieldReferencesJobTest extends IntegrationTestBase {
 
     final CleanUpFieldReferencesJob instance = new CleanUpFieldReferencesJob();


### PR DESCRIPTION
### Parent Issue

Fixes #36753

### Problem

`CleanUpFieldReferencesJobTest` could not be instantiated when run on its own — a single-class run from the IDE, or `-Dit.test=CleanUpFieldReferencesJobTest`. Weld blew up before any test method executed:

```
org.jboss.weld.exceptions.UnsatisfiedResolutionException: WELD-001334: Unsatisfied dependencies for type CleanUpFieldReferencesJobTest with qualifiers
    at org.jboss.weld.bean.builtin.InstanceImpl.checkBeanResolved(InstanceImpl.java:241)
    at org.jboss.weld.bean.builtin.InstanceImpl.get(InstanceImpl.java:113)
    at com.dotcms.DataProviderWeldRunner.createTest(DataProviderWeldRunner.java:38)
```

**Root cause.** `DataProviderWeldRunner.createTest()` builds the test instance through the CDI container:

```java
return CONTAINER.select(getTestClass().getJavaClass()).get();
```

`dotcms-integration/src/test/resources/META-INF/beans.xml` declares `bean-discovery-mode="annotated"`, so a class is only registered as a bean when it carries a bean-defining annotation. The test class had none, so `select(...)` resolved to nothing and threw. It was also still on `@RunWith(DataProviderRunner.class)`, which does not go through the container at all — the class had drifted from the pattern the rest of the module uses.

### Solution

Bring the class in line with the convention already used by the other 11 Weld-based tests in `dotcms-integration` (`OSIndexAPIImplIntegrationTest`, `DependencyBundlerTest`, `SiteSearchDualWriteRouterIT`, `MigrationPhaseStoreBootstrapIT`, …): annotate with `@ApplicationScoped` and run with `DataProviderWeldRunner`. The now-unused `DataProviderRunner` import is dropped.

```diff
-@RunWith(DataProviderRunner.class)
+@ApplicationScoped
+@RunWith(DataProviderWeldRunner.class)
 public class CleanUpFieldReferencesJobTest extends IntegrationTestBase {
```

One file, +4/−2. **Test-only change — no production code is touched.**

### How to Test

Run the class in isolation, which is the path that was broken:

```bash
./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=CleanUpFieldReferencesJobTest
```

Expected: all 4 data-provider cases run and pass (`checkboxFieldVarName` / `dateTimeFieldVarName`, in both the JSON-backed and column-backed variants) with no `UnsatisfiedResolutionException`. The same run from the IDE as a single-class run should also be green.

The test stays registered in `MainSuite2b`, so the suite run covers it as before.

### Notes

Only the individual-run path was broken — the suite run masked it, which is why CI stayed green. Worth keeping in mind for any other test still on `@RunWith(DataProviderRunner.class)` that also needs container-managed instantiation: the failure only surfaces when the class is run in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
