### PR TITLE
fix(ci): SBOM generator — pin anchore_syft, use stable syft entry point

### DIFF
--- a/.github/actions/legacy-release/sbom-generator/action.yml
+++ b/.github/actions/legacy-release/sbom-generator/action.yml
@@ -41,7 +41,10 @@ runs:
     - name: Scan Docker Image with Syft
       shell: bash
       run: |
-        pipx run anchore_syft dotcms/dotcms:${{ env.DOTCMS_VERSION }} -o cyclonedx-json > core/sbom-cyclonedx.json
+        # --spec + explicit `syft` app: upstream renamed its exposed scripts and an
+        # unpinned `pipx run anchore_syft` stopped resolving (#36755). Version pinned
+        # so a future packaging change can't silently break releases again.
+        pipx run --spec anchore_syft==1.18.1 syft dotcms/dotcms:${{ env.DOTCMS_VERSION }} -o cyclonedx-json > core/sbom-cyclonedx.json
 
     - name: Rename SBOM file with dotCMS version
       shell: bash


### PR DESCRIPTION
Upstream `anchore_syft` renamed its exposed executable scripts, so the unpinned `pipx run anchore_syft` in the SBOM generator fails on every release (observed on v26.07.27-01, run 30285041675 attempt 2). Because `release-notes` needs the `release` job with `if: success()`, the SBOM failure also kills release-notes and the changelog publish — same over-coupling family as #36744.

Fix: `pipx run --spec anchore_syft==1.18.1 syft …` — stable entry point per the package's own usage hint, version-pinned so upstream packaging changes can't break releases silently.

Local verification: the pinned invocation resolves and runs (`syft --version` OK).

Closes: #36755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ogYXVeZsBVUHkwzdStYPJ

This PR fixes: #36755