### PR TITLE
fix(changelog-publisher): send required eolDate field (create path 400s without it)

### DIFF
--- a/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/cli.py
+++ b/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/cli.py
@@ -49,6 +49,11 @@ def cmd_publish(args: argparse.Namespace) -> int:
         return 2
     # Default per site convention: EOL = released date + 1 year (current track).
     if args.eol_date:
+        try:
+            dt.date.fromisoformat(args.eol_date)
+        except ValueError:
+            log.error("invalid --eol-date %r: expected yyyy-MM-dd", args.eol_date)
+            return 2
         eol_date = args.eol_date
     else:
         try:

--- a/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/cli.py
+++ b/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/cli.py
@@ -40,6 +40,15 @@ def cmd_publish(args: argparse.Namespace) -> int:
     with open(args.notes_file, encoding="utf-8") as fh:
         release_notes = fh.read()
     released_date = args.released_date or dt.date.today().isoformat()
+    # Default per site convention: EOL = released date + 1 year (current track).
+    if args.eol_date:
+        eol_date = args.eol_date
+    else:
+        r = dt.date.fromisoformat(released_date)
+        try:
+            eol_date = r.replace(year=r.year + 1).isoformat()
+        except ValueError:  # Feb 29
+            eol_date = r.replace(year=r.year + 1, day=28).isoformat()
 
     service_account = args.service_account or os.environ.get(_SERVICE_ACCOUNT_ENV, "")
 
@@ -51,6 +60,7 @@ def cmd_publish(args: argparse.Namespace) -> int:
             release_notes=release_notes,
             docker_image=args.docker_image,
             released_date=released_date,
+            eol_date=eol_date,
             service_account=service_account or None,
             force=args.force,
             apply=args.apply,
@@ -80,6 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
     pub.add_argument("--notes-file", required=True, help="path to the release-notes markdown (normally the GitHub release body)")
     pub.add_argument("--docker-image", required=True, help="deployment docker image tag")
     pub.add_argument("--released-date", default="", help="availability date (yyyy-MM-dd); defaults to today")
+    pub.add_argument("--eol-date", default="", help="planned end-of-life date (yyyy-MM-dd); defaults to released date + 1 year")
     pub.add_argument("--apply", action="store_true", help="actually search + fire the Publish action")
     pub.add_argument(
         "--service-account", default="",

--- a/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/cli.py
+++ b/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/cli.py
@@ -40,11 +40,17 @@ def cmd_publish(args: argparse.Namespace) -> int:
     with open(args.notes_file, encoding="utf-8") as fh:
         release_notes = fh.read()
     released_date = args.released_date or dt.date.today().isoformat()
+    # Validate before any use: a malformed operator-supplied date must be a clean
+    # usage error (rc 2), never a traceback (module contract).
+    try:
+        r = dt.date.fromisoformat(released_date)
+    except ValueError:
+        log.error("invalid --released-date %r: expected yyyy-MM-dd", released_date)
+        return 2
     # Default per site convention: EOL = released date + 1 year (current track).
     if args.eol_date:
         eol_date = args.eol_date
     else:
-        r = dt.date.fromisoformat(released_date)
         try:
             eol_date = r.replace(year=r.year + 1).isoformat()
         except ValueError:  # Feb 29

--- a/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/publisher.py
+++ b/.github/actions/core-cicd/changelog-publisher/src/changelog_publisher/publisher.py
@@ -70,6 +70,7 @@ def build_contentlet(
     release_notes: str,
     docker_image: str,
     released_date: str,
+    eol_date: str,
     identifier: str | None = None,
 ) -> dict:
     """Build the fire payload's contentlet.
@@ -84,6 +85,9 @@ def build_contentlet(
         "releaseNotes": release_notes,
         "dockerImage": docker_image,
         "releasedDate": released_date,
+        # Required field on the live type (validated 2026-07-27: the fire 400s without
+        # it). Site convention: released date + 1 year for current-track entries.
+        "eolDate": eol_date,
         "showInChangeLog": True,
         "lts": _LTS_CURRENT,
         "released": _RELEASED,
@@ -102,6 +106,7 @@ def publish(
     release_notes: str,
     docker_image: str,
     released_date: str,
+    eol_date: str,
     service_account: str | None = None,
     force: bool = False,
     apply: bool,
@@ -122,6 +127,7 @@ def publish(
             release_notes=release_notes,
             docker_image=docker_image,
             released_date=released_date,
+            eol_date=eol_date,
         )
         client.fire(contentlet, apply=apply)
         if apply and not _wait_until_searchable(client, version):
@@ -149,6 +155,7 @@ def publish(
         release_notes=release_notes,
         docker_image=docker_image,
         released_date=released_date,
+        eol_date=eol_date,
         identifier=hit.identifier,
     )
     client.fire(contentlet, apply=apply)

--- a/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
+++ b/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
@@ -194,7 +194,7 @@ def test_protective_skip_exits_zero_with_marker(tmp_path, monkeypatch, capsys):
 def test_malformed_released_date_exits_two_with_clean_error(tmp_path, monkeypatch, capsys, caplog):
     """A malformed --released-date is a usage error: rc 2, clean one-line error, no
     traceback, zero network calls (review finding on #36759)."""
-    monkeypatch.setenv("DOTCMS_DEVSITE_TOKEN", "t")
+    monkeypatch.setenv("DOTCMS_DEVSITE_RELEASENOTES_TOKEN", "t")
 
     with caplog.at_level("ERROR"):
         rc = main(_argv(tmp_path, "26.07.10-01", "--released-date", "garbage", "--apply"))

--- a/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
+++ b/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
@@ -190,6 +190,22 @@ def test_protective_skip_exits_zero_with_marker(tmp_path, monkeypatch, capsys):
 
 
 @responses_lib.activate
+@responses_lib.activate
+def test_malformed_released_date_exits_two_with_clean_error(tmp_path, monkeypatch, capsys, caplog):
+    """A malformed --released-date is a usage error: rc 2, clean one-line error, no
+    traceback, zero network calls (review finding on #36759)."""
+    monkeypatch.setenv("DOTCMS_DEVSITE_TOKEN", "t")
+
+    with caplog.at_level("ERROR"):
+        rc = main(_argv(tmp_path, "26.07.10-01", "--released-date", "garbage", "--apply"))
+
+    assert rc == 2
+    out, err = capsys.readouterr()
+    assert "Traceback" not in out and "Traceback" not in err
+    assert any("released-date" in r.message for r in caplog.records)
+    assert len(responses_lib.calls) == 0
+
+
 def test_missing_backend_url_exits_one_with_clean_error(tmp_path, monkeypatch, capsys, caplog):
     """A missing/empty DOTCMS_DEVSITE_URL -> rc 1 with a clean one-line error (the URL is a
     repo variable, never hardcoded — an unset variable must fail loudly, not fall back)."""

--- a/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
+++ b/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
@@ -121,6 +121,46 @@ def test_apply_issues_fire_call(tmp_path, monkeypatch):
     assert len(put_calls) == 1
 
 
+# ---------------------------------------------------------------------------
+# Default eolDate derivation — the branch the release workflow actually runs
+# (it never passes --eol-date), so the computed VALUE must be pinned.
+# ---------------------------------------------------------------------------
+
+def _fired_eol_date() -> str:
+    put_calls = [c for c in responses_lib.calls if c.request.method == "PUT"]
+    assert len(put_calls) == 1
+    return json.loads(put_calls[0].request.body)["contentlet"]["eolDate"]
+
+
+@responses_lib.activate
+def test_default_eol_date_is_released_plus_one_year(tmp_path, monkeypatch):
+    """No --eol-date -> fired payload carries releasedDate + 1 year (site convention)."""
+    monkeypatch.setenv("DOTCMS_DEVSITE_RELEASENOTES_TOKEN", "t")
+    responses_lib.add(responses_lib.POST, _SEARCH_URL, json=_fixture("search_empty.json"), status=200)
+    responses_lib.add(responses_lib.PUT, _FIRE_URL, json={"entity": {}}, status=200)
+
+    rc = main(_argv(tmp_path, "26.07.10-01", "--apply"))  # _argv sets released 2026-07-16
+
+    assert rc == 0
+    assert _fired_eol_date() == "2027-07-16"
+
+
+@responses_lib.activate
+def test_default_eol_date_handles_feb_29(tmp_path, monkeypatch):
+    """Feb 29 release -> EOL falls back to Feb 28 of the (non-leap) next year."""
+    monkeypatch.setenv("DOTCMS_DEVSITE_RELEASENOTES_TOKEN", "t")
+    responses_lib.add(responses_lib.POST, _SEARCH_URL, json=_fixture("search_empty.json"), status=200)
+    responses_lib.add(responses_lib.PUT, _FIRE_URL, json={"entity": {}}, status=200)
+
+    argv = [a for a in _argv(tmp_path, "28.02.29-01", "--apply")]
+    argv[argv.index("2026-07-16")] = "2028-02-29"
+
+    rc = main(argv)
+
+    assert rc == 0
+    assert _fired_eol_date() == "2029-02-28"
+
+
 # ===========================================================================
 # User Story 3 — failure exit contract + skip-vs-failure stdout distinction
 # ===========================================================================

--- a/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
+++ b/.github/actions/core-cicd/changelog-publisher/tests/test_cli.py
@@ -190,7 +190,6 @@ def test_protective_skip_exits_zero_with_marker(tmp_path, monkeypatch, capsys):
 
 
 @responses_lib.activate
-@responses_lib.activate
 def test_malformed_released_date_exits_two_with_clean_error(tmp_path, monkeypatch, capsys, caplog):
     """A malformed --released-date is a usage error: rc 2, clean one-line error, no
     traceback, zero network calls (review finding on #36759)."""
@@ -206,6 +205,23 @@ def test_malformed_released_date_exits_two_with_clean_error(tmp_path, monkeypatc
     assert len(responses_lib.calls) == 0
 
 
+@responses_lib.activate
+def test_malformed_eol_date_exits_two_with_clean_error(tmp_path, monkeypatch, capsys, caplog):
+    """--eol-date gets the same up-front validation as --released-date: rc 2, clean
+    error, no traceback, zero network calls (contract symmetry)."""
+    monkeypatch.setenv("DOTCMS_DEVSITE_RELEASENOTES_TOKEN", "t")
+
+    with caplog.at_level("ERROR"):
+        rc = main(_argv(tmp_path, "26.07.10-01", "--eol-date", "garbage", "--apply"))
+
+    assert rc == 2
+    out, err = capsys.readouterr()
+    assert "Traceback" not in out and "Traceback" not in err
+    assert any("eol-date" in r.message for r in caplog.records)
+    assert len(responses_lib.calls) == 0
+
+
+@responses_lib.activate
 def test_missing_backend_url_exits_one_with_clean_error(tmp_path, monkeypatch, capsys, caplog):
     """A missing/empty DOTCMS_DEVSITE_URL -> rc 1 with a clean one-line error (the URL is a
     repo variable, never hardcoded — an unset variable must fail loudly, not fall back)."""

--- a/.github/actions/core-cicd/changelog-publisher/tests/test_edge_cases.py
+++ b/.github/actions/core-cicd/changelog-publisher/tests/test_edge_cases.py
@@ -30,7 +30,7 @@ def _publish(client, version, **overrides):
     kwargs = dict(
         release_notes="**dotCMS %s** notes\n" % version,
         docker_image=f"dotcms/dotcms:{version}_abc1234",
-        released_date="2026-07-16",
+        eol_date="2027-01-01", released_date="2026-07-16",
         apply=True,
     )
     kwargs.update(overrides)
@@ -96,7 +96,7 @@ def test_older_line_patch_carries_todays_date_and_touches_only_its_version():
     _add_fire()
     client = CorpsitesClient(token="t")
 
-    result = _publish(client, "26.05.27-04", released_date="2026-07-16")
+    result = _publish(client, "26.05.27-04", eol_date="2027-01-01", released_date="2026-07-16")
 
     assert result.status == "created"
     body = _fire_bodies()[0]

--- a/.github/actions/core-cicd/changelog-publisher/tests/test_publisher.py
+++ b/.github/actions/core-cicd/changelog-publisher/tests/test_publisher.py
@@ -50,6 +50,7 @@ def _publish(client, **overrides):
         release_notes="### Fixes {#Fixes-26.07.10-01}\n- Something ([#1](https://x/pull/1))\n",
         docker_image="dotcms/dotcms:26.07.10-01_abc1234",
         released_date="2026-07-16",
+        eol_date="2027-07-16",
         service_account=SERVICE_ACCOUNT,
         apply=True,
     )
@@ -72,6 +73,7 @@ def test_create_path_fires_publish_with_expected_fields():
     assert c["minor"] == "26.07.10-01"
     assert c["dockerImage"] == "dotcms/dotcms:26.07.10-01_abc1234"
     assert c["releasedDate"] == "2026-07-16"
+    assert c["eolDate"] == "2027-07-16"
     assert "### Fixes" in c["releaseNotes"]
     # Verified current-track stored values (T004, data-model.md).
     assert c["showInChangeLog"] is True


### PR DESCRIPTION
First live fires of the changelog publisher (the #36750 backfill) hit a 400: `Dotcmsbuilds` requires `eolDate`, which the payload omitted — the maiden release run would have failed identically. Payload now includes it; CLI gains `--eol-date` defaulting to released date + 1 year (the convention every current-track entry follows, verified live). 31 tests green; the four-version backfill ran successfully on this exact code.

Closes: #36758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ogYXVeZsBVUHkwzdStYPJ

This PR fixes: #36758