### PR TITLE
fix(ci): stop Claude AI workflows overwriting each other's PR comment

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -93,6 +93,13 @@ jobs:
       timeout_minutes: 30
       runner: ubuntu-latest
       enable_mention_detection: false
+      # No progress comment: claude-code-action finds the comment to reuse by
+      # "authored by the Claude app bot" with no per-workflow marker, so this
+      # review would grab — and overwrite — the code review comment posted by
+      # ai_claude-orchestrator.yml (#36761). STEP 5 below upserts this review's
+      # own <!-- dotcms-backend-review --> comment, so it needs no comment of
+      # its own. Only the code-review orchestrator owns a sticky comment.
+      track_progress: false
       claude_args: >-
         --allowedTools
         "Agent,Bash(git diff*),Bash(git log*),Bash(git show*),Bash(cat CLAUDE.md*),Bash(cat docs/backend/*),Bash(cat docs/core/*),Bash(cat dotCMS/src/*),Bash(find dotCMS/src -name '*.java'*),Bash(grep -rn dotCMS/src*),Bash(gh pr comment*),Bash(gh pr review*),Bash(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/issues/comments/*),Bash(jq*)"

--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -91,6 +91,13 @@ jobs:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
+      # No progress comment: claude-code-action finds the comment to reuse by
+      # "authored by the Claude app bot" with no per-workflow marker, so this
+      # check would grab — and overwrite — the code review comment posted by
+      # ai_claude-orchestrator.yml (#36761). This check reports through a label,
+      # plus its own comment when the change is unsafe, so it needs no comment
+      # of its own. Only the code-review orchestrator owns a sticky comment.
+      track_progress: false
       prompt: |
         You are a dotCMS rollback-safety analyst. Determine whether the changes in this PR are safe to roll back to the previous release.
 


### PR DESCRIPTION
Closes: #36761

## Problem

Three Claude workflows run on every `pull_request` in this repo — `ai_claude-orchestrator.yml` (code review), `ai_claude-rollback-safety.yml`, `ai_claude-backend-reviewer.yml`. They all route to the Anthropic path, and `anthropics/claude-code-action@v1` finds the comment to reuse by **"authored by the Claude app bot"**, with no per-workflow marker:

```ts
// create-initial.ts
const existingComment = comments.data.find((comment) => {
  const idMatch = comment.user?.id === CLAUDE_APP_BOT_ID;   // 209825114
  const botNameMatch = comment.user?.type === "Bot" && comment.user?.login.toLowerCase().includes("claude");
  ...
});
```

So the later workflow resets the earlier one's comment to "Claude Code is working…" and writes its own result over it. [PR #36759](https://github.com/dotCMS/core/pull/36759#issuecomment-5096277486) — one comment, eight edits, two workflows:

| time | run | content |
|---|---|---|
| 20:10:08 | Claude AI Orchestrator (30301039985) | creates comment |
| 20:11:23 | " | **Code Review: PR #36759** |
| 20:12:17 | Claude AI Rollback Safety (30301040015) | reset to "Claude Code is working…" — **review gone** |
| 20:13:50 | " | Rollback-Safety Analysis |

This is deterministic, not a race — ordering decides only who wins, so a concurrency group would not help. Note the rollback check wasn't even *supposed* to comment there: its verdict was "safe", and STEP 4b says label only. The comment it destroyed the review with was the action's own progress comment.

## Change

One owner for the action-managed comment. `ai_claude-orchestrator.yml` keeps it — an auto-updating review comment is the point there. The other two pass `track_progress: false`:

- **rollback-safety** reports through the `AI: Safe To Rollback` / `AI: Not Safe To Rollback` label, plus its own `gh pr comment` when unsafe. On a safe verdict the analysis lives in the job log, which is the accepted trade here.
- **backend-reviewer** upserts its own `<!-- dotcms-backend-review -->` marker comment in STEP 5.

Neither needs a progress comment, and neither can hijack the review's now.

## Dependency — shipped

`track_progress` was hardcoded `"true"` in `claude-executor.yml`. dotCMS/ai-workflows#64 exposes it (default `true`, no behaviour change for other consumers); released as [**v3.4.0**](https://github.com/dotCMS/ai-workflows/releases/tag/v3.4.0) and the floating **`v3` tag now points at it**, so the input this PR passes exists. Declared `type: boolean`, which is why `false` here is unquoted (unlike `issue_autodoc.yml`, which calls the action directly, where `with:` values are strings).

Verified on this PR: both workflows now resolve `track_progress: false` and get past the earlier `startup_failure`.

## Not verified here

`claude-code-action` skips any PR that modifies its own workflow file ("Workflow validation failed… identical content to the version on the repository's default branch"), so on this PR the rollback and backend jobs are skipped and no label is applied. End-to-end no-clobber behaviour is exercised by the first ordinary PR after this merges.

## Upstream

The real fix is a namespaced sticky marker in `claude-code-action`. The Bedrock/Codex executors in `ai-workflows` already do this via `sticky_namespace`; the limitation and the one-owner convention are now documented in that repo's README (§6).

This PR fixes: #36761