### PR TITLE
docs(evergreen-tracks): interim support-facing track-change runbook + CX briefing outline

### DIFF
--- a/.github/actions/core-cicd/evergreen-tracks/CX-BRIEFING.md
+++ b/.github/actions/core-cicd/evergreen-tracks/CX-BRIEFING.md
@@ -4,8 +4,13 @@ Agenda for the live session with **Dean Gonzalez / CX**. Goal: CX can take a tra
 end to end using [SUPPORT-RUNBOOK.md](SUPPORT-RUNBOOK.md) without asking engineering what the words
 mean. 30 minutes plus Q&A.
 
-**Pre-read (send with the invite):** [SUPPORT-RUNBOOK.md](SUPPORT-RUNBOOK.md) and the published
-customer doc [dev.dotcms.com/docs/evergreen-tracks](https://dev.dotcms.com/docs/evergreen-tracks).
+**Pre-read (send with the invite)** — send the Google Doc links, not the GitHub ones:
+
+- [Evergreen Tracks — Support Runbook (interim)](https://docs.google.com/document/d/1tLEzbZOC5D5cXDq0S_bHtsKqd0-13hSUAcXfPeLlblI/edit) (source: [SUPPORT-RUNBOOK.md](SUPPORT-RUNBOOK.md))
+- [Evergreen Tracks — CX / Support Briefing Outline](https://docs.google.com/document/d/1DyjRKAB_aiwnRShLuQLYx-PbnyiH5Ft5XeCgPNDc1YY/edit) — this agenda
+- The published customer doc [dev.dotcms.com/docs/evergreen-tracks](https://dev.dotcms.com/docs/evergreen-tracks)
+
+Both Docs live in the **Engineering** shared drive → `dotEvergreen`, editable by `all@dotcms.com`.
 
 ---
 
@@ -70,8 +75,8 @@ a gap in the runbook: update the runbook, don't just answer it once.
 
 Known open items to raise if CX doesn't:
 - What SLA does a track-change request get? (Not defined yet — CX to propose.)
-- Who publishes the runbook to the internal KB, and where does it live so it doesn't fork from
-  this file?
+- The Google Doc above is the published copy today. Does CX also want it mirrored into their own KB
+  (e.g. Freshdesk solutions), and if so who owns keeping that copy in sync with the repo file?
 - Do we proactively tell customers which track they're on, or answer on request only?
 
 ---

--- a/.github/actions/core-cicd/evergreen-tracks/CX-BRIEFING.md
+++ b/.github/actions/core-cicd/evergreen-tracks/CX-BRIEFING.md
@@ -1,0 +1,85 @@
+# Evergreen Tracks — CX / Support Briefing Outline
+
+Agenda for the live session with **Dean Gonzalez / CX**. Goal: CX can take a track-change request
+end to end using [SUPPORT-RUNBOOK.md](SUPPORT-RUNBOOK.md) without asking engineering what the words
+mean. 30 minutes plus Q&A.
+
+**Pre-read (send with the invite):** [SUPPORT-RUNBOOK.md](SUPPORT-RUNBOOK.md) and the published
+customer doc [dev.dotcms.com/docs/evergreen-tracks](https://dev.dotcms.com/docs/evergreen-tracks).
+
+---
+
+## 1. What tracks are, in customer language (5 min)
+
+- A track controls **how fresh** a release an environment gets. Same artifacts on every track —
+  only the timing differs.
+- Three tracks: `latest` (every GA release), `standard` (~14 days old, the default),
+  `trailing` (~28 days old).
+- **Per environment, not per customer.** Dev on `latest`, prod on `trailing` is normal.
+- Where the fleet is today: ~180 `standard`, 9 `trailing`, 1 `latest`. Standard is the default and
+  most customers will never ask for anything.
+- The one sentence that prevents most escalations: **tracks are forward-only — moving slower never
+  rolls a running version backward.**
+
+## 2. What CX owns vs what platform owns (3 min)
+
+- CX: intake, validation, expectation-setting, customer comms, closing the ticket.
+- Platform / Enablement: the manifest PR, the merge, verification. CODEOWNER approval is required,
+  so this cannot be self-served by support — and that is deliberate.
+- Interim reality: every track change is a hand-shipped PR. Self-service is roadmap (Workstream B).
+
+## 3. The request flow, walked live (10 min)
+
+Walk the runbook's five steps against a real example (bcbs `dev-2310`, the one env on `latest`):
+
+1. **Intake** — the ticket template; why an informal Slack ask still becomes a ticket.
+2. **Validate** — tenant/env slug (not the friendly name), requested track is one of three,
+   requester authority, eligibility gates, and *is this env maintenance-paused*.
+3. **Hand off** — what platform will do: label edit; faster move also bumps the pinned image
+   digest, slower move is label-only with no restart.
+4. **Verify** — Argo Synced/Healthy, `imageID` is the truth, env serving.
+5. **Reply** — which env, new track, whether the version changed now, when the next update lands.
+
+## 4. The three answers CX will need most (7 min)
+
+Read them out loud from §6 of the runbook so the wording is shared:
+
+- "Does moving slower roll us back?" → No; it stops advancing until it catches up.
+- "When will our next update apply?" → `latest`: next GA. `standard`/`trailing`: next maintenance
+  window, newest GA older than ~14/~28 days. **No specific dates promised.**
+- "Put us back on last month's version" → that's a rollback, not a track change → escalate.
+
+Also flag: custom cadences / skipping a release are **not** supported; a customer already running a
+flagged release is an **incident**, escalate immediately.
+
+## 5. Escalation and the sheet (3 min)
+
+- Escalation path: CX → platform/Enablement, `#team-cloud-engineering`,
+  `@dotcms/platform-engineers` / `@dotcms/CloudEng-Support`, ticket always linked.
+- The **"dotCMS Maintenance Pause List & Evergreen Tracks"** sheet is CX's registry, kept in sync by
+  hand. Git is the source of truth; when they disagree, the sheet gets fixed. Whoever changes a
+  track or a pause updates the sheet in the same sitting.
+- Maintenance pauses (Duncan Aviation, Jostens, firstmac today) are **never** cleared as a
+  side-effect of a track request.
+
+## 6. Q&A capture (rest of session)
+
+Log every question **in the issue thread on dotCMS/core#36522** — one comment, question + answer,
+or question + owner if unanswered. Anything that needed an engineering answer during the session is
+a gap in the runbook: update the runbook, don't just answer it once.
+
+Known open items to raise if CX doesn't:
+- What SLA does a track-change request get? (Not defined yet — CX to propose.)
+- Who publishes the runbook to the internal KB, and where does it live so it doesn't fork from
+  this file?
+- Do we proactively tell customers which track they're on, or answer on request only?
+
+---
+
+## Exit criteria for the session
+
+- [ ] CX can name the three tracks and their timing without notes.
+- [ ] CX can state the forward-only rule in customer words.
+- [ ] Ticket template in use for the next real request.
+- [ ] Q&A captured on #36522; runbook updated for anything that was unclear.
+- [ ] Owner named for publishing the runbook to the internal KB.

--- a/.github/actions/core-cicd/evergreen-tracks/README.md
+++ b/.github/actions/core-cicd/evergreen-tracks/README.md
@@ -39,3 +39,9 @@ Pass `--apply` to actually move tags. Without it, the command prints the plan an
 ## Test
 
     uv run pytest
+
+## Support-facing docs
+
+Customer track-change requests are handled per
+[SUPPORT-RUNBOOK.md](SUPPORT-RUNBOOK.md) (intake → validate → apply → verify → escalate), with
+[CX-BRIEFING.md](CX-BRIEFING.md) as the agenda for walking CX through it.

--- a/.github/actions/core-cicd/evergreen-tracks/README.md
+++ b/.github/actions/core-cicd/evergreen-tracks/README.md
@@ -45,3 +45,23 @@ Pass `--apply` to actually move tags. Without it, the command prints the plan an
 Customer track-change requests are handled per
 [SUPPORT-RUNBOOK.md](SUPPORT-RUNBOOK.md) (intake → validate → apply → verify → escalate), with
 [CX-BRIEFING.md](CX-BRIEFING.md) as the agenda for walking CX through it.
+
+Both are published as Google Docs for support to read — [Support
+Runbook](https://docs.google.com/document/d/1tLEzbZOC5D5cXDq0S_bHtsKqd0-13hSUAcXfPeLlblI/edit) /
+[CX Briefing](https://docs.google.com/document/d/1DyjRKAB_aiwnRShLuQLYx-PbnyiH5Ft5XeCgPNDc1YY/edit)
+(Engineering shared drive → `dotEvergreen`). These files stay canonical: change them here, then
+re-publish the Docs.
+
+To re-publish after editing, render the markdown to HTML and push it over the existing Doc — same
+file ID, so the links above never change (needs the [`gws`](https://github.com/dotCMS/platform) CLI
+authenticated as a dotCMS user):
+
+    uv run --with markdown python -c 'import markdown,sys,pathlib; \
+      pathlib.Path("out.html").write_text(markdown.markdown(pathlib.Path(sys.argv[1]).read_text(), \
+      extensions=["tables","sane_lists","fenced_code"]))' SUPPORT-RUNBOOK.md
+    gws drive files update \
+      --params '{"fileId":"1tLEzbZOC5D5cXDq0S_bHtsKqd0-13hSUAcXfPeLlblI","supportsAllDrives":true}' \
+      --upload out.html --upload-content-type text/html
+
+Keep the "canonical copy" banner at the top of the Doc — it is what stops the two copies forking.
+`fenced_code` is not optional: without it, code blocks arrive in the Doc with stray ``` markers.

--- a/.github/actions/core-cicd/evergreen-tracks/SUPPORT-RUNBOOK.md
+++ b/.github/actions/core-cicd/evergreen-tracks/SUPPORT-RUNBOOK.md
@@ -4,6 +4,11 @@
 engineer who applies them. **Interim** because track changes are a manual manifest edit until
 self-service track selection ships.
 
+> **Published copy for CX:** this file is the canonical source; the copy support actually reads is
+> the Google Doc **[Evergreen Tracks — Support Runbook (interim)](https://docs.google.com/document/d/1tLEzbZOC5D5cXDq0S_bHtsKqd0-13hSUAcXfPeLlblI/edit)**
+> (Engineering shared drive → `dotEvergreen`). **Land corrections here, then re-publish the Doc** —
+> the Doc carries a banner saying so, but nothing enforces it.
+
 **Related docs**
 
 | Doc | Use it for |

--- a/.github/actions/core-cicd/evergreen-tracks/SUPPORT-RUNBOOK.md
+++ b/.github/actions/core-cicd/evergreen-tracks/SUPPORT-RUNBOOK.md
@@ -13,7 +13,7 @@ self-service track selection ships.
 
 | Doc | Use it for |
 |---|---|
-| [RUNBOOK.md](RUNBOOK.md) — operator runbook | Exception operations: tainting a bad release, holding a track, holding a single environment. Incident work, not routine requests. |
+| [RUNBOOK.md](RUNBOOK.md) — operator runbook | Exception operations: tainting a bad release, holding a track, holding a single environment. Incident work, not routine requests. **Lands with [PR #36770](https://github.com/dotCMS/core/pull/36770)** — until that merges, the file (and the links to it below) won't resolve; escalate to platform, who have the procedures. |
 | [README.md](README.md) | How the track tags themselves advance (the promote action, cadence, approval gate). |
 | [dev.dotcms.com/docs/evergreen-tracks](https://dev.dotcms.com/docs/evergreen-tracks) | The published customer-facing explanation. **Everything you tell a customer must match this page.** |
 | ["dotCMS Maintenance Pause List & Evergreen Tracks" sheet](https://docs.google.com/spreadsheets/d/1pDSXjBYuUfGLufNcrhK-zVeSLrGb-c38qpZzDM3LUfg/edit) | The CX-facing registry of who is on what track and who is paused. Updated by hand — see step 4.4. |
@@ -39,8 +39,9 @@ Two facts that drive almost every support answer:
    version backward. It simply stops advancing until the slower track catches up to the version it
    already runs.
 
-Fleet snapshot (2026-07-28): 190 subscribed environments — 180 `standard`, 9 `trailing`
-(greensky, lennox, lennox-dr, suny), 1 `latest` (bcbs `dev-2310`).
+Fleet snapshot (2026-07-28): 190 subscribed environments — 180 `standard`; 9 `trailing`, which are
+9 *environments* across 4 tenants (greensky ×4, lennox ×2, lennox-dr ×1, suny ×2); 1 `latest`
+(bcbs `dev-2310`). Re-count with the `grep` in step 3.1 rather than trusting this line.
 
 ---
 
@@ -178,6 +179,12 @@ metadata:
         image: mirror.gcr.io/dotcms/dotcms:26.07.27-01@sha256:d0e1515a70989e2deb1d59364773ef76802af9857b7ea058dffb282b8f34f19d
 ```
 
+That is bcbs `dev-2310`'s real pin — and its digest deliberately **differs** from the `latest`
+digest in the step 4.3 table even though both say `26.07.27-01`: the same version gets rebuilt, so
+one version can have several digests. **A pin whose digest doesn't match the table is not by itself
+drift** — check the version first, and only treat a digest difference as something to raise if the
+*version* is behind.
+
 So the label alone changes *future* behavior; it does not move the running version.
 
 | Move | Edit | Effect |
@@ -214,7 +221,9 @@ Snapshot for orientation — **re-resolve, never copy these** (2026-07-28):
 | `trailing` | 26.06.22-03 | `sha256:d28362adad00db09faf941f5c0de39a7b1ba6f6dca5d1903442a1ffb1fe7e2e6` |
 
 Note that the same version can exist as several rebuild digests (e.g. `26.07.27-01` and
-`26.07.27-01_66cdc38`). Always pin the digest the *track tag* currently resolves to.
+`26.07.27-01_66cdc38`). Always pin the digest the *track tag* currently resolves to — and that is
+why the example pin in step 4.2 shows `26.07.27-01` on a different digest than the `latest` row
+above. Same version, different rebuild; not a mismatch to escalate.
 
 ### 4.4 Ship it
 
@@ -267,13 +276,15 @@ running to check.
 
 | Track | Answer |
 |---|---|
-| `latest` | On the next GA release. |
+| `latest` | On the next GA release — once platform ships the pin bump for it. |
 | `standard` | At our next scheduled maintenance window, landing on the newest GA release older than ~14 days. |
 | `trailing` | At our next scheduled maintenance window, landing on the newest GA release older than ~28 days. |
 
-Do **not** promise a specific date or a fixed day-of-week. `standard` and `trailing` advance only
-when an operator dispatches the promote action at a maintenance window — that human step *is* the
-cadence gate. If the customer needs a date, ask platform for the next window rather than guessing.
+Do **not** promise a specific date or a fixed day-of-week — for **any** track, including `latest`.
+While the reconciler is in dry-run (see step 4.2), *no* environment advances by itself: `latest`
+tracks each GA release but still needs the pin shipped, and `standard`/`trailing` advance only when
+an operator dispatches the promote action at a maintenance window. If the customer needs a date,
+ask platform rather than guessing.
 
 ### 6.3 "Can we go back to version X?"
 
@@ -325,7 +336,7 @@ Be honest about these on tickets; they are the reason this runbook says "interim
 - **No self-service.** Every track change is a manifest PR by platform. Self-service selection is
   on the roadmap (Workstream B).
 - **No automatic version advance yet.** The reconciler is deployed but dry-run everywhere, so
-  `standard`/`trailing` envs move only when a human ships the pin. Never tell a customer their
+  **every** env — `latest` included — moves only when a human ships the pin. Never tell a customer their
   environment will update itself on a specific date.
 - **Sheet ↔ git drift.** The CX sheet is updated by hand. Verify against git before answering
   "what track am I on".

--- a/.github/actions/core-cicd/evergreen-tracks/SUPPORT-RUNBOOK.md
+++ b/.github/actions/core-cicd/evergreen-tracks/SUPPORT-RUNBOOK.md
@@ -1,0 +1,344 @@
+# Evergreen Tracks — Support Runbook (interim)
+
+**Audience:** CX / support agents taking customer track-change requests, and the platform
+engineer who applies them. **Interim** because track changes are a manual manifest edit until
+self-service track selection ships.
+
+**Related docs**
+
+| Doc | Use it for |
+|---|---|
+| [RUNBOOK.md](RUNBOOK.md) — operator runbook | Exception operations: tainting a bad release, holding a track, holding a single environment. Incident work, not routine requests. |
+| [README.md](README.md) | How the track tags themselves advance (the promote action, cadence, approval gate). |
+| [dev.dotcms.com/docs/evergreen-tracks](https://dev.dotcms.com/docs/evergreen-tracks) | The published customer-facing explanation. **Everything you tell a customer must match this page.** |
+| ["dotCMS Maintenance Pause List & Evergreen Tracks" sheet](https://docs.google.com/spreadsheets/d/1pDSXjBYuUfGLufNcrhK-zVeSLrGb-c38qpZzDM3LUfg/edit) | The CX-facing registry of who is on what track and who is paused. Updated by hand — see step 4.4. |
+
+---
+
+## 0. The model in one minute
+
+A **track** controls *how fresh* a release an environment receives. All tracks install the same
+released artifacts; only the timing differs.
+
+| Track | Lands on the customer | Typical use |
+|---|---|---|
+| `latest` | Every GA release, immediately | Dev / early-validation envs, teams with strong CI |
+| `standard` | GA releases ~14 days old — the default | Most environments |
+| `trailing` | GA releases ~28 days old | Conservative / production-leaning envs |
+
+Two facts that drive almost every support answer:
+
+1. **Track is per environment**, not per customer. Dev on `latest` and prod on `trailing` is a
+   normal, supported setup.
+2. **Tracks are forward-only.** Moving an environment to a *slower* track never rolls its running
+   version backward. It simply stops advancing until the slower track catches up to the version it
+   already runs.
+
+Fleet snapshot (2026-07-28): 190 subscribed environments — 180 `standard`, 9 `trailing`
+(greensky, lennox, lennox-dr, suny), 1 `latest` (bcbs `dev-2310`).
+
+---
+
+## 1. Who does what
+
+| Step | Owner |
+|---|---|
+| Intake, validation, customer comms | **CX / support** |
+| The manifest change (PR to `dotCMS/infrastructure-as-code`) | **Platform / Enablement** (Steve's team) — CODEOWNER approval is required, so support cannot self-serve this |
+| Verification that it applied | Platform, reported back on the ticket |
+| Closing the loop with the customer | **CX / support** |
+
+Support's job is steps 2, 3, 6 and 7. Step 4 and 5 are documented here so you know what you are
+asking for, can read the PR, and can answer "is it done yet".
+
+---
+
+## 2. Intake — what the request looks like
+
+Track changes arrive as a **support ticket** (Freshdesk). They also arrive informally in calls and
+in Slack; if that happens, **open a ticket anyway** — the ticket is the audit trail for a change to
+a customer's production update behavior.
+
+Capture these fields before handing off. Paste this block into the ticket:
+
+```
+Track change request
+--------------------
+Customer / tenant:        e.g. bcbs
+Environment(s):           e.g. dev-2310            (one line per env)
+Current track:            latest | standard | trailing | unknown
+Requested track:          latest | standard | trailing
+Requester:                name + email
+Requester is authorized:  yes/no — how confirmed
+Reason (optional):        e.g. "want dev validating new releases first"
+Urgency / window:         normal | before <date> | tied to a release
+```
+
+If the customer asks "**what track am I on?**" rather than for a change, that is answerable
+without any change — see step 3.1, answer, and close.
+
+---
+
+## 3. Validate before handing off
+
+### 3.1 Which environment, exactly
+
+Environments map 1:1 to a directory in `dotCMS/infrastructure-as-code`:
+
+```
+kubernetes/customers/<tenant>/<env>/statefulset.yaml
+```
+
+e.g. `kubernetes/customers/bcbs/dev-2310/statefulset.yaml`. Customer-facing environment names
+("dev", "our UAT box") are not always the directory name — confirm the tenant slug and env slug,
+not the friendly name. Current track for every subscribed env:
+
+```bash
+# in a dotCMS/infrastructure-as-code checkout
+grep -r "dotcms.cloud/evergreen-track" kubernetes/customers/ | sed 's|kubernetes/customers/||'
+```
+
+The CX sheet is the human-facing registry, but **git is the source of truth** — if they disagree,
+git wins and the sheet needs fixing.
+
+### 3.2 Which track
+
+Only `latest`, `standard`, `trailing`. There is no "every release but skip X", no per-customer
+schedule, and no custom age threshold. If the customer wants something else, that is a product
+conversation → escalate (step 7), don't promise it.
+
+### 3.3 Requester authority
+
+The requester must be a **named technical contact / admin on the account**. A track change alters
+when production updates land, so treat it like any other production change request: if the
+requester is not a known contact, get confirmation from one before handing off.
+
+### 3.4 Set the forward-only expectation *before* the change
+
+Say this explicitly on the ticket, in these words:
+
+> Moving to a faster track takes effect as soon as we make the change. Moving to a slower track
+> never rolls a running version backward — your environment stays on its current version and
+> simply stops advancing until that version ages into the new track, then updates resume.
+
+If the customer's actual goal is "**go back to the version we ran last month**", that is a
+**rollback**, not a track change. Do not action it as a track change → escalate (step 7).
+
+### 3.5 Eligibility
+
+An environment must satisfy all of these to be updated automatically. Platform will re-check, but
+flagging it at intake avoids a round trip:
+
+- `spec.replicas >= 2` (updates are rolling, zero-downtime — a single-replica env can't be)
+- Redis session sharing enabled (`TOMCAT_REDIS_SESSION_ENABLED = "true"`)
+- **not** currently maintenance-paused (`dotcms.cloud/maintenance-pause: "true"`)
+
+If an env fails a gate, the track label can still be set, but the env will be skipped and reported
+rather than rolled. Say so on the ticket instead of promising updates that won't happen.
+
+### 3.6 Paused customers
+
+Some environments are deliberately paused (as of 2026-07-28: Duncan Aviation, Jostens, firstmac).
+**Do not un-pause an environment as part of a track-change request** — the pause exists for a
+reason (e.g. a Java upgrade hold) and clearing it is a separate decision by the CX owner for that
+account. Note the pause on the ticket and escalate.
+
+---
+
+## 4. Apply — the manifest change
+
+> Performed by **platform / Enablement**. Support: this is what to expect to see linked on the
+> ticket.
+
+### 4.1 Edit the environment's manifest
+
+One file: `kubernetes/customers/<tenant>/<env>/statefulset.yaml`. The track lives in the
+StatefulSet's own `metadata.labels` (not the pod template):
+
+```yaml
+metadata:
+  namespace: bcbs
+  name: dotcms-bcbs-dev-2310
+  labels:
+    ...
+    dotcms.cloud/evergreen-track: latest        # <- the track
+```
+
+### 4.2 Faster move vs slower move — they are different edits
+
+**No manifest ever references a floating tag.** Every environment pins an immutable
+`<version>@sha256:<digest>`:
+
+```yaml
+        image: mirror.gcr.io/dotcms/dotcms:26.07.27-01@sha256:d0e1515a70989e2deb1d59364773ef76802af9857b7ea058dffb282b8f34f19d
+```
+
+So the label alone changes *future* behavior; it does not move the running version.
+
+| Move | Edit | Effect |
+|---|---|---|
+| **Faster** (e.g. `standard` → `latest`) | Change the label **and**, in the same PR, bump the pinned `image:` to the requested track's current version + digest | Rolling update now — which is what the public doc promises ("takes effect as soon as our support team makes the change") |
+| **Slower** (e.g. `latest` → `trailing`) | Change the label **only**. Never edit the image line downward | No restart, no version change. The env stops advancing until `trailing` reaches its version |
+
+Interim caveat (2026-07-28): the floating-tag reconciler that would advance pins automatically is
+deployed but running **dry-run everywhere** (`PUSH_ENABLED=false`), so **no environment's version
+advances on its own today** — every version change is a human PR. That is why a faster-track move
+must bump the image pin in the same PR rather than waiting for automation.
+
+### 4.3 Resolve the track's current version + digest
+
+Take the digest from **Docker Hub**, not `mirror.gcr.io` (the mirror lags):
+
+```bash
+curl -s https://hub.docker.com/v2/repositories/dotcms/dotcms/tags/latest \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["digest"])'
+```
+
+Then find the version tag sharing that digest (the pin keeps the version human-readable):
+
+```bash
+docker buildx imagetools inspect dotcms/dotcms:latest        # or match the digest in Hub's tag list
+```
+
+Snapshot for orientation — **re-resolve, never copy these** (2026-07-28):
+
+| Track | Version | Digest |
+|---|---|---|
+| `latest` | 26.07.27-01 | `sha256:52bbae5e0c99bc82a6ee4a04e0bd3c98fd86367b181db0ef17531be7d37d00ce` |
+| `standard` | 26.07.06-3 | `sha256:962acedc475b589d6bf816230fd52c3072e815939e041fa2e917b65bc1e7ed99` |
+| `trailing` | 26.06.22-03 | `sha256:d28362adad00db09faf941f5c0de39a7b1ba6f6dca5d1903442a1ffb1fe7e2e6` |
+
+Note that the same version can exist as several rebuild digests (e.g. `26.07.27-01` and
+`26.07.27-01_66cdc38`). Always pin the digest the *track tag* currently resolves to.
+
+### 4.4 Ship it
+
+1. PR against `master` touching **only** that environment's `statefulset.yaml` (one env per PR
+   keeps the audit trail clean and the revert trivial). Reference the support ticket in the body.
+2. `master` requires **1 CODEOWNER approval** — `CODEOWNERS` is `* @dotcms/platform-engineers
+   @dotcms/CloudEng-Support` — plus the manifest/label checks. Merge.
+3. Argo CD picks it up on its **poll** (no webhook) — allow a few minutes.
+4. **Update the CX sheet** (*Evergreen Tracks* tab). Sheet ← git sync is not automated, so skipping
+   this leaves CX reading stale data.
+
+Never `kubectl set image` a live environment. Argo runs `automated: {}` **without `selfHeal`**, so
+a hand patch is not reverted and silently diverges from git.
+
+---
+
+## 5. Verify
+
+1. **Label as committed:**
+   ```bash
+   grep -H -e evergreen-track -e maintenance-pause \
+     kubernetes/customers/<tenant>/<env>/statefulset.yaml
+   ```
+2. **Argo CD:** the Application is named for the **customer**, not the env (`recurse: true` covers
+   all their envs). Expect **Synced / Healthy**.
+3. **What is actually running** — `imageID` is the truth; the `ver` and
+   `dotcms.cloud/dotcms-version` labels in manifests are stale decoration:
+   ```bash
+   kubectl -n <tenant> get pods -l fullname=dotcms-<tenant>-<env> \
+     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].imageID}{"\n"}{end}'
+   ```
+4. **Environment healthy:** for a faster move (pods rolled), confirm the env is serving before
+   replying — all pods Ready, no crash-looping, site responding.
+5. **Reply to the customer** with: which env, new track, whether a version change happened now
+   (and to what version), and when their next update will land (step 6.2).
+
+A slower move is verified by the label alone — pods do **not** restart, so there is nothing new
+running to check.
+
+---
+
+## 6. Customer answers (copy-paste)
+
+### 6.1 "Does moving to a slower track roll us back?"
+
+> No. Tracks are forward-only. Your environment keeps running its current version; it just stops
+> advancing until that version ages into the new track's window, and updates resume from there.
+
+### 6.2 "When will our next update apply?"
+
+| Track | Answer |
+|---|---|
+| `latest` | On the next GA release. |
+| `standard` | At our next scheduled maintenance window, landing on the newest GA release older than ~14 days. |
+| `trailing` | At our next scheduled maintenance window, landing on the newest GA release older than ~28 days. |
+
+Do **not** promise a specific date or a fixed day-of-week. `standard` and `trailing` advance only
+when an operator dispatches the promote action at a maintenance window — that human step *is* the
+cadence gate. If the customer needs a date, ask platform for the next window rather than guessing.
+
+### 6.3 "Can we go back to version X?"
+
+Not via tracks — that is a rollback. Escalate (step 7). Nothing in this runbook moves a customer
+backward.
+
+### 6.4 "Can we pause updates for a while?"
+
+Yes — that is a maintenance pause, not a track change. It keeps the track label but stops rolls.
+Escalate to platform with the reason and the expected duration, and record it on the *Maintenance
+Pause List* tab.
+
+### 6.5 "We heard release X has a problem — will we get it?"
+
+If a release is flagged with a known issue, we taint it and no track advances onto it. If the
+customer is *already* on a flagged release, that is an incident, not a track question → escalate
+immediately (step 7).
+
+### 6.6 "Can we have a custom schedule / skip a release / pick our own age threshold?"
+
+Not supported. Three tracks, defined by version age. Anything else is a product request →
+escalate, don't promise.
+
+---
+
+## 7. Escalation
+
+**Path:** CX / support → **platform / Enablement**. Slack `#team-cloud-engineering`
+(`#support` for the customer-facing thread), GitHub teams `@dotcms/platform-engineers` /
+`@dotcms/CloudEng-Support`. Always link the support ticket.
+
+| Situation | Where it goes |
+|---|---|
+| Routine track change (validated per step 3) | Platform — manifest PR (step 4) |
+| Env fails an eligibility gate (single replica, no Redis sessions) | Platform — needs an env change first, not just a label |
+| Environment is maintenance-paused | Account's CX owner + platform, before anything is changed |
+| Customer wants an older version (rollback) | Platform — **incident/change path**, not a track change |
+| Customer is on a release with a known issue | Platform, **immediately** — taint / track hold, see [RUNBOOK.md](RUNBOOK.md) |
+| Need to freeze a whole track, or pull a track off a bad release | Platform only — [RUNBOOK.md](RUNBOOK.md) procedures 1 and 2 |
+| Customer wants a custom cadence / self-service today | Product — self-service is Workstream B, not yet available |
+| Suspected regression after an update | Normal bug/incident path, and tell platform which env and which digest it is running |
+
+---
+
+## 8. Known interim limitations
+
+Be honest about these on tickets; they are the reason this runbook says "interim".
+
+- **No self-service.** Every track change is a manifest PR by platform. Self-service selection is
+  on the roadmap (Workstream B).
+- **No automatic version advance yet.** The reconciler is deployed but dry-run everywhere, so
+  `standard`/`trailing` envs move only when a human ships the pin. Never tell a customer their
+  environment will update itself on a specific date.
+- **Sheet ↔ git drift.** The CX sheet is updated by hand. Verify against git before answering
+  "what track am I on".
+- **Track ≠ running version.** The label says what an env *should* follow; `imageID` says what it
+  runs. They can differ (a paused env, a skipped gate, a pin nobody advanced).
+
+---
+
+## 9. Quick reference
+
+| I need to… | Do this |
+|---|---|
+| Tell a customer what track they're on | `grep -r evergreen-track kubernetes/customers/<tenant>/` — git, not the sheet |
+| Move an env to a faster track | Hand to platform: label + image-pin bump, one PR |
+| Move an env to a slower track | Hand to platform: label only, no image change, no restart |
+| Answer "when's our next update" | Step 6.2 — no specific dates |
+| Handle "put us back on the old version" | Rollback → escalate |
+| Handle "pause our updates" | Maintenance pause → escalate; record on the sheet |
+| Handle "release X is broken" | Escalate immediately → operator [RUNBOOK.md](RUNBOOK.md) |
+
+Briefing material for the CX walkthrough of this runbook: [CX-BRIEFING.md](CX-BRIEFING.md).


### PR DESCRIPTION
## What

The **support/CX half** of the interim track-change documentation, so a CX agent can action a customer track-change request end to end without asking engineering what the words mean.

- **`SUPPORT-RUNBOOK.md`** — intake → validate → apply → verify → escalate:
  - **Intake:** ticket template (tenant, env, current/requested track, requester authority, urgency); informal asks still become tickets.
  - **Validate:** env slug → real path `kubernetes/customers/<tenant>/<env>/statefulset.yaml`; only three tracks; requester authority; the eligibility gates (`replicas >= 2`, Redis sessions, not maintenance-paused); don't un-pause a paused env as a side effect.
  - **Apply:** the `dotcms.cloud/evergreen-track` label on the StatefulSet's own `metadata.labels`, with the faster/slower asymmetry spelled out — a **faster** move must bump the pinned `image:` digest in the same PR (that's what makes the public doc's "takes effect as soon as our support team makes the change" true), a **slower** move is label-only, no restart, no rollback. Includes the Docker-Hub digest resolution command and the `CODEOWNERS` / Argo-poll merge path.
  - **Verify:** committed label, Argo Application (named per **customer**, not env) Synced/Healthy, `imageID` as ground truth, env serving.
  - **Customer answers:** copy-paste wording for "does slower roll us back", "when's our next update", "put us back on version X" (= rollback, escalate), pause requests, flagged releases, custom cadences.
  - **Escalation table:** CX → platform/Enablement (`#team-cloud-engineering`, `@dotcms/platform-engineers` / `@dotcms/CloudEng-Support`); incident-shaped cases hand off to the operator runbook.
- **`CX-BRIEFING.md`** — agenda for the live session with Dean Gonzalez / CX: the model in plain English, who owns what, the flow walked against a real env, the three answers CX needs most, escalation + the CX sheet, Q&A capture (logged on #36522) and exit criteria.
- **`README.md`** — links both.

## Scope split

- **#36769 / PR #36770** = the **in-repo operator** runbook: taint a release, hold a track, hold a single environment. This PR **cross-links it rather than duplicating it** — every incident-shaped case here escalates into it. Both files live in the same directory; the README hunks don't overlap.
  - **Merge ordering:** this PR links `RUNBOOK.md`, which only exists on #36770's branch. It is not a merge gate — the runbook's first reference says the operator runbook lands with #36770 and tells the reader to escalate to platform meanwhile — but merging #36770 first (or soon after) is preferable so the links resolve.
- **This PR / #36522** = the **support-facing** runbook + the CX briefing. Still open on #36522 after this merges: publishing to the internal KB, running the briefing, and actioning one real request.

## Published for CX in Drive

Support agents don't read the repo, so the CX-facing copies are Google Docs in the **Engineering** shared drive → `dotEvergreen` (already editable by `all@dotcms.com`, so no extra sharing was needed):

- [Evergreen Tracks — Support Runbook (interim)](https://docs.google.com/document/d/1tLEzbZOC5D5cXDq0S_bHtsKqd0-13hSUAcXfPeLlblI/edit)
- [Evergreen Tracks — CX / Support Briefing Outline](https://docs.google.com/document/d/1DyjRKAB_aiwnRShLuQLYx-PbnyiH5Ft5XeCgPNDc1YY/edit)

These markdown files stay canonical. Each Doc opens with a banner pointing back at the repo path, and the README documents the re-publish step (render to HTML, push over the same Drive file ID so the links never change).

Part of #36522

## Verification

Nothing here was written from memory — the operational claims were checked against live state on 2026-07-28:

- Real example env: `kubernetes/customers/bcbs/dev-2310/statefulset.yaml` carries `dotcms.cloud/evergreen-track: latest` and a digest-pinned `mirror.gcr.io/dotcms/dotcms:26.07.27-01@sha256:d0e1515…` — confirming manifests pin immutable digests, never floating tags.
- Fleet distribution on `dotCMS/infrastructure-as-code` `master`: 180 `standard`; 9 `trailing` **environments** across 4 tenants (greensky ×4, lennox ×2, lennox-dr ×1, suny ×2); 1 `latest` (bcbs/dev-2310).
- Track pointers resolved from Docker Hub: `latest` = 26.07.27-01, `standard` = 26.07.06-3, `trailing` = 26.06.22-03 (documented as a re-resolve-don't-copy snapshot).
- Merge path: IaC `CODEOWNERS` is `* @dotcms/platform-engineers @dotcms/CloudEng-Support`.
- Gates and paused tenants read from the reconciler's own README/spec (`replicas >= 2`, `TOMCAT_REDIS_SESSION_ENABLED`, `maintenance-pause`; Duncan Aviation / Jostens / firstmac).
- **Interim caveat that shapes the apply step:** the floating-tag reconciler is deployed per cluster but `PUSH_ENABLED=false` in every cluster CronJob, so no env advances on its own today — every version change is a human PR. The runbook says so and tells support not to promise dates.
- Customer-facing wording aligned to the published page dev.dotcms.com/docs/evergreen-tracks (fetched, HTTP 200).

## Review findings addressed (commit 0ec73bf)

1. **HIGH — dead links to `RUNBOOK.md`.** Kept the links (they resolve once #36770 merges) and added an inline note at the first reference naming the PR and telling the reader to escalate to platform meanwhile. Merge ordering noted above.
2. **MED — §6.2 `latest` over-promised.** Now "on the next GA release — once platform ships the pin bump for it", with the surrounding guidance extended to *all* tracks and §8 corrected to say every env including `latest`.
3. **MED — "9 `trailing` (4 names)".** The names were tenants, not envs. Re-verified against IaC `master`: 9 environments across 4 tenants (greensky ×4, lennox ×2, lennox-dr ×1, suny ×2). Fixed in the runbook and above, with a pointer to re-count via the step 3.1 grep.
4. **MED — same version, two digests across §4.2/§4.3.** Both places now say why (`26.07.27-01` gets rebuilt, so one version has several digests) and give the rule: compare *versions* first; a digest difference alone is not drift to escalate.

The published Google Doc was re-rendered from the fixed markdown over the same Drive file ID, so the Doc and this PR match and the shared link is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCJs9UXf1FWqYTsjkwc9n2
