### PR TITLE
Add line divider component and integrate into edit content field

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
@@ -5,8 +5,11 @@
 
 @switch (field.fieldType) {
     @case (fieldTypes.LINE_DIVIDER) {
-        <h3 class="m-0 text-gray-700">{{ field.name }}</h3>
-        <p-divider />
+        @defer (on immediate) {
+            <dot-edit-content-line-divider-field
+                [field]="field"
+                [attr.data-testId]="'field-' + field.variable" />
+        }
     }
     @case (fieldTypes.SELECT) {
         @defer (on immediate) {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -47,6 +47,7 @@ import { DotFileFieldUploadService } from '../../fields/dot-edit-content-file-fi
 import { DotEditContentHostFolderFieldComponent } from '../../fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component';
 import { DotEditContentJsonFieldComponent } from '../../fields/dot-edit-content-json-field/dot-edit-content-json-field.component';
 import { DotEditContentKeyValueComponent } from '../../fields/dot-edit-content-key-value/dot-edit-content-key-value.component';
+import { DotEditContentLineDividerFieldComponent } from '../../fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component';
 import { DotEditContentMultiSelectFieldComponent } from '../../fields/dot-edit-content-multi-select-field/dot-edit-content-multi-select-field.component';
 import { DotEditContentRadioFieldComponent } from '../../fields/dot-edit-content-radio-field/dot-edit-content-radio-field.component';
 import { DotEditContentRelationshipFieldComponent } from '../../fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component';
@@ -65,6 +66,7 @@ import {
     createFormGroupDirectiveMock,
     DOT_MESSAGE_SERVICE_MOCK,
     FIELDS_MOCK,
+    LINE_DIVIDER_MOCK,
     TREE_SELECT_MOCK
 } from '../../utils/mocks';
 
@@ -269,7 +271,7 @@ const FIELD_TYPES_COMPONENTS: Record<FIELD_TYPES, Type<unknown> | DotEditFieldTe
         component: null // this field is not being rendered for now.
     },
     [FIELD_TYPES.LINE_DIVIDER]: {
-        component: null
+        component: DotEditContentLineDividerFieldComponent
     }
 };
 
@@ -403,6 +405,55 @@ describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields
             expect(component).toBeTruthy();
             expect(component instanceof FIELD_TYPE).toBeTruthy();
         });
+    });
+});
+
+describe('DotEditContentFieldComponent - Line Divider Field', () => {
+    let spectator: Spectator<DotEditContentFieldComponent>;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentFieldComponent,
+        imports: [DotEditContentFieldComponent],
+        providers: [
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            mockProvider(GlobalStore, {
+                systemConfig: signal({
+                    systemTimezone: {
+                        id: 'UTC',
+                        label: 'Coordinated Universal Time',
+                        offset: 0
+                    }
+                })
+            }),
+            mockProvider(DotHttpErrorManagerService),
+            {
+                provide: ControlContainer,
+                useValue: createFormGroupDirectiveMock()
+            }
+        ]
+    });
+
+    beforeEach(() => {
+        spectator = createComponent({
+            props: {
+                field: LINE_DIVIDER_MOCK
+            }
+        });
+    });
+
+    it('should render the line divider field component', () => {
+        spectator.detectChanges();
+
+        const lineDividerField = spectator.query(DotEditContentLineDividerFieldComponent);
+        expect(lineDividerField).toBeTruthy();
+    });
+
+    it('should render the line divider title with the field name', () => {
+        spectator.detectChanges();
+
+        const title = spectator.query(byTestId('line-divider-title'));
+        expect(title?.textContent?.trim()).toBe(LINE_DIVIDER_MOCK.name);
     });
 });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
@@ -9,8 +9,6 @@ import {
 } from '@angular/core';
 import { ControlContainer, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
-import { DividerModule } from 'primeng/divider';
-
 import {
     DotCMSBaseTypesContentTypes,
     DotCMSContentlet,
@@ -29,6 +27,7 @@ import { DotEditContentFileFieldComponent } from '../../fields/dot-edit-content-
 import { DotEditContentHostFolderFieldComponent } from '../../fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component';
 import { DotEditContentJsonFieldComponent } from '../../fields/dot-edit-content-json-field/dot-edit-content-json-field.component';
 import { DotEditContentKeyValueComponent } from '../../fields/dot-edit-content-key-value/dot-edit-content-key-value.component';
+import { DotEditContentLineDividerFieldComponent } from '../../fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component';
 import { DotEditContentMultiSelectFieldComponent } from '../../fields/dot-edit-content-multi-select-field/dot-edit-content-multi-select-field.component';
 import { DotEditContentRadioFieldComponent } from '../../fields/dot-edit-content-radio-field/dot-edit-content-radio-field.component';
 import { DotEditContentRelationshipFieldComponent } from '../../fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component';
@@ -70,7 +69,7 @@ import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
         DotEditContentWYSIWYGFieldComponent,
         DotEditContentFileFieldComponent,
         DotEditContentRelationshipFieldComponent,
-        DividerModule
+        DotEditContentLineDividerFieldComponent
     ]
 })
 export class DotEditContentFieldComponent {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
@@ -66,7 +66,6 @@ import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
         DotEditContentCategoryFieldComponent,
         DotEditContentBlockEditorComponent,
         DotEditContentKeyValueComponent,
-        DotEditContentWYSIWYGFieldComponent,
         DotEditContentFileFieldComponent,
         DotEditContentRelationshipFieldComponent,
         DotEditContentLineDividerFieldComponent

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.html
@@ -1,0 +1,9 @@
+@let field = $field();
+
+@if (field.name) {
+    <div class="w-full bg-surface-100 p-3" data-testid="line-divider">
+        <h3 class="m-0 font-semibold text-gray-700" data-testid="line-divider-title">
+            {{ field.name }}
+        </h3>
+    </div>
+}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.spec.ts
@@ -1,0 +1,52 @@
+import { byTestId, createComponentFactory, Spectator } from '@openng/spectator/jest';
+
+import { createFakeLineDividerField } from '@dotcms/utils-testing';
+
+import { DotEditContentLineDividerFieldComponent } from './dot-edit-content-line-divider-field.component';
+
+describe('DotEditContentLineDividerFieldComponent', () => {
+    let spectator: Spectator<DotEditContentLineDividerFieldComponent>;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentLineDividerFieldComponent,
+        detectChanges: false
+    });
+
+    it('should render the line divider bar with the field name', () => {
+        const field = createFakeLineDividerField({
+            name: 'Open Graph (OG Meta Tags)',
+            variable: 'openGraph'
+        });
+
+        spectator = createComponent({
+            props: {
+                field
+            }
+        });
+        spectator.detectChanges();
+
+        const divider = spectator.query(byTestId('line-divider'));
+        const title = spectator.query(byTestId('line-divider-title'));
+
+        expect(divider).toBeTruthy();
+        expect(divider).toHaveClass('bg-surface-50', 'border-surface-200');
+        expect(title?.textContent?.trim()).toBe(field.name);
+    });
+
+    it('should not render the line divider bar when the field name is empty', () => {
+        const field = createFakeLineDividerField({
+            name: '',
+            variable: 'openGraph'
+        });
+
+        spectator = createComponent({
+            props: {
+                field
+            }
+        });
+        spectator.detectChanges();
+
+        expect(spectator.query(byTestId('line-divider'))).toBeNull();
+        expect(spectator.query(byTestId('line-divider-title'))).toBeNull();
+    });
+});

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.spec.ts
@@ -29,7 +29,7 @@ describe('DotEditContentLineDividerFieldComponent', () => {
         const title = spectator.query(byTestId('line-divider-title'));
 
         expect(divider).toBeTruthy();
-        expect(divider).toHaveClass('bg-surface-50', 'border-surface-200');
+        expect(divider).toHaveClass('bg-surface-100');
         expect(title?.textContent?.trim()).toBe(field.name);
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-line-divider-field/dot-edit-content-line-divider-field.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
+
+@Component({
+    selector: 'dot-edit-content-line-divider-field',
+    templateUrl: './dot-edit-content-line-divider-field.component.html',
+    styleUrls: ['./dot-edit-content-line-divider-field.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        class: 'dot-edit-content-line-divider-field block'
+    }
+})
+export class DotEditContentLineDividerFieldComponent {
+    /**
+     * The line divider field metadata used to render the section title.
+     */
+    $field = input.required<DotCMSContentTypeField>({ alias: 'field' });
+}


### PR DESCRIPTION
This pull request adds a new `DotEditContentLineDividerFieldComponent` to handle rendering of line divider fields in the edit content UI, replacing the previous inline template logic. It updates the main field rendering component to use this new component, adds comprehensive tests, and removes the dependency on the third-party divider module.

**Component integration and rendering:**

* Replaces the inline rendering of line divider fields in `dot-edit-content-field.component.html` with the new `DotEditContentLineDividerFieldComponent`, using Angular's `@defer` for improved performance.
* Registers `DotEditContentLineDividerFieldComponent` in the main component's module and removes the unused `DividerModule` import. [[1]](diffhunk://#diff-f03434ad88316542a23c3fb0bf50b6650130632c3e7953d7ee3c882cb5950d06R30) [[2]](diffhunk://#diff-f03434ad88316542a23c3fb0bf50b6650130632c3e7953d7ee3c882cb5950d06L73-R72)

**Testing improvements:**

* Adds a dedicated spec file for `DotEditContentLineDividerFieldComponent` with tests for rendering and conditional display based on the field name.
* Updates the main field component's test suite to include tests for the line divider field, ensuring the new component is rendered and displays the correct title. [[1]](diffhunk://#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fR50) [[2]](diffhunk://#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fR69) [[3]](diffhunk://#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fL272-R274) [[4]](diffhunk://#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fR411-R459)

**New component implementation:**

* Implements `DotEditContentLineDividerFieldComponent` with a simple template that displays a section title if the field has a name, using `@angular/core`'s new `input` API. [[1]](diffhunk://#diff-8522fd43afb8b8ae8c61f52881b6766826547a3a05dcf0f9049f09c0029d5360R1-R9) [[2]](diffhunk://#diff-74223e58ac38830c7dd2073fd8379b9a7f8308fe9713c4ae3ded40a5d8a8234eR1-R19)

This PR fixes: #36614

This PR fixes: #36614