### PR TITLE
Enhance overlay alignment and search input controls in host folder field

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.spec.ts
@@ -1,6 +1,11 @@
 import { alignOverlayLeftToTrigger } from './host-folder-field-overlay.utils';
 
 describe('alignOverlayLeftToTrigger', () => {
+    afterEach(() => {
+        Object.defineProperty(window, 'scrollX', { value: 0, configurable: true });
+        Object.defineProperty(window, 'innerWidth', { value: 1024, configurable: true });
+    });
+
     it('should align the overlay left edge to the trigger left edge', () => {
         const trigger = document.createElement('button');
         const container = document.createElement('div');
@@ -44,5 +49,75 @@ describe('alignOverlayLeftToTrigger', () => {
         alignOverlayLeftToTrigger(trigger, container);
 
         expect(container.style.left).toBe('384px');
+    });
+
+    it('should include horizontal scroll offset in document coordinates', () => {
+        const trigger = document.createElement('button');
+        const container = document.createElement('div');
+
+        Object.defineProperty(window, 'scrollX', { value: 200, configurable: true });
+        jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+            left: 120,
+            top: 0,
+            right: 420,
+            bottom: 40,
+            width: 300,
+            height: 40,
+            x: 120,
+            y: 0,
+            toJSON: () => ({})
+        });
+        Object.defineProperty(container, 'offsetWidth', { value: 640 });
+
+        alignOverlayLeftToTrigger(trigger, container);
+
+        expect(container.style.left).toBe('320px');
+    });
+
+    it('should clamp using viewport coordinates when horizontally scrolled', () => {
+        const trigger = document.createElement('button');
+        const container = document.createElement('div');
+
+        Object.defineProperty(window, 'scrollX', { value: 200, configurable: true });
+        Object.defineProperty(window, 'innerWidth', { value: 1024, configurable: true });
+        jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+            left: 900,
+            top: 0,
+            right: 1200,
+            bottom: 40,
+            width: 300,
+            height: 40,
+            x: 900,
+            y: 0,
+            toJSON: () => ({})
+        });
+        Object.defineProperty(container, 'offsetWidth', { value: 640 });
+
+        alignOverlayLeftToTrigger(trigger, container);
+
+        expect(container.style.left).toBe('584px');
+    });
+
+    it('should clamp left when the trigger is partially off-screen to the left', () => {
+        const trigger = document.createElement('button');
+        const container = document.createElement('div');
+
+        Object.defineProperty(window, 'scrollX', { value: 100, configurable: true });
+        jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+            left: -30,
+            top: 0,
+            right: 270,
+            bottom: 40,
+            width: 300,
+            height: 40,
+            x: -30,
+            y: 0,
+            toJSON: () => ({})
+        });
+        Object.defineProperty(container, 'offsetWidth', { value: 640 });
+
+        alignOverlayLeftToTrigger(trigger, container);
+
+        expect(container.style.left).toBe('100px');
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.spec.ts
@@ -1,0 +1,48 @@
+import { alignOverlayLeftToTrigger } from './host-folder-field-overlay.utils';
+
+describe('alignOverlayLeftToTrigger', () => {
+    it('should align the overlay left edge to the trigger left edge', () => {
+        const trigger = document.createElement('button');
+        const container = document.createElement('div');
+
+        jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+            left: 120,
+            top: 0,
+            right: 420,
+            bottom: 40,
+            width: 300,
+            height: 40,
+            x: 120,
+            y: 0,
+            toJSON: () => ({})
+        });
+        Object.defineProperty(container, 'offsetWidth', { value: 640 });
+
+        alignOverlayLeftToTrigger(trigger, container);
+
+        expect(container.style.left).toBe('120px');
+    });
+
+    it('should clamp the overlay when it would overflow the viewport', () => {
+        const trigger = document.createElement('button');
+        const container = document.createElement('div');
+
+        jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+            left: 900,
+            top: 0,
+            right: 1200,
+            bottom: 40,
+            width: 300,
+            height: 40,
+            x: 900,
+            y: 0,
+            toJSON: () => ({})
+        });
+        Object.defineProperty(container, 'offsetWidth', { value: 640 });
+        Object.defineProperty(window, 'innerWidth', { value: 1024, configurable: true });
+
+        alignOverlayLeftToTrigger(trigger, container);
+
+        expect(container.style.left).toBe('384px');
+    });
+});

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.ts
@@ -1,16 +1,17 @@
 /**
  * Left-aligns a popover overlay to the trigger's left edge, clamping to the viewport when
  * the overlay is wider than the trigger (e.g. minWidth exceeds trigger width).
+ *
+ * Coordinates match PrimeNG's body-appended overlays: viewport rects plus horizontal scroll.
  */
 export function alignOverlayLeftToTrigger(trigger: HTMLElement, container: HTMLElement): void {
     const triggerRect = trigger.getBoundingClientRect();
     const containerWidth = container.offsetWidth;
     const viewportWidth = window.innerWidth;
-    let left = triggerRect.left;
-
-    if (left + containerWidth > viewportWidth) {
-        left = Math.max(0, viewportWidth - containerWidth);
-    }
+    const scrollX = window.scrollX;
+    const minLeft = scrollX;
+    const maxLeft = scrollX + Math.max(0, viewportWidth - containerWidth);
+    const left = Math.min(Math.max(triggerRect.left + scrollX, minLeft), maxLeft);
 
     container.style.left = `${left}px`;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field-overlay.utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Left-aligns a popover overlay to the trigger's left edge, clamping to the viewport when
+ * the overlay is wider than the trigger (e.g. minWidth exceeds trigger width).
+ */
+export function alignOverlayLeftToTrigger(trigger: HTMLElement, container: HTMLElement): void {
+    const triggerRect = trigger.getBoundingClientRect();
+    const containerWidth = container.offsetWidth;
+    const viewportWidth = window.innerWidth;
+    let left = triggerRect.left;
+
+    if (left + containerWidth > viewportWidth) {
+        left = Math.max(0, viewportWidth - containerWidth);
+    }
+
+    container.style.left = `${left}px`;
+}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.html
@@ -66,6 +66,7 @@
     (onHide)="store.closeOverlay()"
     (onShow)="onOverlayShow()"
     [dismissable]="true"
+    [focusOnShow]="false"
     [style]="{ width: $overlayWidth(), minWidth: '40rem' }"
     appendTo="body"
     [pt]="popoverPt"
@@ -81,6 +82,7 @@
                     <p-iconField class="mb-3 w-full shrink-0">
                         <p-inputIcon class="pi pi-search text-sm text-surface-500" />
                         <input
+                            #sitesSearchInput
                             pInputText
                             size="large"
                             type="text"
@@ -91,6 +93,16 @@
                                 'dot.file.field.host.folder.sites.search.placeholder' | dm
                             "
                             (input)="onSiteSearchInput($event)" />
+                        @if (store.sitesSearchLoading()) {
+                            <p-inputIcon
+                                class="pi pi-spinner pi-spin text-sm text-surface-500"
+                                data-testid="host-folder-sites-search-loading" />
+                        } @else if (store.siteSearchTerm()) {
+                            <p-inputIcon
+                                class="pi pi-times cursor-pointer text-xs text-surface-500 hover:text-surface-800"
+                                data-testid="host-folder-sites-search-clear"
+                                (click)="clearSitesSearch()" />
+                        }
                     </p-iconField>
                 } @else {
                     <span class="block shrink-0 pb-3 text-xs font-semibold text-gray-600 uppercase">
@@ -174,6 +186,7 @@
                     <p-iconField class="w-full shrink-0">
                         <p-inputIcon class="pi pi-search text-sm text-surface-500" />
                         <input
+                            #folderSearchInput
                             pInputText
                             size="large"
                             type="text"
@@ -182,6 +195,16 @@
                             [value]="store.searchTerm()"
                             [placeholder]="'dot.file.field.host.folder.search.placeholder' | dm"
                             (input)="onSearchInput($event)" />
+                        @if (store.searchLoading()) {
+                            <p-inputIcon
+                                class="pi pi-spinner pi-spin text-sm text-surface-500"
+                                data-testid="host-folder-search-loading" />
+                        } @else if (store.searchTerm()) {
+                            <p-inputIcon
+                                class="pi pi-times cursor-pointer text-xs text-surface-500 hover:text-surface-800"
+                                data-testid="host-folder-search-clear"
+                                (click)="clearFolderSearch()" />
+                        }
                     </p-iconField>
                 }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.html
@@ -99,9 +99,12 @@
                                 data-testid="host-folder-sites-search-loading" />
                         } @else if (store.siteSearchTerm()) {
                             <p-inputIcon
-                                class="pi pi-times cursor-pointer text-xs text-surface-500 hover:text-surface-800"
+                                class="cursor-pointer text-xs text-surface-500 hover:text-surface-800"
+                                [attr.aria-label]="'edit.content.sidebar.activities.clear' | dm"
                                 data-testid="host-folder-sites-search-clear"
-                                (click)="clearSitesSearch()" />
+                                (click)="clearSitesSearch()">
+                                <i class="pi pi-times"></i>
+                            </p-inputIcon>
                         }
                     </p-iconField>
                 } @else {
@@ -202,9 +205,12 @@
                                 data-testid="host-folder-search-loading" />
                         } @else if (store.searchTerm()) {
                             <p-inputIcon
-                                class="pi pi-times cursor-pointer text-xs text-surface-500 hover:text-surface-800"
+                                class="cursor-pointer text-xs text-surface-500 hover:text-surface-800"
+                                [attr.aria-label]="'edit.content.sidebar.activities.clear' | dm"
                                 data-testid="host-folder-search-clear"
-                                (click)="clearFolderSearch()" />
+                                (click)="clearFolderSearch()">
+                                <i class="pi pi-times"></i>
+                            </p-inputIcon>
                         }
                     </p-iconField>
                 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.html
@@ -156,7 +156,8 @@
                                     [class.hover:bg-gray-100]="!isSelectedSite"
                                     [pTooltip]="site.label"
                                     [tooltipDisabled]="site.label.length <= 10"
-                                    tooltipPosition="top"
+                                    tooltipPosition="right"
+                                    [pTooltipPT]="siteTooltipPt"
                                     [showDelay]="800"
                                     data-testid="host-folder-site-item"
                                     (click)="onSiteSelect(site)">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.spec.ts
@@ -605,6 +605,37 @@ describe('DotHostFolderFieldComponent', () => {
             expect(store.openOverlay).toHaveBeenCalled();
         });
 
+        it('should left-align the popover to the trigger after show', async () => {
+            const trigger = document.createElement('button');
+            Object.defineProperty(trigger, 'offsetWidth', { value: 300 });
+            jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+                left: 80,
+                top: 0,
+                right: 380,
+                bottom: 40,
+                width: 300,
+                height: 40,
+                x: 80,
+                y: 0,
+                toJSON: () => ({})
+            });
+
+            const container = document.createElement('div');
+            container.classList.add('p-popover');
+            Object.defineProperty(container, 'offsetWidth', { value: 640 });
+            document.body.appendChild(container);
+
+            const event = new Event('click');
+            Object.defineProperty(event, 'currentTarget', { value: trigger });
+            spectator.component.toggleOverlay(event);
+            spectator.component.onOverlayShow();
+            spectator.detectChanges();
+            await spectator.fixture.whenStable();
+
+            expect(container.style.left).toBe('80px');
+            document.body.removeChild(container);
+        });
+
         it('should schedule a scroll to the selected folder once the overlay renders', async () => {
             const node = TREE_SELECT_MOCK[0].children[0];
             store.setPendingNode(node);
@@ -825,6 +856,117 @@ describe('DotHostFolderFieldComponent', () => {
             expect(queryInOverlay('host-folder-folders-loading')).toHaveText('Loading folders...');
             expect(queryInOverlay('host-folder-search-input')).toBeNull();
         }));
+
+        it('should keep the folders search input visible while search is loading', fakeAsync(() => {
+            const queryInOverlay = (testId: string): Element | null =>
+                spectator.query(byTestId(testId)) ??
+                document.querySelector(`[data-testid="${testId}"]`);
+
+            jest.spyOn(store, 'sitesLoading').mockReturnValue(false);
+            jest.spyOn(store, 'showFoldersPanelLoading').mockReturnValue(true);
+            jest.spyOn(store, 'showFolderSearch').mockReturnValue(true);
+            jest.spyOn(store, 'searchLoading').mockReturnValue(true);
+            jest.spyOn(store, 'searchTerm').mockReturnValue('ab');
+            jest.spyOn(store, 'displayedFolders').mockReturnValue([]);
+            spectator.detectChanges();
+
+            const popoverDe = spectator.fixture.debugElement.query(By.directive(Popover));
+            const popover = popoverDe.componentInstance as Popover;
+            const trigger = document.createElement('button');
+            const event = new Event('click');
+            Object.defineProperty(event, 'currentTarget', { value: trigger });
+            popover.show(event, trigger);
+            spectator.detectChanges();
+
+            expect(queryInOverlay('host-folder-search-input')).toBeTruthy();
+            expect(queryInOverlay('host-folder-search-loading')).toBeTruthy();
+            expect(queryInOverlay('host-folder-search-clear')).toBeNull();
+        }));
+    });
+
+    describe('search clear controls', () => {
+        const openOverlay = () => {
+            const popoverDe = spectator.fixture.debugElement.query(By.directive(Popover));
+            const popover = popoverDe.componentInstance as Popover;
+            const trigger = document.createElement('button');
+            const event = new Event('click');
+            Object.defineProperty(event, 'currentTarget', { value: trigger });
+            popover.show(event, trigger);
+            spectator.detectChanges();
+        };
+
+        const queryInOverlay = (testId: string): Element | null =>
+            spectator.query(byTestId(testId)) ??
+            document.querySelector(`[data-testid="${testId}"]`);
+
+        it('should show the sites search clear control when the term is not empty and not loading', () => {
+            jest.spyOn(store, 'showSitesSearch').mockReturnValue(true);
+            jest.spyOn(store, 'siteSearchTerm').mockReturnValue('demo');
+            jest.spyOn(store, 'sitesSearchLoading').mockReturnValue(false);
+            spectator.detectChanges();
+            openOverlay();
+
+            expect(queryInOverlay('host-folder-sites-search-clear')).toBeTruthy();
+            expect(queryInOverlay('host-folder-sites-search-loading')).toBeNull();
+        });
+
+        it('should show the sites search loading spinner instead of the clear control', () => {
+            jest.spyOn(store, 'showSitesSearch').mockReturnValue(true);
+            jest.spyOn(store, 'siteSearchTerm').mockReturnValue('demo');
+            jest.spyOn(store, 'sitesSearchLoading').mockReturnValue(true);
+            spectator.detectChanges();
+            openOverlay();
+
+            expect(queryInOverlay('host-folder-sites-search-loading')).toBeTruthy();
+            expect(queryInOverlay('host-folder-sites-search-clear')).toBeNull();
+        });
+
+        it('should clear the sites search and restore focus', async () => {
+            jest.spyOn(store, 'showSitesSearch').mockReturnValue(true);
+            jest.spyOn(store, 'siteSearchTerm').mockReturnValue('demo');
+            jest.spyOn(store, 'sitesSearchLoading').mockReturnValue(false);
+            jest.spyOn(store, 'filterSites');
+            spectator.detectChanges();
+            openOverlay();
+
+            const input = queryInOverlay('host-folder-sites-search-input') as HTMLInputElement;
+            input.focus();
+            spectator.click(byTestId('host-folder-sites-search-clear'));
+            spectator.detectChanges();
+            await spectator.fixture.whenStable();
+
+            expect(store.filterSites).toHaveBeenCalledWith('');
+            expect(document.activeElement).toBe(input);
+        });
+
+        it('should show the folders search clear control when the term is not empty and not loading', () => {
+            jest.spyOn(store, 'showFolderSearch').mockReturnValue(true);
+            jest.spyOn(store, 'searchTerm').mockReturnValue('ab');
+            jest.spyOn(store, 'searchLoading').mockReturnValue(false);
+            spectator.detectChanges();
+            openOverlay();
+
+            expect(queryInOverlay('host-folder-search-clear')).toBeTruthy();
+            expect(queryInOverlay('host-folder-search-loading')).toBeNull();
+        });
+
+        it('should clear the folders search and restore focus', async () => {
+            jest.spyOn(store, 'showFolderSearch').mockReturnValue(true);
+            jest.spyOn(store, 'searchTerm').mockReturnValue('ab');
+            jest.spyOn(store, 'searchLoading').mockReturnValue(false);
+            jest.spyOn(store, 'search');
+            spectator.detectChanges();
+            openOverlay();
+
+            const input = queryInOverlay('host-folder-search-input') as HTMLInputElement;
+            input.focus();
+            spectator.click(byTestId('host-folder-search-clear'));
+            spectator.detectChanges();
+            await spectator.fixture.whenStable();
+
+            expect(store.search).toHaveBeenCalledWith('');
+            expect(document.activeElement).toBe(input);
+        });
     });
 
     it('should propagate the committed value through the form control accessor', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.spec.ts
@@ -80,7 +80,7 @@ describe('DotHostFolderFieldComponent', () => {
         ]
     });
 
-    let overlayMock: { toggle: jest.Mock; hide: jest.Mock };
+    let overlayMock: { toggle: jest.Mock; hide: jest.Mock; container?: HTMLElement };
 
     const createToggleEvent = (offsetWidth = 320): Event => {
         const trigger = document.createElement('button');
@@ -621,9 +621,8 @@ describe('DotHostFolderFieldComponent', () => {
             });
 
             const container = document.createElement('div');
-            container.classList.add('p-popover');
             Object.defineProperty(container, 'offsetWidth', { value: 640 });
-            document.body.appendChild(container);
+            overlayMock.container = container;
 
             const event = new Event('click');
             Object.defineProperty(event, 'currentTarget', { value: trigger });
@@ -633,7 +632,6 @@ describe('DotHostFolderFieldComponent', () => {
             await spectator.fixture.whenStable();
 
             expect(container.style.left).toBe('80px');
-            document.body.removeChild(container);
         });
 
         it('should schedule a scroll to the selected folder once the overlay renders', async () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.ts
@@ -129,6 +129,16 @@ export class DotHostFolderFieldComponent extends BaseControlValueAccessor<string
     };
 
     /**
+     * PrimeNG tooltip text uses `white-space: pre-line` and `word-break: break-word`, and the
+     * root caps width at `--p-tooltip-max-width` (12.5rem). Inline overrides keep site hostnames
+     * on one line; Tailwind classes on tooltipStyleClass do not reach `.p-tooltip-text`.
+     */
+    protected readonly siteTooltipPt = {
+        root: { style: { maxWidth: 'none' } },
+        text: { style: { whiteSpace: 'nowrap', wordBreak: 'normal' } }
+    };
+
+    /**
      * Removes PrimeNG's default tree padding; the folders section manages its own spacing.
      * Search results use top-aligned icons and roomier row spacing to match the design.
      * PrimeNG sets node gap/padding via CSS variables (`--p-tree-node-gap`, etc.) which beat

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.ts
@@ -7,6 +7,7 @@ import {
     Component,
     computed,
     DestroyRef,
+    ElementRef,
     forwardRef,
     inject,
     Injector,
@@ -28,6 +29,8 @@ import { Tree, TreeModule } from 'primeng/tree';
 
 import { TreeNodeItem, TreeNodeSelectItem } from '@dotcms/dotcms-models';
 import { DotMessagePipe, DotTruncatePathPipe } from '@dotcms/ui';
+
+import { alignOverlayLeftToTrigger } from './host-folder-field-overlay.utils';
 
 import { BaseControlValueAccessor } from '../../../shared/base-control-value-accesor';
 import { HostFolderFiledStore } from '../../store/host-folder-field.store';
@@ -84,6 +87,11 @@ export class DotHostFolderFieldComponent extends BaseControlValueAccessor<string
      * committing a selection.
      */
     $overlay = viewChild<Popover>(Popover);
+    /**
+     * References to the overlay search inputs, used to restore focus after clearing.
+     */
+    $sitesSearchInput = viewChild<ElementRef<HTMLInputElement>>('sitesSearchInput');
+    $folderSearchInput = viewChild<ElementRef<HTMLInputElement>>('folderSearchInput');
     /**
      * Reference to the folders tree, used to scroll the selected node into view when the
      * overlay opens.
@@ -168,6 +176,7 @@ export class DotHostFolderFieldComponent extends BaseControlValueAccessor<string
     readonly #injector = inject(Injector);
     readonly #clipboard = inject(Clipboard);
     #copyResetTimer: ReturnType<typeof setTimeout> | undefined;
+    #overlayTrigger: HTMLElement | null = null;
 
     constructor() {
         super();
@@ -186,17 +195,23 @@ export class DotHostFolderFieldComponent extends BaseControlValueAccessor<string
         }
 
         const trigger = event.currentTarget as HTMLElement;
+        this.#overlayTrigger = trigger;
         this.$overlayWidth.set(`${trigger.offsetWidth}px`);
         this.$overlay()?.toggle(event, trigger);
     }
 
     /**
-     * Opens the overlay and scrolls the currently selected folder into view once the tree
-     * has finished rendering (and loading, if the initial folders request is still pending).
+     * Opens the overlay, left-aligns it to the trigger, and scrolls the selected folder into view.
      */
     onOverlayShow(): void {
         this.store.openOverlay();
-        afterNextRender(() => this.#scrollSelectedFolderIntoView(), { injector: this.#injector });
+        afterNextRender(
+            () => {
+                this.#alignPopoverToTrigger();
+                this.#scrollSelectedFolderIntoView();
+            },
+            { injector: this.#injector }
+        );
     }
 
     /**
@@ -233,6 +248,22 @@ export class DotHostFolderFieldComponent extends BaseControlValueAccessor<string
      */
     onSiteSearchInput(event: Event): void {
         this.store.filterSites(this.#readInputValue(event));
+    }
+
+    /**
+     * Clears the sites search and restores focus to the input.
+     */
+    clearSitesSearch(): void {
+        this.store.filterSites('');
+        this.#focusSearchInput(this.$sitesSearchInput());
+    }
+
+    /**
+     * Clears the folders search and restores focus to the input.
+     */
+    clearFolderSearch(): void {
+        this.store.search('');
+        this.#focusSearchInput(this.$folderSearchInput());
     }
 
     /**
@@ -280,6 +311,37 @@ export class DotHostFolderFieldComponent extends BaseControlValueAccessor<string
 
     #readInputValue(event: Event): string {
         return (event.target as HTMLInputElement).value;
+    }
+
+    #focusSearchInput(inputRef: ElementRef<HTMLInputElement> | undefined): void {
+        afterNextRender(() => inputRef?.nativeElement.focus(), { injector: this.#injector });
+    }
+
+    #alignPopoverToTrigger(): void {
+        const trigger = this.#overlayTrigger;
+        const container = this.#resolvePopoverContainer();
+
+        if (!trigger || !container) {
+            return;
+        }
+
+        alignOverlayLeftToTrigger(trigger, container);
+    }
+
+    #resolvePopoverContainer(): HTMLElement | null {
+        const popover = this.$overlay() as Popover & {
+            container?: HTMLElement | { nativeElement: HTMLElement };
+        };
+
+        if (!popover?.container) {
+            const overlays = document.body.querySelectorAll('.p-popover');
+
+            return overlays.length > 0 ? (overlays[overlays.length - 1] as HTMLElement) : null;
+        }
+
+        return popover.container instanceof HTMLElement
+            ? popover.container
+            : popover.container.nativeElement;
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/components/host-folder-field/host-folder-field.component.ts
@@ -319,29 +319,13 @@ export class DotHostFolderFieldComponent extends BaseControlValueAccessor<string
 
     #alignPopoverToTrigger(): void {
         const trigger = this.#overlayTrigger;
-        const container = this.#resolvePopoverContainer();
+        const container = this.$overlay()?.container;
 
         if (!trigger || !container) {
             return;
         }
 
         alignOverlayLeftToTrigger(trigger, container);
-    }
-
-    #resolvePopoverContainer(): HTMLElement | null {
-        const popover = this.$overlay() as Popover & {
-            container?: HTMLElement | { nativeElement: HTMLElement };
-        };
-
-        if (!popover?.container) {
-            const overlays = document.body.querySelectorAll('.p-popover');
-
-            return overlays.length > 0 ? (overlays[overlays.length - 1] as HTMLElement) : null;
-        }
-
-        return popover.container instanceof HTMLElement
-            ? popover.container
-            : popover.container.nativeElement;
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.spec.ts
@@ -1823,6 +1823,35 @@ describe('HostFolderFiledStore', () => {
 
             expect(store.sitesSearchLoading()).toBe(false);
         }));
+
+        it('should stay false while loading more sites with an active search term', fakeAsync(() => {
+            const pageOne = createSiteList(SITE_PAGE_LIMIT);
+            const pageTwo$ = new Subject<{
+                sites: TreeNodeItem[];
+                pagination: DotPagination;
+            }>();
+
+            mockSitesPage(service, pageOne);
+            store.filterSites('demo');
+            tick(300);
+
+            expect(store.sitesSearchLoading()).toBe(false);
+            expect(store.siteSearchTerm()).toBe('demo');
+
+            service.getSitesPage.mockReturnValue(pageTwo$.asObservable());
+            store.loadMoreSites();
+            tick();
+
+            expect(store.sitesPagination().loading).toBe(true);
+            expect(store.sites().length).toBeGreaterThan(0);
+            expect(store.sitesSearchLoading()).toBe(false);
+
+            pageTwo$.next(createSitesPageResponse(createSiteList(1, 'page-two'), 80, 2));
+            pageTwo$.complete();
+            tick();
+
+            expect(store.sitesSearchLoading()).toBe(false);
+        }));
     });
 
     describe('filterSites', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.spec.ts
@@ -1761,6 +1761,68 @@ describe('HostFolderFiledStore', () => {
 
             expect(store.showFolderSearch()).toBe(true);
         });
+
+        it('should stay true while folder search is loading with an active search term', fakeAsync(() => {
+            const search$ = new Subject<{
+                folders: TreeNodeItem[];
+                pagination: DotPagination;
+            }>();
+            service.searchFolders.mockReturnValue(search$.asObservable());
+
+            store.selectSite(site);
+            store.openOverlay();
+            store.search('ab');
+            tick(300);
+
+            expect(store.searchLoading()).toBe(true);
+            expect(store.showFoldersPanelLoading()).toBe(true);
+            expect(store.showFolderSearch()).toBe(true);
+
+            search$.next({ folders: [], pagination: mockPagination });
+            search$.complete();
+            tick();
+        }));
+    });
+
+    describe('sitesSearchLoading', () => {
+        beforeEach(() => {
+            mockSitesPage(service, TREE_SELECT_SITES_MOCK);
+            store.loadSites({ path: null, isRequired: false });
+            store.openOverlay();
+        });
+
+        it('should be false during the initial sites catalog load', () => {
+            patchState(unprotected(store), {
+                siteSearchTerm: '',
+                sitesPagination: {
+                    page: 1,
+                    hasMore: false,
+                    loading: true,
+                    totalEntries: 0
+                }
+            });
+
+            expect(store.sitesSearchLoading()).toBe(false);
+        });
+
+        it('should be true while a sites search request is in flight', fakeAsync(() => {
+            const sites$ = new Subject<{
+                sites: TreeNodeItem[];
+                pagination: DotPagination;
+            }>();
+            service.getSitesPage.mockReturnValue(sites$.asObservable());
+
+            store.filterSites('demo');
+            tick(300);
+
+            expect(store.sitesSearchLoading()).toBe(true);
+
+            sites$.next(createSitesPageResponse([TREE_SELECT_SITES_MOCK[0]]));
+            sites$.complete();
+            tick();
+
+            expect(store.sitesSearchLoading()).toBe(false);
+        }));
     });
 
     describe('filterSites', () => {
@@ -1777,7 +1839,7 @@ describe('HostFolderFiledStore', () => {
             tick(100);
 
             expect(store.sites()).toEqual(initialSites);
-            expect(store.siteSearchTerm()).toBe('');
+            expect(store.siteSearchTerm()).toBe('demo');
         }));
 
         it('should debounce and query the sites API with the search term', fakeAsync(() => {
@@ -1785,7 +1847,7 @@ describe('HostFolderFiledStore', () => {
             service.getSitesPage.mockClear();
 
             store.filterSites('demo');
-            expect(store.siteSearchTerm()).toBe('');
+            expect(store.siteSearchTerm()).toBe('demo');
 
             tick(300);
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
@@ -444,12 +444,16 @@ export const HostFolderFiledStore = signalStore(
                     return folders().length > 0;
                 }),
                 /**
-                 * Whether the sites search input should show a loading spinner (active search only,
-                 * not the initial catalog load).
+                 * Whether the sites search input should show a loading spinner.
+                 * True only for a fresh search request (term set, list cleared, page-1 in flight) —
+                 * not the initial catalog load, and not background load-more pagination (which
+                 * keeps existing sites and uses the virtual scroller loading indicator instead).
                  */
                 sitesSearchLoading: computed(
                     () =>
-                        siteSearchTerm().trim().length > 0 && sitesPagination().loading
+                        siteSearchTerm().trim().length > 0 &&
+                        sitesPagination().loading &&
+                        sites().length === 0
                 ),
                 /**
                  * Sites currently loaded for the panel (API-backed list; no local filtering).

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
@@ -424,8 +424,9 @@ export const HostFolderFiledStore = signalStore(
                         sitesCatalogTotal() > SITE_SEARCH_THRESHOLD
                 ),
                 /**
-                 * Whether the folders panel should show the search input. Hidden while the panel
-                 * loading state is shown and when the selected site has no folders after load.
+                 * Whether the folders panel should show the search input. Hidden during the initial
+                 * folders load (unless a search term is already set) and when the selected site has
+                 * no folders after load. Stays visible while a search request is in flight.
                  */
                 showFolderSearch: computed(() => {
                     if (searchTerm().length > 0) {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/store/host-folder-field.store.ts
@@ -428,12 +428,12 @@ export const HostFolderFiledStore = signalStore(
                  * loading state is shown and when the selected site has no folders after load.
                  */
                 showFolderSearch: computed(() => {
-                    if (showFoldersPanelLoading()) {
-                        return false;
+                    if (searchTerm().length > 0) {
+                        return true;
                     }
 
-                    if (searchTerm().length >= MIN_SEARCH_LENGTH) {
-                        return true;
+                    if (showFoldersPanelLoading()) {
+                        return false;
                     }
 
                     if (foldersStatus() !== ComponentStatus.LOADED) {
@@ -442,6 +442,14 @@ export const HostFolderFiledStore = signalStore(
 
                     return folders().length > 0;
                 }),
+                /**
+                 * Whether the sites search input should show a loading spinner (active search only,
+                 * not the initial catalog load).
+                 */
+                sitesSearchLoading: computed(
+                    () =>
+                        siteSearchTerm().trim().length > 0 && sitesPagination().loading
+                ),
                 /**
                  * Sites currently loaded for the panel (API-backed list; no local filtering).
                  */
@@ -913,14 +921,14 @@ export const HostFolderFiledStore = signalStore(
              */
             filterSites: rxMethod<string>(
                 pipe(
+                    tap((term: string) => patchState(store, { siteSearchTerm: term })),
                     debounceTime(300),
                     filter(() => store.overlayOpen()),
                     map((term) => ({ term, epoch: store.queryEpoch() })),
                     distinctUntilChanged((a, b) => a.term === b.term && a.epoch === b.epoch),
                     map(({ term }) => term),
-                    tap((term: string) =>
+                    tap(() =>
                         patchState(store, {
-                            siteSearchTerm: term,
                             sitesPagination: {
                                 ...store.sitesPagination(),
                                 loading: true


### PR DESCRIPTION
Fixes #36612

This pull request enhances the user experience and accessibility of the host folder field popover in the edit content module. The main improvements include better overlay alignment, improved search input usability, and more robust visual feedback for search actions. The changes are grouped below by theme.

**Popover Overlay Improvements**
- Added a utility function `alignOverlayLeftToTrigger` to ensure the overlay is left-aligned with the trigger and clamps within the viewport. This is invoked after the overlay is shown for consistent positioning.

**Search Input Usability and Controls**
- Introduced clear ("x") controls and loading spinners for both sites and folders search inputs, including logic and UI for showing/hiding these controls based on search state. Inputs regain focus after clearing.
- Ensured search inputs remain visible while loading, improving user feedback during asynchronous operations.

**Accessibility and Focus Management**
- Added template references and logic to restore focus to the appropriate search input after clearing its value, supporting keyboard accessibility.

**Visual and UI Enhancements**
- Updated tooltip configuration for site items to improve legibility of hostnames and prevent unwanted text wrapping. Tooltip position changed from "top" to "right" with custom styles.
- Set `[focusOnShow]="false"` for the popover to prevent automatic focus, allowing for custom focus handling.

**Testing**
- Added and updated unit tests to cover overlay alignment, search controls, focus restoration, and loading feedback for both sites and folders search.

These changes collectively improve the usability, accessibility, and polish of the host folder field popover experience.