### PR TITLE
fix(ci): repair scheduled image CVE scan (trivy-action → v0.36.0)

### DIFF
--- a/.github/workflows/cicd_scheduled_image-cve-scan.yml
+++ b/.github/workflows/cicd_scheduled_image-cve-scan.yml
@@ -32,7 +32,7 @@ jobs:
       IMAGE: ${{ inputs.image || 'dotcms/dotcms:latest' }}
     steps:
       - name: Run Trivy (SARIF for Security tab)
-        uses: aquasecurity/trivy-action@v0.33.1
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}
           format: sarif
@@ -48,7 +48,7 @@ jobs:
           category: image-cve-scan
 
       - name: Run Trivy (table summary)
-        uses: aquasecurity/trivy-action@v0.33.1
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}
           format: table

--- a/.github/workflows/cicd_scheduled_image-cve-scan.yml
+++ b/.github/workflows/cicd_scheduled_image-cve-scan.yml
@@ -32,7 +32,7 @@ jobs:
       IMAGE: ${{ inputs.image || 'dotcms/dotcms:latest' }}
     steps:
       - name: Run Trivy (SARIF for Security tab)
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: ${{ env.IMAGE }}
           format: sarif
@@ -48,7 +48,7 @@ jobs:
           category: image-cve-scan
 
       - name: Run Trivy (table summary)
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: ${{ env.IMAGE }}
           format: table


### PR DESCRIPTION
Fixes #36549

## Problem

The [Scheduled Image CVE Scan](https://github.com/dotCMS/core/actions/workflows/cicd_scheduled_image-cve-scan.yml) — the workflow added to close the image-vulnerability monitoring gap (#36549) — had never produced results. Every run failed.

## Root causes (two, in sequence)

1. **Action wouldn't resolve.** The workflow referenced `aquasecurity/trivy-action@0.33.1`, but that action's release tags are **`v`-prefixed** (`v0.33.1`, `v0.36.0`, …). Without the `v`, GitHub can't resolve the ref, so the job died at **Set up job** before any scan ran:
   ```
   Unable to resolve action `aquasecurity/trivy-action@0.33.1`, unable to find version `0.33.1`
   ```

2. **Installer downloaded a nonexistent binary.** Adding the `v` (→ `@v0.33.1`) got the action to resolve, but `v0.33.1` hardcodes trivy binary **v0.65.0**, which has **no GitHub release** (404). The installer found the tag then exited 1 fetching a nonexistent asset.

## Fix

Bump both uses of the action to **`aquasecurity/trivy-action@v0.36.0`**, which:
- defaults to trivy binary **v0.70.0** (a valid, current release), and
- hash-pins its internal `setup-trivy` installer.

The other pinned actions (`github/codeql-action/upload-sarif@v4`, `actions/upload-artifact@v4`) resolve correctly and are unchanged.

## Verification

Triggered the workflow via `workflow_dispatch` on this branch — [run 30474869026](https://github.com/dotCMS/core/actions/runs/30474869026) completed **successfully**: both Trivy scans ran, SARIF uploaded to the Security tab (category `image-cve-scan`), summary table written, and results artifact uploaded.

## Review notes

- Per review feedback, this description now matches the shipped version (`v0.36.0`).
- On tag- vs SHA-pinning: left as a version tag to stay **consistent with the repo's existing convention** (`github/codeql-action` is likewise tag-pinned in this workflow). SHA-pinning third-party actions is reasonable supply-chain hardening but is out of scope for this fix and would be better applied repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)