### PR TITLE
chore(sdk): bump MinSdkVersion.VALUE to 26.07.28-01

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/config/MinSdkVersion.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/config/MinSdkVersion.java
@@ -41,7 +41,7 @@ public final class MinSdkVersion {
      * previously published SDK version is still considered compatible. The first real
      * bump of this value should replace this baseline.
      */
-    public static final String VALUE = "0.0.0";
+    public static final String VALUE = "26.07.28-01";
 
     private MinSdkVersion() {
         // utility class, no instances


### PR DESCRIPTION
Automated post-release bump. Release `26.07.28-01` was flagged (via `bump_min_sdk_version`) as containing an SDK-breaking change. This raises the compatibility floor advertised via the `X-DotCMS-Min-SDK` header to `26.07.28-01`. Please review and merge — this does not auto-merge.

Fixes #36780