### PR TITLE
fix(tests): remove wall-clock timing assertions from flaky unit tests

### DIFF
--- a/dotCMS/src/test/java/com/dotcms/metrics/timing/TimeMetricHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/metrics/timing/TimeMetricHelperTest.java
@@ -4,14 +4,23 @@ import com.dotcms.UnitTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-import static graphql.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link TimeMetricHelper} class.
  *
+ * <p>The duration is stubbed rather than produced by a {@code Thread.sleep()}. Asserting on a
+ * slept-through duration made these tests depend on sleep precision: the default {@code %.4f} mask
+ * only tolerated a ~10ms overshoot, which fails on any loaded machine.</p>
+ *
  * @author vico
  */
 public class TimeMetricHelperTest extends UnitTestBase {
+
+    private static final long DURATION_MS = 1500L;
+    private static final float DURATION_SECONDS = 1.5f;
 
     private TimeMetricHelper timeMetricHelper;
 
@@ -24,24 +33,24 @@ public class TimeMetricHelperTest extends UnitTestBase {
      * Test the {@link TimeMetricHelper#formatDuration(TimeMetric, String)} method with a custom mask.
      */
     @Test
-    public void testFormatSecondsWithCustomMask() throws InterruptedException {
-        final TimeMetric timeMetric = TimeMetric.mark("some-time-metric");
-        Thread.sleep(100);
-        timeMetric.stop();
-        final String formatted = timeMetricHelper.formatDuration(timeMetric, "%.2f");
-        assertTrue(formatted.startsWith("0.1"));
+    public void testFormatSecondsWithCustomMask() {
+        final TimeMetric timeMetric = mock(TimeMetric.class);
+        when(timeMetric.getDuration()).thenReturn(DURATION_MS);
+
+        assertEquals(String.format("%.2f", DURATION_SECONDS),
+                timeMetricHelper.formatDuration(timeMetric, "%.2f"));
     }
 
     /**
      * Test the {@link TimeMetricHelper#formatDuration(TimeMetric)} method with the default mask.
      */
     @Test
-    public void testFormatSecondsWithDefaultMask() throws InterruptedException {
-        final TimeMetric timeMetric = TimeMetric.mark("some-time-metric");
-        Thread.sleep(100);
-        timeMetric.stop();
-        final String formatted = timeMetricHelper.formatDuration(timeMetric);
-        assertTrue(formatted.startsWith("0.10"));
+    public void testFormatSecondsWithDefaultMask() {
+        final TimeMetric timeMetric = mock(TimeMetric.class);
+        when(timeMetric.getDuration()).thenReturn(DURATION_MS);
+
+        assertEquals(String.format("%.4f", DURATION_SECONDS),
+                timeMetricHelper.formatDuration(timeMetric));
     }
 
 }

--- a/dotCMS/src/test/java/com/dotcms/regex/MatcherTimeoutFactoryTest.java
+++ b/dotCMS/src/test/java/com/dotcms/regex/MatcherTimeoutFactoryTest.java
@@ -17,6 +17,9 @@ import io.vavr.control.Try;
 
 public class MatcherTimeoutFactoryTest {
 
+    /** How often the quarantine window is sampled, instead of spinning on it. */
+    private static final long QUARANTINE_POLL_MS = 250L;
+
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         // prime regex engine - takes about 800ms
@@ -100,19 +103,20 @@ public class MatcherTimeoutFactoryTest {
             long endTime = System.currentTimeMillis();
             
             // the regex returned after the expected timeout time.
-            assertTrue(endTime >= startTime + MatcherTimeoutFactory.VANITY_URL_REGEX_TIMEOUT);
-            
-            // the regex returned within 100ms of the expected timeout time
-            assertTrue(endTime < startTime + MatcherTimeoutFactory.VANITY_URL_REGEX_TIMEOUT + 100);
-            
+            // NOTE: only the lower bound is asserted. An upper bound would be measuring scheduler
+            // latency, not behavior, and fails intermittently on loaded CI runners.
+            assertTrue("regex should not have returned before its timeout elapsed",
+                            endTime >= startTime + MatcherTimeoutFactory.VANITY_URL_REGEX_TIMEOUT);
+
             //we got a good exception message
-            assertTrue(exception.getMessage().contains(pattern.toString()));
+            assertTrue("exception message should name the pattern, was: " + exception.getMessage(),
+                            exception.getMessage().contains(pattern.toString()));
 
         }
     }
 
     @Test
-    public void test_regex_quarantine() {
+    public void test_regex_quarantine() throws InterruptedException {
         MatcherTimeoutFactory.SLOW_REGEX_CACHE.invalidateAll();
 
         for (String[] evil : evilPatternAndMatchingString) {
@@ -126,15 +130,16 @@ public class MatcherTimeoutFactoryTest {
                 MatcherTimeoutFactory.matcher(pattern, evil[1]).matches()
             );
             
-            // while the regex is in quarantine, we should get the NO_MATCH_PATTERN result
+            // while the regex is in quarantine, we should get the NO_MATCH_PATTERN result.
+            // NOTE: polling rather than spinning. The old loop asserted each lookup completed in
+            // under 100ms, which measured cache performance instead of quarantine behavior and
+            // failed intermittently on loaded CI runners (see issue #35174).
             while (System.currentTimeMillis() < runUntil) {
-                long startTime = System.currentTimeMillis();
                 Matcher matcher = MatcherTimeoutFactory.matcher(pattern, evil[1]);
                 // we have the NO_MATCH_PATTERN
                 assertEquals(MatcherTimeoutFactory.NO_MATCH_PATTERN, matcher.pattern());
-                
-                //asert that we are now returning a no match regex in under 100ms
-                assertTrue(System.currentTimeMillis() < startTime + 100);
+
+                Thread.sleep(QUARANTINE_POLL_MS);
             }
             
             // wait until the regex is released from quarantine

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/dotcache/DotCacheToolTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/dotcache/DotCacheToolTest.java
@@ -1,6 +1,8 @@
 package com.dotcms.rendering.velocity.viewtools.dotcache;
 
 import com.dotmarketing.business.cache.provider.MockCacheAdministrator;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -12,6 +14,12 @@ import org.junit.Test;
  * @since Nov 14th, 2022
  */
 public class DotCacheToolTest {
+
+    /**
+     * Upper bound for the cache to settle. Generous on purpose: it only caps how long a broken
+     * assertion takes to report, it is not the expected wait.
+     */
+    private static final long SETTLE_TIMEOUT_SECONDS = 10L;
 
     private static DotCacheTool dotCacheTool;
 
@@ -28,12 +36,9 @@ public class DotCacheToolTest {
      *     <li><b>Expected Result:</b> After setting the entry's TTL to zero, it must be flushed out of the cache and
      *     null must be returned.</li>
      * </ul>
-     *
-     * @throws InterruptedException Highly unlikely error related to the {@code Thread.sleep()} call, which is necessary
-     *                              because of the Debouncer being applied to the {@code DotCacheTool.put()} methods.
      */
     @Test
-    public void test_cache_TTL_0() throws InterruptedException {
+    public void test_cache_TTL_0() {
         dotCacheTool.clear();
         final String cacheKey = "cacheKey";
         final String now = "now:" + System.currentTimeMillis();
@@ -53,39 +58,38 @@ public class DotCacheToolTest {
      *     <li><b>Expected Result:</b> After waiting for more than 2 seconds, the entry must be flushed out of the
      *     cache and null must be returned.</li>
      * </ul>
-     *
-     * @throws InterruptedException Highly unlikely error related to the {@code Thread.sleep()} call, which is necessary
-     *                              because of the Debouncer being applied to the {@code DotCacheTool.put()} methods.
      */
     @Test
-    public void test_cache_TTL_2() throws InterruptedException {
+    public void test_cache_TTL_2() {
         dotCacheTool.clear();
         final String cacheKey = "cacheKey";
         final String now = "now:" + System.currentTimeMillis();
 
         dotCacheTool.put(cacheKey, now, 2);
         Assert.assertEquals(dotCacheTool.get(cacheKey), now);
-        Thread.sleep(2500);
-        Assert.assertNull(dotCacheTool.get(cacheKey));
+
+        // the entry must expire on its own; polling rather than sleeping just past the TTL
+        Awaitility.await()
+                .atMost(SETTLE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .until(() -> dotCacheTool.get(cacheKey) == null);
     }
 
     
     @Test
-    public void test_putDebounce() throws InterruptedException {
+    public void test_putDebounce() {
         dotCacheTool.clear();
         final String cacheKey = "cacheKey";
         final String now = "now:" + System.currentTimeMillis();
 
         dotCacheTool.putDebounce(cacheKey, now, 2);
-        
+
         // not in cache yet, debouncing for 1 sec
         Assert.assertNull(dotCacheTool.get(cacheKey));
-        
-        // added after 1 second
-        Thread.sleep(1200);
-        Assert.assertEquals(dotCacheTool.get(cacheKey), now);
 
-
+        // added once the debounce window elapses
+        Awaitility.await()
+                .atMost(SETTLE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .until(() -> now.equals(dotCacheTool.get(cacheKey)));
     }
     
     
@@ -98,12 +102,9 @@ public class DotCacheToolTest {
      *     Then, clear the whole DotCache.</li>
      *     <li><b>Expected Result:</b> After clearing the whole cache, a null must be returned.</li>
      * </ul>
-     *
-     * @throws InterruptedException Highly unlikely error related to the {@code Thread.sleep()} call, which is necessary
-     *                              because of the Debouncer being applied to the {@code DotCacheTool.put()} methods.
      */
     @Test
-    public void test_cache_clear() throws InterruptedException {
+    public void test_cache_clear() {
         dotCacheTool.clear();
         final String cacheKey = "cacheKey";
         final String now = "now:" + System.currentTimeMillis();
@@ -123,18 +124,15 @@ public class DotCacheToolTest {
      *     Then, remove it from the DotCache by its key.</li>
      *     <li><b>Expected Result:</b> After explicitly removing it, a null must be returned.</li>
      * </ul>
-     *
-     * @throws InterruptedException Highly unlikely error related to the {@code Thread.sleep()} call, which is necessary
-     *                              because of the Debouncer being applied to the {@code DotCacheTool.put()} methods.
      */
     @Test
-    public void test_remove() throws InterruptedException {
+    public void test_remove() {
         dotCacheTool.clear();
         final String cacheKey = "cacheKey";
         final String now = "now:" + System.currentTimeMillis();
 
+        // NOTE: no wait needed. Only putDebounce() is debounced; put() writes through.
         dotCacheTool.put(cacheKey, now);
-        Thread.sleep(1200);
         Assert.assertEquals(dotCacheTool.get(cacheKey), now);
 
         dotCacheTool.remove(cacheKey);


### PR DESCRIPTION
## What

Removes wall-clock timing assertions from three unit test classes in the JVM Tests suite. These assertions measured how fast the machine ran rather than whether the code behaved correctly, so they failed intermittently on loaded CI runners.

Fixes #35174.

## Why

### `MatcherTimeoutFactoryTest` — the reported flake

`test_regex_quarantine` asserted that each Caffeine cache lookup completed in under 100 ms, inside a loop that spun for ~28 seconds. Any GC pause or CPU contention on the runner failed it. Because the assertion carried no message, the CI annotation surfaced only `java.lang.AssertionError: undefined`.

The correctness requirement — a quarantined pattern keeps returning `NO_MATCH_PATTERN` for the duration of the quarantine window — is unchanged. The loop now samples every 250 ms instead of busy-spinning, so it no longer pins a core for 28 seconds.

`test_regex_timeout` had the same defect one method away and was **not** covered by the issue: it allowed 100 ms of slack over a 2000 ms `Thread.sleep`. The lower bound (the regex must not return before its timeout elapsed) is the real assertion and is kept; the upper bound measured scheduler latency and is gone. It would have been the next failure.

Both remaining assertions gained messages so a future failure names the problem instead of reporting `undefined`.

### `TimeMetricHelperTest` — already broken

`formatDuration`'s default mask is `%.4f`, and the test asserted `startsWith("0.10")` after a `Thread.sleep(100)`. That tolerates **under 10 ms of overshoot**. Both tests in the class fail deterministically on a developer laptop and pass on CI only by luck of timing.

The duration is now stubbed with Mockito, which pins the actual contract (default mask is `%.4f`, milliseconds are divided by 1000, a custom mask is honored) with no dependence on sleep precision. Also replaces a stray `import static graphql.Assert.assertTrue` with the JUnit equivalent.

### `DotCacheToolTest` — thin margins and one sleep that did nothing

- `test_putDebounce` slept 1200 ms against a 1000 ms debounce window: a 200 ms margin. Now polls with Awaitility.
- `test_cache_TTL_2` slept 2500 ms against a 2000 ms TTL: a 500 ms margin. Now polls with Awaitility.
- `test_remove` slept 1200 ms for no reason. Only `putDebounce()` is debounced; `put()` writes through. The sleep is removed, along with the `@throws InterruptedException` javadoc blocks on four methods that justified it by describing behavior `put()` does not have.

The Awaitility bounds are 10 s. They are deliberately generous — they cap how long a genuinely broken assertion takes to report, they are not the expected wait.

## Verification

Locally, `dotcms-core` unit tests, before:

```
TimeMetricHelperTest      Tests run: 2, Errors: 2   <<< FAILURE   (3.3 s)
MatcherTimeoutFactoryTest Tests run: 4, OK          (38.1 s)
DotCacheToolTest          Tests run: 5, OK          ( 4.9 s)
```

After — 5 consecutive runs green, 4 of them with all 16 cores saturated by busy-loops to emulate a loaded runner:

```
TimeMetricHelperTest      Tests run: 2, OK          ( 2.1 s)
MatcherTimeoutFactoryTest Tests run: 4, OK          (38.1 s)
DotCacheToolTest          Tests run: 5, OK          ( 3.1 s)
```

No production code is touched. Net coverage is unchanged: every assertion removed was about elapsed time, not behavior.

## Known limitation

`MatcherTimeoutFactoryTest` still takes ~38 s. That is not the flake — it is the real 30-second quarantine window (`VANITY_URL_QUARANTINE_MS`) that the test legitimately waits out, plus two 2-second regex timeouts. Cutting it down means making those constants injectable in `MatcherTimeoutFactory`; they are `static final`, read from `Config` at class-init, so a test cannot shorten them after the class loads. That is a production change with class-load-ordering risk across tests sharing a surefire fork, so it is deliberately left out of a stabilization PR.

This PR fixes: #35174