### PR TITLE
fix(content-types): focus the Name input when creating, nothing when editing

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.integration.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.integration.spec.ts
@@ -89,7 +89,15 @@ class DialogFocusHostComponent {
 const NAME_INPUT_SELECTOR = '#content-type-form-name';
 const NEW_EDIT_CONTENT_CHECKBOX_SELECTOR = '#newEditContentLabel';
 
-describe('ContentTypesFormComponent focus inside p-dialog', () => {
+/**
+ * Integration tests: the real ContentTypesFormComponent rendered inside a real PrimeNG p-dialog.
+ *
+ * These are not unit tests. The behavior under test only exists when both collaborate -- who wins
+ * the initial focus between the form and the dialog. Neither of the sibling unit specs can cover
+ * it: content-types-form.component.spec.ts renders no dialog, and
+ * dot-content-types-edit.component.spec.ts stubs the form away.
+ */
+describe('ContentTypesFormComponent inside p-dialog - Integration Tests', () => {
     let fixture: ComponentFixture<DialogFocusHostComponent>;
     let originalOffsetParent: PropertyDescriptor;
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.integration.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.integration.spec.ts
@@ -1,9 +1,9 @@
 import { mockProvider } from '@openng/spectator/jest';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { ApplicationRef, Component, Injectable } from '@angular/core';
+import { ApplicationRef, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
@@ -17,54 +17,22 @@ import {
     DotSiteService,
     DotWorkflowService
 } from '@dotcms/data-access';
-import {
-    DotCMSBaseTypesContentTypes,
-    DotCMSContentType,
-    FeaturedFlags
-} from '@dotcms/dotcms-models';
+import { DotCMSBaseTypesContentTypes, DotCMSContentType } from '@dotcms/dotcms-models';
 import {
     cleanUpDialog,
     createFakeSite,
     dotcmsContentTypeBasicMock,
-    DotWorkflowServiceMock,
-    MockDotMessageService
+    DotWorkflowServiceMock
 } from '@dotcms/utils-testing';
 
 import { ContentTypesFormComponent } from './content-types-form.component';
+import {
+    buildActivatedRouteMock,
+    createContentTypesFormMessageServiceMock,
+    MockDotLicenseService
+} from './content-types-form.testing';
 
-@Injectable()
-class MockDotLicenseService {
-    isEnterprise(): Observable<boolean> {
-        return of(false);
-    }
-}
-
-const messageServiceMock = new MockDotMessageService({
-    'contenttypes.content.content': 'Content',
-    'contenttypes.content.widget': 'Widget',
-    'contenttypes.form.name': 'Name',
-    'contenttypes.form.label.icon': 'Icon',
-    'contenttypes.form.label.description': 'Description',
-    'contenttypes.form.field.host_folder.label': 'Host or Folder',
-    'contenttypes.form.label.workflow': 'Workflow',
-    'contenttypes.form.label.workflow.actions': 'Workflow Actions',
-    'contenttypes.form.label.publish.date.field': 'Publish Date Field',
-    'contenttypes.form.field.expire.date.field': 'Expire Date Field',
-    'contenttypes.form.field.detail.page': 'Detail Page',
-    'contenttypes.form.label.URL.pattern': 'URL Pattern',
-    'content.type.form.banner.message': 'Try the new content editor'
-});
-
-/** Fresh route per test so no shared mutable flag state leaks between them. */
-const buildActivatedRoute = (newContentEditorEnabled: boolean) => ({
-    snapshot: {
-        data: {
-            featuredFlags: {
-                [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: newContentEditorEnabled
-            }
-        }
-    }
-});
+const messageServiceMock = createContentTypesFormMessageServiceMock();
 
 const fakeSite = createFakeSite({ hostname: 'demo.dotcms.com', archived: false });
 
@@ -86,7 +54,9 @@ class DialogFocusHostComponent {
     };
 }
 
-const NAME_INPUT_SELECTOR = '#content-type-form-name';
+const NAME_INPUT_SELECTOR = '[data-testid="content-type-form-name"]';
+// PrimeNG renders the focusable input behind p-checkbox's inputId, so target that rather than a
+// data-testid on the p-checkbox host, which is not the element that receives focus.
 const NEW_EDIT_CONTENT_CHECKBOX_SELECTOR = '#newEditContentLabel';
 
 /**
@@ -139,7 +109,7 @@ describe('ContentTypesFormComponent inside p-dialog - Integration Tests', () => 
                 { provide: DotLicenseService, useClass: MockDotLicenseService },
                 {
                     provide: ActivatedRoute,
-                    useValue: buildActivatedRoute(newContentEditorEnabled)
+                    useValue: buildActivatedRouteMock(newContentEditorEnabled)
                 },
                 mockProvider(DotSiteService, {
                     getSites: jest.fn().mockReturnValue(

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.spec.ts
@@ -1,0 +1,240 @@
+import { mockProvider } from '@openng/spectator/jest';
+import { Observable, of } from 'rxjs';
+
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component, Injectable } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+
+import { Dialog, DialogModule } from 'primeng/dialog';
+
+import {
+    DotHttpErrorManagerService,
+    DotLicenseService,
+    DotMessageService,
+    DotSiteService,
+    DotWorkflowService
+} from '@dotcms/data-access';
+import {
+    DotCMSBaseTypesContentTypes,
+    DotCMSContentType,
+    FeaturedFlags
+} from '@dotcms/dotcms-models';
+import {
+    cleanUpDialog,
+    createFakeSite,
+    dotcmsContentTypeBasicMock,
+    DotWorkflowServiceMock,
+    MockDotMessageService
+} from '@dotcms/utils-testing';
+
+import { ContentTypesFormComponent } from './content-types-form.component';
+
+@Injectable()
+class MockDotLicenseService {
+    isEnterprise(): Observable<boolean> {
+        return of(false);
+    }
+}
+
+const messageServiceMock = new MockDotMessageService({
+    'contenttypes.content.content': 'Content',
+    'contenttypes.content.widget': 'Widget',
+    'contenttypes.form.name': 'Name',
+    'contenttypes.form.label.icon': 'Icon',
+    'contenttypes.form.label.description': 'Description',
+    'contenttypes.form.field.host_folder.label': 'Host or Folder',
+    'contenttypes.form.label.workflow': 'Workflow',
+    'contenttypes.form.label.workflow.actions': 'Workflow Actions',
+    'contenttypes.form.label.publish.date.field': 'Publish Date Field',
+    'contenttypes.form.field.expire.date.field': 'Expire Date Field',
+    'contenttypes.form.field.detail.page': 'Detail Page',
+    'contenttypes.form.label.URL.pattern': 'URL Pattern',
+    'content.type.form.banner.message': 'Try the new content editor'
+});
+
+/** Fresh route per test so no shared mutable flag state leaks between them. */
+const buildActivatedRoute = (newContentEditorEnabled: boolean) => ({
+    snapshot: {
+        data: {
+            featuredFlags: {
+                [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: newContentEditorEnabled
+            }
+        }
+    }
+});
+
+const fakeSite = createFakeSite({ hostname: 'demo.dotcms.com', archived: false });
+
+/** Mirrors the create-mode markup: the real form rendered inside a real PrimeNG dialog. */
+@Component({
+    selector: 'dot-test-dialog-focus-host',
+    template: `
+        <p-dialog [visible]="true" [modal]="true" [focusOnShow]="focusOnShow">
+            <dot-content-types-form [contentType]="contentType" />
+        </p-dialog>
+    `,
+    imports: [DialogModule, ContentTypesFormComponent]
+})
+class DialogFocusHostComponent {
+    focusOnShow = false;
+    contentType: DotCMSContentType = {
+        ...dotcmsContentTypeBasicMock,
+        baseType: 'CONTENT'
+    };
+}
+
+const NAME_INPUT_SELECTOR = '#content-type-form-name';
+const NEW_EDIT_CONTENT_CHECKBOX_SELECTOR = '#newEditContentLabel';
+
+describe('ContentTypesFormComponent focus inside p-dialog', () => {
+    let fixture: ComponentFixture<DialogFocusHostComponent>;
+    let originalOffsetParent: PropertyDescriptor;
+
+    const queryElement = (selector: string): HTMLElement =>
+        fixture.debugElement.query(By.css(selector))?.nativeElement ?? null;
+
+    const formComponent = (): ContentTypesFormComponent =>
+        fixture.debugElement.query(By.directive(ContentTypesFormComponent))
+            .componentInstance as ContentTypesFormComponent;
+
+    /**
+     * Renders the dialog and settles focus.
+     *
+     * jsdom never fires a CSS transition end, so PrimeNG's `onAfterEnter` is invoked directly to
+     * reproduce its post-animation focus call. Both contenders are one-shot timers pending at that
+     * point (dotAutofocus at 100ms, PrimeNG at its transition duration), so flushing pending timers
+     * runs them in their real order without coupling the test to either vendor's delay.
+     */
+    const openDialogAndSettleFocus = ({
+        focusOnShow,
+        newContentEditorEnabled,
+        baseType = 'CONTENT'
+    }: {
+        focusOnShow: boolean;
+        newContentEditorEnabled: boolean;
+        baseType?: DotCMSBaseTypesContentTypes;
+    }): void => {
+        TestBed.configureTestingModule({
+            imports: [DialogFocusHostComponent],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                { provide: DotMessageService, useValue: messageServiceMock },
+                { provide: DotWorkflowService, useClass: DotWorkflowServiceMock },
+                { provide: DotLicenseService, useClass: MockDotLicenseService },
+                {
+                    provide: ActivatedRoute,
+                    useValue: buildActivatedRoute(newContentEditorEnabled)
+                },
+                mockProvider(DotSiteService, {
+                    getSites: jest.fn().mockReturnValue(
+                        of({
+                            sites: [fakeSite],
+                            pagination: { currentPage: 1, perPage: 40, totalEntries: 1 }
+                        })
+                    ),
+                    getSiteById: jest.fn().mockReturnValue(of(fakeSite))
+                }),
+                mockProvider(DotHttpErrorManagerService)
+            ]
+        });
+
+        fixture = TestBed.createComponent(DialogFocusHostComponent);
+        fixture.componentInstance.focusOnShow = focusOnShow;
+        fixture.componentInstance.contentType = {
+            ...dotcmsContentTypeBasicMock,
+            baseType
+        };
+        fixture.detectChanges();
+
+        const dialog: Dialog = fixture.debugElement.query(By.directive(Dialog)).componentInstance;
+        dialog.onAfterEnter();
+
+        jest.runOnlyPendingTimers();
+    };
+
+    beforeAll(() => {
+        // PrimeNG only focuses elements it considers visible (DomHandler.isVisible checks
+        // offsetParent). jsdom has no layout engine, so without this shim every element looks
+        // hidden, PrimeNG's focus() becomes a no-op and the focus race under test never happens.
+        originalOffsetParent = Object.getOwnPropertyDescriptor(
+            HTMLElement.prototype,
+            'offsetParent'
+        );
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+            configurable: true,
+            get(): Element | null {
+                return this.parentElement;
+            }
+        });
+    });
+
+    afterAll(() => {
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', originalOffsetParent);
+    });
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        cleanUpDialog(fixture);
+    });
+
+    describe('focusOnShow disabled (create mode)', () => {
+        // The binding does not branch on baseType, but every base type reaches this same dialog
+        // through create/:type — so the focus outcome is asserted for real, not just inferred.
+        it.each<DotCMSBaseTypesContentTypes>(['CONTENT', 'WIDGET'])(
+            'should focus the name input instead of the new content banner checkbox for %s',
+            (baseType) => {
+                openDialogAndSettleFocus({
+                    focusOnShow: false,
+                    newContentEditorEnabled: true,
+                    baseType
+                });
+
+                const nameInput = queryElement(NAME_INPUT_SELECTOR);
+                const newEditContentCheckbox = queryElement(NEW_EDIT_CONTENT_CHECKBOX_SELECTOR);
+
+                expect(newEditContentCheckbox).not.toBeNull();
+                expect(document.activeElement).toBe(nameInput);
+                expect(document.activeElement).not.toBe(newEditContentCheckbox);
+            }
+        );
+
+        it('should focus the name input when the new content banner is hidden', () => {
+            openDialogAndSettleFocus({ focusOnShow: false, newContentEditorEnabled: false });
+
+            expect(queryElement(NEW_EDIT_CONTENT_CHECKBOX_SELECTOR)).toBeNull();
+            expect(document.activeElement).toBe(queryElement(NAME_INPUT_SELECTOR));
+        });
+
+        it('should let the focused input update the name control without touching the banner', () => {
+            openDialogAndSettleFocus({ focusOnShow: false, newContentEditorEnabled: true });
+
+            const form = formComponent().form;
+            const newEditContentBefore = form.get('newEditContent').value;
+            const nameInput = document.activeElement as HTMLInputElement;
+
+            nameInput.value = 'My Content Type';
+            nameInput.dispatchEvent(new Event('input'));
+
+            expect(form.get('name').value).toBe('My Content Type');
+            expect(form.get('newEditContent').value).toBe(newEditContentBefore);
+        });
+    });
+
+    describe('focusOnShow enabled (edit mode)', () => {
+        it('should focus the first focusable element in DOM order', () => {
+            // Documents the current, intentionally untouched edit-mode behavior: PrimeNG wins the
+            // race and focuses the DOM-first focusable element instead of the name input.
+            openDialogAndSettleFocus({ focusOnShow: true, newContentEditorEnabled: true });
+
+            expect(document.activeElement).toBe(queryElement(NEW_EDIT_CONTENT_CHECKBOX_SELECTOR));
+        });
+    });
+});

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.spec.ts
@@ -185,7 +185,7 @@ describe('ContentTypesFormComponent focus inside p-dialog', () => {
         cleanUpDialog(fixture);
     });
 
-    describe('focusOnShow disabled (create mode)', () => {
+    describe('focusOnShow disabled (the production value, both create and edit)', () => {
         // The binding does not branch on baseType, but every base type reaches this same dialog
         // through create/:type — so the focus outcome is asserted for real, not just inferred.
         it.each<DotCMSBaseTypesContentTypes>(['CONTENT', 'WIDGET'])(
@@ -228,13 +228,16 @@ describe('ContentTypesFormComponent focus inside p-dialog', () => {
         });
     });
 
-    describe('focusOnShow enabled (edit mode)', () => {
-        it('should focus the first focusable element in DOM order', () => {
-            // Documents the current, intentionally untouched edit-mode behavior: PrimeNG wins the
-            // race and focuses the DOM-first focusable element instead of the name input.
+    describe('focusOnShow enabled (reproduces the bug being fixed)', () => {
+        it('should let PrimeNG steal focus to the first focusable element in DOM order', () => {
+            // Not a production configuration -- this reproduces the defect so the reason the
+            // binding must stay disabled is pinned in a test. Leaving focusOnShow on lets PrimeNG's
+            // post-transition focus() win over the form's own focus, landing on the banner
+            // checkbox. This was the visible "focus appears on Name, then jumps away" symptom.
             openDialogAndSettleFocus({ focusOnShow: true, newContentEditorEnabled: true });
 
             expect(document.activeElement).toBe(queryElement(NEW_EDIT_CONTENT_CHECKBOX_SELECTOR));
+            expect(document.activeElement).not.toBe(queryElement(NAME_INPUT_SELECTOR));
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form-dialog-focus.spec.ts
@@ -3,7 +3,7 @@ import { Observable, of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { Component, Injectable } from '@angular/core';
+import { ApplicationRef, Component, Injectable } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
@@ -104,18 +104,22 @@ describe('ContentTypesFormComponent focus inside p-dialog', () => {
      * Renders the dialog and settles focus.
      *
      * jsdom never fires a CSS transition end, so PrimeNG's `onAfterEnter` is invoked directly to
-     * reproduce its post-animation focus call. Both contenders are one-shot timers pending at that
-     * point (dotAutofocus at 100ms, PrimeNG at its transition duration), so flushing pending timers
-     * runs them in their real order without coupling the test to either vendor's delay.
+     * reproduce its post-animation focus call, then its pending one-shot timer is flushed. Flushing
+     * pending timers rather than advancing a fixed amount keeps the test decoupled from PrimeNG's
+     * transition duration.
+     *
+     * Passing an `id` puts the form in edit mode, the same way production does.
      */
     const openDialogAndSettleFocus = ({
         focusOnShow,
         newContentEditorEnabled,
-        baseType = 'CONTENT'
+        baseType = 'CONTENT',
+        id = null
     }: {
         focusOnShow: boolean;
         newContentEditorEnabled: boolean;
         baseType?: DotCMSBaseTypesContentTypes;
+        id?: string;
     }): void => {
         TestBed.configureTestingModule({
             imports: [DialogFocusHostComponent],
@@ -146,9 +150,13 @@ describe('ContentTypesFormComponent focus inside p-dialog', () => {
         fixture.componentInstance.focusOnShow = focusOnShow;
         fixture.componentInstance.contentType = {
             ...dotcmsContentTypeBasicMock,
-            baseType
+            baseType,
+            id
         };
         fixture.detectChanges();
+        // The form focuses the Name input from afterNextRender, and those hooks run on the
+        // application tick rather than on detectChanges.
+        TestBed.inject(ApplicationRef).tick();
 
         const dialog: Dialog = fixture.debugElement.query(By.directive(Dialog)).componentInstance;
         dialog.onAfterEnter();
@@ -185,7 +193,7 @@ describe('ContentTypesFormComponent focus inside p-dialog', () => {
         cleanUpDialog(fixture);
     });
 
-    describe('focusOnShow disabled (the production value, both create and edit)', () => {
+    describe('create mode', () => {
         // The binding does not branch on baseType, but every base type reaches this same dialog
         // through create/:type — so the focus outcome is asserted for real, not just inferred.
         it.each<DotCMSBaseTypesContentTypes>(['CONTENT', 'WIDGET'])(
@@ -225,6 +233,33 @@ describe('ContentTypesFormComponent focus inside p-dialog', () => {
 
             expect(form.get('name').value).toBe('My Content Type');
             expect(form.get('newEditContent').value).toBe(newEditContentBefore);
+        });
+    });
+
+    describe('edit mode', () => {
+        it('should not focus anything when the content type already exists', () => {
+            openDialogAndSettleFocus({
+                focusOnShow: false,
+                newContentEditorEnabled: true,
+                id: '1234-5678-edit'
+            });
+
+            // Nothing should grab focus while editing: the name is already filled in.
+            expect(document.activeElement).toBe(document.body);
+            expect(document.activeElement).not.toBe(queryElement(NAME_INPUT_SELECTOR));
+            expect(document.activeElement).not.toBe(
+                queryElement(NEW_EDIT_CONTENT_CHECKBOX_SELECTOR)
+            );
+        });
+
+        it('should not focus anything when the new content banner is hidden', () => {
+            openDialogAndSettleFocus({
+                focusOnShow: false,
+                newContentEditorEnabled: false,
+                id: '1234-5678-edit'
+            });
+
+            expect(document.activeElement).toBe(document.body);
         });
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -27,7 +27,8 @@
             pInputText
             type="text"
             name="name"
-            formControlName="name" />
+            formControlName="name"
+            data-testid="content-type-form-name" />
         <dot-field-validation-message
             [message]="'dot.common.message.field.required' | dm: [nameFieldLabel]"
             [field]="form.get('name')" />

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -6,7 +6,7 @@
     novalidate>
     @if (newContentEditorEnabled) {
         <div
-            class="absolute top-22 -ml-5 z-40 left-5 w-full flex items-center gap-1 py-2 px-4 text-sm bg-primary-200 text-primary-900"
+            class="absolute top-22 left-5 z-40 -ml-5 flex w-full items-center gap-1 bg-primary-200 px-4 py-2 text-sm text-primary-900"
             data-test-id="content-type__new-content-banner">
             <p-checkbox
                 class="p-checkbox-sm"
@@ -27,8 +27,7 @@
             pInputText
             type="text"
             name="name"
-            formControlName="name"
-            dotAutofocus />
+            formControlName="name" />
         <dot-field-validation-message
             [message]="'dot.common.message.field.required' | dm: [nameFieldLabel]"
             [field]="form.get('name')" />
@@ -144,7 +143,7 @@
                     class="w-full"
                     formControlName="urlMapPattern" />
                 <dot-field-helper
-                    class="absolute top-1/2 -translate-y-1/2 right-1"
+                    class="absolute top-1/2 right-1 -translate-y-1/2"
                     [message]="'contenttypes.hint.URL.map.pattern.hint1' | dm" />
             </div>
         </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
@@ -1,9 +1,9 @@
 import { createComponentFactory, mockProvider, Spectator } from '@openng/spectator/jest';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { ApplicationRef, Injectable } from '@angular/core';
+import { ApplicationRef } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
@@ -26,52 +26,19 @@ import {
     dotcmsContentTypeBasicMock,
     dotcmsContentTypeFieldBasicMock,
     DotWorkflowServiceMock,
-    MockDotMessageService,
     mockWorkflows,
     mockWorkflowsActions
 } from '@dotcms/utils-testing';
 
 import { ContentTypesFormComponent } from './content-types-form.component';
+import {
+    createContentTypesFormMessageServiceMock,
+    MockDotLicenseService
+} from './content-types-form.testing';
 
 import { DotWorkflowsActionsSelectorFieldService } from '../../../../../view/components/_common/dot-workflows-actions-selector-field/services/dot-workflows-actions-selector-field.service';
 
-@Injectable()
-class MockDotLicenseService {
-    isEnterprise(): Observable<boolean> {
-        return of(false);
-    }
-}
-
-const messageServiceMock = new MockDotMessageService({
-    'contenttypes.form.field.detail.page': 'Detail Page',
-    'contenttypes.form.field.expire.date.field': 'Expire Date Field',
-    'contenttypes.form.field.host_folder.label': 'Host or Folder',
-    'contenttypes.form.identifier': 'Identifier',
-    'contenttypes.form.label.publish.date.field': 'Publish Date Field',
-    'contenttypes.hint.URL.map.pattern.hint1': 'Hello World',
-    'contenttypes.form.label.URL.pattern': 'URL Pattern',
-    'contenttypes.content.variable': 'Variable',
-    'contenttypes.form.label.workflow': 'Workflow',
-    'contenttypes.action.cancel': 'Cancel',
-    'contenttypes.form.label.description': 'Description',
-    'contenttypes.form.name': 'Name',
-    'contenttypes.action.save': 'Save',
-    'contenttypes.action.update': 'Update',
-    'contenttypes.action.create': 'Create',
-    'contenttypes.action.edit': 'Edit',
-    'contenttypes.action.delete': 'Delete',
-    'contenttypes.form.name.error.required': 'Error is wrong',
-    'contenttypes.action.form.cancel': 'Cancel',
-    'contenttypes.content.contenttype': 'content type',
-    'contenttypes.content.fileasset': 'fileasset',
-    'contenttypes.content.content': 'Content',
-    'contenttypes.content.form': 'Form',
-    'contenttypes.content.persona': 'Persona',
-    'contenttypes.content.widget': 'Widget',
-    'contenttypes.content.htmlpage': 'Page',
-    'contenttypes.content.key_value': 'Key Value',
-    'contenttypes.content.vanity_url:': 'Vanity Url'
-});
+const messageServiceMock = createContentTypesFormMessageServiceMock();
 
 const mockActivatedRoute = {
     snapshot: {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.spec.ts
@@ -3,7 +3,7 @@ import { Observable, of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { Injectable } from '@angular/core';
+import { ApplicationRef, Injectable } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
@@ -204,7 +204,23 @@ describe('ContentTypesFormComponent', () => {
             baseType: 'CONTENT'
         });
         spectator.detectChanges();
+        // The focus runs in an afterNextRender hook, which fires on the application tick.
+        spectator.inject(ApplicationRef).tick();
+
         expect(spectator.component.$inputName().nativeElement).toBe(document.activeElement);
+    });
+
+    it('should not focus the name on edit mode', () => {
+        spectator.setInput('contentType', {
+            ...dotcmsContentTypeBasicMock,
+            baseType: 'CONTENT',
+            id: '1234-5678-edit'
+        });
+        spectator.detectChanges();
+        spectator.inject(ApplicationRef).tick();
+
+        // Editing an existing content type must not steal focus into the already-filled Name field.
+        expect(document.activeElement).not.toBe(spectator.component.$inputName().nativeElement);
     });
 
     it('should have canSave property false by default (form is invalid)', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
@@ -4,8 +4,10 @@ import { AsyncPipe } from '@angular/common';
 import {
     Component,
     ElementRef,
+    Injector,
     OnDestroy,
     OnInit,
+    afterNextRender,
     inject,
     input,
     output,
@@ -43,7 +45,6 @@ import {
     FeaturedFlags
 } from '@dotcms/dotcms-models';
 import {
-    DotAutofocusDirective,
     DotFieldRequiredDirective,
     DotFieldValidationMessageComponent,
     DotMessagePipe,
@@ -77,7 +78,6 @@ import { DotFieldHelperComponent } from '../../../../../view/components/dot-fiel
         InputTextModule,
         DotMessagePipe,
         DotFieldRequiredDirective,
-        DotAutofocusDirective,
         DotFieldValidationMessageComponent,
         DotMdIconSelectorComponent,
         DotSiteComponent,
@@ -93,6 +93,7 @@ export class ContentTypesFormComponent implements OnInit, OnDestroy {
     private dotLicenseService = inject(DotLicenseService);
     private dotMessageService = inject(DotMessageService);
     private readonly route = inject(ActivatedRoute);
+    private readonly injector = inject(Injector);
 
     readonly $inputName = viewChild.required<ElementRef>('name');
 
@@ -117,7 +118,20 @@ export class ContentTypesFormComponent implements OnInit, OnDestroy {
         this.bindActionButtonState();
 
         this.nameFieldLabel = this.setNameFieldLabel();
-        this.$inputName().nativeElement.focus();
+
+        // Only when creating: the Name field is the first thing to fill in, so typing should work
+        // without a click. When editing, the content type already has a name and nothing should
+        // grab focus. The dialog hosting this form disables PrimeNG's own focusOnShow, so this is
+        // the single place deciding what gets focused.
+        //
+        // Deferred because the input is not focusable yet while this form is still being rendered
+        // inside the dialog -- a synchronous focus() here is a no-op.
+        if (!this.isEditMode()) {
+            afterNextRender(() => this.$inputName().nativeElement.focus(), {
+                injector: this.injector
+            });
+        }
+
         this.newContentEditorEnabled =
             this.route.snapshot?.data?.featuredFlags[
                 FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
@@ -93,7 +93,7 @@ export class ContentTypesFormComponent implements OnInit, OnDestroy {
     private dotLicenseService = inject(DotLicenseService);
     private dotMessageService = inject(DotMessageService);
     private readonly route = inject(ActivatedRoute);
-    private readonly injector = inject(Injector);
+    readonly #injector = inject(Injector);
 
     readonly $inputName = viewChild.required<ElementRef>('name');
 
@@ -128,7 +128,7 @@ export class ContentTypesFormComponent implements OnInit, OnDestroy {
         // inside the dialog -- a synchronous focus() here is a no-op.
         if (!this.isEditMode()) {
             afterNextRender(() => this.$inputName().nativeElement.focus(), {
-                injector: this.injector
+                injector: this.#injector
             });
         }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.testing.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.testing.ts
@@ -1,0 +1,72 @@
+import { Observable, of } from 'rxjs';
+
+import { Injectable } from '@angular/core';
+
+import { FeaturedFlags } from '@dotcms/dotcms-models';
+import { MockDotMessageService } from '@dotcms/utils-testing';
+
+/**
+ * Shared test doubles for the content types form specs.
+ *
+ * `content-types-form.component.spec.ts` and
+ * `content-types-form-dialog-focus.integration.spec.ts` both drive the same component and were
+ * duplicating these verbatim. Test-only: nothing here is reachable from `src/main.ts`, so it never
+ * reaches the app bundle.
+ */
+@Injectable()
+export class MockDotLicenseService {
+    isEnterprise(): Observable<boolean> {
+        return of(false);
+    }
+}
+
+/** Union of the labels both specs need. */
+export const CONTENT_TYPES_FORM_MESSAGES = {
+    'contenttypes.action.cancel': 'Cancel',
+    'contenttypes.action.create': 'Create',
+    'contenttypes.action.delete': 'Delete',
+    'contenttypes.action.edit': 'Edit',
+    'contenttypes.action.form.cancel': 'Cancel',
+    'contenttypes.action.save': 'Save',
+    'contenttypes.action.update': 'Update',
+    'contenttypes.content.content': 'Content',
+    'contenttypes.content.contenttype': 'content type',
+    'contenttypes.content.fileasset': 'fileasset',
+    'contenttypes.content.form': 'Form',
+    'contenttypes.content.htmlpage': 'Page',
+    'contenttypes.content.key_value': 'Key Value',
+    'contenttypes.content.persona': 'Persona',
+    'contenttypes.content.vanity_url:': 'Vanity Url',
+    'contenttypes.content.variable': 'Variable',
+    'contenttypes.content.widget': 'Widget',
+    'contenttypes.form.field.detail.page': 'Detail Page',
+    'contenttypes.form.field.expire.date.field': 'Expire Date Field',
+    'contenttypes.form.field.host_folder.label': 'Host or Folder',
+    'contenttypes.form.identifier': 'Identifier',
+    'contenttypes.form.label.URL.pattern': 'URL Pattern',
+    'contenttypes.form.label.description': 'Description',
+    'contenttypes.form.label.icon': 'Icon',
+    'contenttypes.form.label.publish.date.field': 'Publish Date Field',
+    'contenttypes.form.label.workflow': 'Workflow',
+    'contenttypes.form.label.workflow.actions': 'Workflow Actions',
+    'contenttypes.form.name': 'Name',
+    'contenttypes.form.name.error.required': 'Error is wrong',
+    'contenttypes.hint.URL.map.pattern.hint1': 'Hello World',
+    'content.type.form.banner.message': 'Try the new content editor'
+};
+
+export const createContentTypesFormMessageServiceMock = (): MockDotMessageService =>
+    new MockDotMessageService(CONTENT_TYPES_FORM_MESSAGES);
+
+/**
+ * Fresh `ActivatedRoute` stub per call, so specs never share mutable feature-flag state.
+ */
+export const buildActivatedRouteMock = (newContentEditorEnabled = true) => ({
+    snapshot: {
+        data: {
+            featuredFlags: {
+                [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: newContentEditorEnabled
+            }
+        }
+    }
+});

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
@@ -22,6 +22,7 @@
     [header]="templateInfo.header"
     [modal]="true"
     [closable]="dialogCloseable"
+    [focusOnShow]="dialogFocusOnShow"
     [style]="{ width: '50rem' }"
     (visibleChange)="show.set($event)"
     (onHide)="onDialogHide()">

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -284,8 +284,10 @@ describe('DotContentTypesEditComponent', () => {
             // The real focus outcome is asserted in
             // content-types-form-dialog-focus.integration.spec.ts.
             expect(dialog.componentInstance.focusOnShow).toBe(false);
-            expect(dialog.componentInstance.focusTrap).toBe(true);
             expect(dialog.componentInstance.closable).toBe(false);
+            // focusTrap is never bound by us -- this asserts PrimeNG's default as a tripwire, so
+            // disabling focusOnShow can never be mistaken for disabling the trap too.
+            expect(dialog.componentInstance.focusTrap).toBe(true);
         });
 
         describe('create', () => {
@@ -606,8 +608,9 @@ describe('DotContentTypesEditComponent', () => {
             // Same reason as create mode: PrimeNG would steal focus from the Name input after the
             // open transition. focusTrap is an independent input and stays enabled.
             expect(dialog.componentInstance.focusOnShow).toBe(false);
-            expect(dialog.componentInstance.focusTrap).toBe(true);
             expect(dialog.componentInstance.closable).toBe(true);
+            // See the create-mode counterpart: asserting PrimeNG's own focusTrap default.
+            expect(dialog.componentInstance.focusTrap).toBe(true);
         });
 
         it('should send notifications to add rows & tab divider', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -281,7 +281,8 @@ describe('DotContentTypesEditComponent', () => {
         it('should disable the dialog focusOnShow while leaving focus trap and closable alone', () => {
             // PrimeNG focuses the first focusable element in DOM order once the open transition
             // ends, which would steal focus from the Name input. See dialogFocusOnShow.
-            // The real focus outcome is asserted in content-types-form-dialog-focus.spec.ts.
+            // The real focus outcome is asserted in
+            // content-types-form-dialog-focus.integration.spec.ts.
             expect(dialog.componentInstance.focusOnShow).toBe(false);
             expect(dialog.componentInstance.focusTrap).toBe(true);
             expect(dialog.componentInstance.closable).toBe(false);

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -278,6 +278,15 @@ describe('DotContentTypesEditComponent', () => {
             expect(comp.templateInfo.header).toEqual('Create Content');
         });
 
+        it('should disable the dialog focusOnShow while leaving focus trap and closable alone', () => {
+            // PrimeNG focuses the first focusable element in DOM order once the open transition
+            // ends, which would steal focus from the Name input. See dialogFocusOnShow.
+            // The real focus outcome is asserted in content-types-form-dialog-focus.spec.ts.
+            expect(dialog.componentInstance.focusOnShow).toBe(false);
+            expect(dialog.componentInstance.focusTrap).toBe(true);
+            expect(dialog.componentInstance.closable).toBe(false);
+        });
+
         describe('create', () => {
             let mockContentType: DotCMSContentType;
             let contentTypeForm: DebugElement;
@@ -588,6 +597,14 @@ describe('DotContentTypesEditComponent', () => {
 
             expect(dialog).not.toBeNull();
             expect(comp.show()).toBeTruthy();
+        });
+
+        it('should keep the PrimeNG dialog focus defaults untouched in edit mode', () => {
+            clickEditButton();
+
+            expect(dialog.componentInstance.focusOnShow).toBe(true);
+            expect(dialog.componentInstance.focusTrap).toBe(true);
+            expect(dialog.componentInstance.closable).toBe(true);
         });
 
         it('should send notifications to add rows & tab divider', () => {
@@ -1042,6 +1059,9 @@ describe('DotContentTypesEditComponent', () => {
                 tick();
 
                 expect(comp.startFormDialog).toHaveBeenCalled();
+                // Opening via query param must not change focus behavior either: the flag is
+                // resolved once from the edit/create mode, not from which trigger opened it.
+                expect(comp.dialogFocusOnShow).toBe(true);
             }));
 
             it('should not open form dialog when open-config is false', (done) => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -599,10 +599,12 @@ describe('DotContentTypesEditComponent', () => {
             expect(comp.show()).toBeTruthy();
         });
 
-        it('should keep the PrimeNG dialog focus defaults untouched in edit mode', () => {
+        it('should disable the dialog focusOnShow while leaving focus trap and closable alone', () => {
             clickEditButton();
 
-            expect(dialog.componentInstance.focusOnShow).toBe(true);
+            // Same reason as create mode: PrimeNG would steal focus from the Name input after the
+            // open transition. focusTrap is an independent input and stays enabled.
+            expect(dialog.componentInstance.focusOnShow).toBe(false);
             expect(dialog.componentInstance.focusTrap).toBe(true);
             expect(dialog.componentInstance.closable).toBe(true);
         });
@@ -1059,9 +1061,8 @@ describe('DotContentTypesEditComponent', () => {
                 tick();
 
                 expect(comp.startFormDialog).toHaveBeenCalled();
-                // Opening via query param must not change focus behavior either: the flag is
-                // resolved once from the edit/create mode, not from which trigger opened it.
-                expect(comp.dialogFocusOnShow).toBe(true);
+                // Opening via query param gets the same focus handling as every other trigger.
+                expect(comp.dialogFocusOnShow).toBe(false);
             }));
 
             it('should not open form dialog when open-config is false', (done) => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
@@ -60,8 +60,8 @@ export class DotContentTypesEditComponent implements OnInit {
     /**
      * Turns off PrimeNG's `p-dialog` `focusOnShow`. PrimeNG focuses the first focusable element in
      * DOM order once the open transition ends (~150ms), which lands on the new-content-editor
-     * banner checkbox and overrides the `dotAutofocus` on the Name input. Disabling it lets the
-     * form's own focus land and stay, instead of competing with a vendor timer.
+     * banner checkbox and overrode the form's own focus on the Name input. With this off, the form
+     * decides what gets focused: the Name input when creating, nothing when editing.
      */
     readonly dialogFocusOnShow = false;
     data: DotCMSContentType;

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
@@ -58,12 +58,12 @@ export class DotContentTypesEditComponent implements OnInit {
     contentTypeActions: MenuItem[];
     dialogCloseable = false;
     /**
-     * Controls PrimeNG's `p-dialog` `focusOnShow`. Disabled in create mode because PrimeNG focuses
-     * the first focusable element in DOM order after the open transition (~150ms), which lands on
-     * the new-content-editor banner checkbox and overrides the `dotAutofocus` on the Name input.
-     * Edit mode keeps the PrimeNG default (`true`).
+     * Turns off PrimeNG's `p-dialog` `focusOnShow`. PrimeNG focuses the first focusable element in
+     * DOM order once the open transition ends (~150ms), which lands on the new-content-editor
+     * banner checkbox and overrides the `dotAutofocus` on the Name input. Disabling it lets the
+     * form's own focus land and stay, instead of competing with a vendor timer.
      */
-    dialogFocusOnShow = true;
+    readonly dialogFocusOnShow = false;
     data: DotCMSContentType;
     dialogActions: DotDialogActions;
     layout: DotCMSContentTypeLayoutRow[];
@@ -111,7 +111,6 @@ export class DotContentTypesEditComponent implements OnInit {
         ];
 
         this.dialogCloseable = this.isEditMode();
-        this.dialogFocusOnShow = this.isEditMode();
         this.setTemplateInfo();
     }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
@@ -57,6 +57,13 @@ export class DotContentTypesEditComponent implements OnInit {
 
     contentTypeActions: MenuItem[];
     dialogCloseable = false;
+    /**
+     * Controls PrimeNG's `p-dialog` `focusOnShow`. Disabled in create mode because PrimeNG focuses
+     * the first focusable element in DOM order after the open transition (~150ms), which lands on
+     * the new-content-editor banner checkbox and overrides the `dotAutofocus` on the Name input.
+     * Edit mode keeps the PrimeNG default (`true`).
+     */
+    dialogFocusOnShow = true;
     data: DotCMSContentType;
     dialogActions: DotDialogActions;
     layout: DotCMSContentTypeLayoutRow[];
@@ -104,6 +111,7 @@ export class DotContentTypesEditComponent implements OnInit {
         ];
 
         this.dialogCloseable = this.isEditMode();
+        this.dialogFocusOnShow = this.isEditMode();
         this.setTemplateInfo();
     }
 


### PR DESCRIPTION
## Summary

Opening the Content Type dialog put initial focus on the new-content-editor banner checkbox instead of the Name input, so you had to click before typing. This affected both the create and the edit dialog.

| Dialog | Before | After |
|---|---|---|
| Create (`create/:type`) | Focus jumped to the banner checkbox | Focus stays in the Name input |
| Edit (`edit/:id`) | Focus jumped to the banner checkbox | Nothing is focused |

The Name input already declared the intent to be focused — `dotAutofocus` on the input plus a `.focus()` in the form's `ngOnInit`, neither gated by mode — and both were undone afterwards by PrimeNG's `p-dialog`:

- `focusOnShow` defaults to `true`, and `onAfterEnter()` schedules `getFocusableElements(content)[0].focus()` using the transition duration (~150ms), which outlives `dotAutofocus`'s 100ms timeout.
- `getFocusableElements` walks the DOM in document order and ignores the `[tabindex]="1"` on the Name input, so the DOM-first banner checkbox won.

The visible symptom was the caret and focus ring appearing on the Name input and then jumping away.

Closes #36816

## Approach

1. **Disable `focusOnShow`** on the `p-dialog`, in both modes, so PrimeNG stops competing for the initial focus. There is no timer race to win — the competitor is removed.
2. **Make the form's focus mode-aware.** Its two mechanisms were both mode-blind: the `dotAutofocus` directive and the `ngOnInit` `.focus()`. A directive cannot be applied conditionally through a binding, so both are replaced by one call in the component, leaving a single place that decides what gets focused.
3. **Defer that call with `afterNextRender`,** because the input is not focusable while the form is still rendering inside the dialog.

Two things found along the way, both worth knowing:

- The synchronous `.focus()` in `ngOnInit` was **dead code**. Removing `dotAutofocus` made the create-mode tests fail, which proved the directive's `setTimeout` was what actually landed the focus all along.
- Edit mode had the same defect from the same cause, and it **predates this branch**: on `main` the `p-dialog` bound no `focusOnShow` at all, so PrimeNG's default of `true` applied to both modes. The issue was originally scoped to create only; since the cause and the fix are the same lever, it is resolved in both rather than leaving a known defect behind a mode guard.

`focusTrap` is deliberately left unbound — it is an independent code path (`[pFocusTrapDisabled]="focusTrap === false"`), so the dialog keeps trapping Tab. `closable` is untouched and still differs by mode as before.

## Changes

| File | Change |
|---|---|
| `dot-content-types-edit.component.ts` | `readonly dialogFocusOnShow = false`, with JSDoc explaining the PrimeNG race so the binding doesn't read as stray. |
| `dot-content-types-edit.component.html` | `[focusOnShow]="dialogFocusOnShow"` on the `p-dialog`. |
| `content-types-form.component.ts` | Focus the Name input from `afterNextRender`, only when not in edit mode. |
| `content-types-form.component.html` | `dotAutofocus` removed from the Name input; the component now owns the decision. |
| `dot-content-types-edit.component.spec.ts` | `focusOnShow` disabled asserted in both modes, `focusTrap`/`closable` pinned unchanged, `?open-config=true` covered. |
| `content-types-form.component.spec.ts` | Create-mode focus test driven through the render hook; new edit-mode no-focus test. |
| `content-types-form-dialog-focus.spec.ts` (new) | Real form inside a real `p-dialog`, asserting actual `document.activeElement` for create and edit, plus a reproduction of the original defect. |

## Acceptance criteria

- [x] **AC1** — Focus lands on `#content-type-form-name` when the create dialog opens. Asserted against real DOM focus. Both cited routes resolve to the same component, so coverage is component-level rather than per-URL.
- [x] **AC2** — Typing fills the Name field. Covered by a synthetic `input` event on the focused element; see manual verification for the real-keystroke path.
- [x] **AC3** — Holds with `CONTENT_EDITOR2_ENABLED` both `true` (banner visible) and `false`.
- [x] **AC4** — The banner checkbox does not receive initial focus, and its control value is unchanged after typing.
- [x] **AC5** — Parametrized over `CONTENT` and `WIDGET` for real focus.
- [x] **AC6** — Opening the edit dialog focuses nothing. Covered for both entry points, the layout gear and `?open-config=true`.
- [x] **AC7** — `focusTrap` and `closable` asserted unchanged in both modes. ESC-to-close and Tab order are untouched by construction (no test asserts them; see manual verification).
- [x] **AC8** — Create focus, edit no-focus, and the defect reproduction all have tests.

## Test plan

```
pnpm nx affected:lint --base=origin/main    # 3 projects, clean
pnpm nx affected:test --base=origin/main    # dotcms-ui 2177 passed / portlets-dot-publishing-queue-portlet 235 passed
```

New spec: 7/7. `dot-content-types-edit.component.spec.ts`: 48/48. `content-types-form.component.spec.ts`: 35/35.

**Mutation-checked twice.** Reverting the dialog binding makes the create-mode and `?open-config=true` assertions fail; reverting the form change makes the edit-mode no-focus assertions fail. The tests gate both halves of the behavior rather than passing regardless — worth noting because the original `'should have name focus by default on create mode'` test passed either way, since it never rendered a `p-dialog`.

Two jsdom constraints the new spec works around, both commented in place:

- jsdom never fires a CSS transition end, so PrimeNG's `onAfterEnter()` is invoked directly instead of awaited. `afterNextRender` hooks are driven with `ApplicationRef.tick()`, which runs them synchronously and so coexists with the fake timers needed to control PrimeNG's own timer.
- jsdom has no layout engine, so PrimeNG's `isVisible`/`offsetParent` check would make its `focus()` a no-op and the race under test would never happen. The spec shims `HTMLElement.prototype.offsetParent` in `beforeAll` and restores it in `afterAll`. This is load-bearing for the assertions' validity, not incidental setup. It cannot leak across files: Jest builds a fresh jsdom realm per test file.

## Manual verification

Confirmed working in the running app for both modes. Steps, including what unit tests cannot reach:

**Create**

1. Go to `/dotAdmin/#/content-types-angular/create/content/fields` — the caret must be in Content Name, with no visible jump to the banner checkbox.
2. Type without clicking anywhere; the text must land in Content Name (the real-keystroke path behind AC2).
3. Repeat with `CONTENT_EDITOR2_ENABLED=false` (AC3).
4. Repeat on `create/widget` (AC5 in a real browser).

**Edit**

5. Open an existing content type, then open the dialog from the layout gear — nothing must be focused.
6. Same via `?open-config=true`.

**Both**

7. ESC still closes the dialog and Tab still cycles inside it (AC7).

This PR fixes: #36816