### PR TITLE
feat(ai): add embeddings support to OpenRouter provider

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/LangChain4jModelFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/LangChain4jModelFactory.java
@@ -15,7 +15,8 @@ import java.util.List;
  * and add an instance to {@link #STRATEGIES}. No other class needs to change.
  *
  * <p>Supported providers: {@code openai}, {@code azure_openai}, {@code bedrock}, {@code vertex_ai}, {@code anthropic}, {@code openrouter}, {@code google_ai}
- * <p>Note: {@code vertex_ai}, {@code anthropic}, and {@code openrouter} support chat only; {@code google_ai} supports chat, embeddings and image.
+ * <p>Note: {@code vertex_ai} and {@code anthropic} support chat only; {@code openrouter} supports chat and
+ * embeddings; {@code google_ai} supports chat, embeddings and image.
  */
 public class LangChain4jModelFactory {
 

--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/OpenRouterModelProviderStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/OpenRouterModelProviderStrategy.java
@@ -6,6 +6,7 @@ import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.image.ImageModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 
 import java.time.Duration;
@@ -21,8 +22,8 @@ import java.time.Duration;
  * <p>Model IDs use the OpenRouter namespaced form, e.g. {@code openai/gpt-4o},
  * {@code anthropic/claude-sonnet-4}, {@code deepseek/deepseek-r1}.
  *
- * <p>Supports chat (streaming and non-streaming) only. OpenRouter does not offer
- * embeddings or image-generation endpoints.
+ * <p>Supports chat (streaming and non-streaming) and embeddings. Image generation is
+ * not supported: OpenRouter's {@code /api/v1/images} endpoint is not OpenAI-shaped.
  */
 class OpenRouterModelProviderStrategy implements ModelProviderStrategy {
 
@@ -55,7 +56,7 @@ class OpenRouterModelProviderStrategy implements ModelProviderStrategy {
                 .modelName(config.model())
                 .baseUrl(baseUrl(config));
         if (config.maxRetries() != null) {
-            Logger.warn(OpenRouterModelProviderStrategy.class,
+            Logger.debug(OpenRouterModelProviderStrategy.class,
                     "maxRetries is not supported by the OpenRouter streaming chat model and will be ignored");
         }
         if (config.temperature() != null) { builder.temperature(config.temperature()); }
@@ -66,14 +67,22 @@ class OpenRouterModelProviderStrategy implements ModelProviderStrategy {
 
     @Override
     public EmbeddingModel buildEmbeddingModel(final ProviderConfig config, final String modelType) {
-        throw new UnsupportedOperationException(
-                "Embeddings are not supported by OpenRouter (no embeddings endpoint)");
+        validate(config, modelType);
+        final OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder builder = OpenAiEmbeddingModel.builder()
+                .apiKey(config.apiKey())
+                .modelName(config.model())
+                .baseUrl(baseUrl(config));
+        if (config.dimensions() != null) { builder.dimensions(config.dimensions()); }
+        if (config.maxRetries() != null) { builder.maxRetries(config.maxRetries()); }
+        if (config.timeout() != null) { builder.timeout(Duration.ofSeconds(config.timeout())); }
+        return builder.build();
     }
 
     @Override
     public ImageModel buildImageModel(final ProviderConfig config, final String modelType) {
         throw new UnsupportedOperationException(
-                "Image generation is not supported by OpenRouter via LangChain4J");
+                "OpenRouter image generation is not supported: the /api/v1/images endpoint "
+                + "is not OpenAI-shaped and cannot be driven by OpenAiImageModel.");
     }
 
     private void validate(final ProviderConfig config, final String modelType) {

--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/ProviderConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/ProviderConfig.java
@@ -60,10 +60,12 @@ import java.util.List;
  *   <li>{@code endpoint} – optional base URL override (proxies/gateways)</li>
  * </ul>
  *
- * <p>OpenRouter (chat only — OpenRouter has no embeddings or image endpoints):
+ * <p>OpenRouter (chat and embeddings; image not supported):
  * <ul>
  *   <li>{@code apiKey} – OpenRouter API key</li>
- *   <li>{@code model} – namespaced model ID, e.g. {@code openai/gpt-4o}, {@code anthropic/claude-sonnet-4}</li>
+ *   <li>{@code model} – namespaced model ID, e.g. {@code openai/gpt-4o}, {@code anthropic/claude-sonnet-4},
+ *       {@code openai/text-embedding-3-small}</li>
+ *   <li>{@code dimensions} – embedding vector size (embeddings only)</li>
  *   <li>{@code endpoint} – optional override of the default base URL ({@code https://openrouter.ai/api/v1})</li>
  * </ul>
  *

--- a/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/LangChain4jModelFactoryTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/LangChain4jModelFactoryTest.java
@@ -728,14 +728,57 @@ public class LangChain4jModelFactoryTest {
     }
 
     /**
-     * Given an OpenRouter config,
+     * Given a valid OpenRouter config,
      * When buildEmbeddingModel is called,
-     * Then an UnsupportedOperationException is thrown since OpenRouter has no embeddings endpoint.
+     * Then an EmbeddingModel is returned successfully.
      */
     @Test
-    public void test_buildEmbeddingModel_openRouter_throws() {
-        assertThrows(UnsupportedOperationException.class,
-                () -> LangChain4jModelFactory.buildEmbeddingModel(openRouterConfig("openai/text-embedding-3-small")));
+    public void test_buildEmbeddingModel_openRouter_returnsModel() {
+        final EmbeddingModel model =
+                LangChain4jModelFactory.buildEmbeddingModel(openRouterConfig("openai/text-embedding-3-small"));
+        assertNotNull(model);
+    }
+
+    /**
+     * Given an OpenRouter embeddings config with a custom endpoint override,
+     * When buildEmbeddingModel is called,
+     * Then an EmbeddingModel is returned successfully.
+     */
+    @Test
+    public void test_buildEmbeddingModel_openRouter_customEndpoint_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .from(openRouterConfig("openai/text-embedding-3-small"))
+                .endpoint("https://custom.example.com/v1")
+                .build();
+        assertNotNull(LangChain4jModelFactory.buildEmbeddingModel(config));
+    }
+
+    /**
+     * Given an OpenRouter embeddings config without an apiKey,
+     * When buildEmbeddingModel is called,
+     * Then an IllegalArgumentException is thrown.
+     */
+    @Test
+    public void test_buildEmbeddingModel_openRouter_missingApiKey_throws() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("openrouter")
+                .model("openai/text-embedding-3-small")
+                .build();
+        assertThrows(IllegalArgumentException.class, () -> LangChain4jModelFactory.buildEmbeddingModel(config));
+    }
+
+    /**
+     * Given an OpenRouter embeddings config without a model,
+     * When buildEmbeddingModel is called,
+     * Then an IllegalArgumentException is thrown.
+     */
+    @Test
+    public void test_buildEmbeddingModel_openRouter_missingModel_throws() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("openrouter")
+                .apiKey("test-key")
+                .build();
+        assertThrows(IllegalArgumentException.class, () -> LangChain4jModelFactory.buildEmbeddingModel(config));
     }
 
     /**


### PR DESCRIPTION
## Summary
- Implement `buildEmbeddingModel()` in `OpenRouterModelProviderStrategy` using `OpenAiEmbeddingModel` pointed at OpenRouter's OpenAI-compatible `/api/v1/embeddings` endpoint
- Drop `maxRetries` unsupported log from `WARN` to `DEBUG` in the streaming chat model builder
- Update `buildImageModel()` exception message to clarify it's a shape mismatch (not a missing endpoint)
- Update javadoc in `OpenRouterModelProviderStrategy`, `ProviderConfig`, and `LangChain4jModelFactory` to drop "chat only" for OpenRouter

Closes #36808

## Test plan
- [x] Replaced `test_buildEmbeddingModel_openRouter_throws` with `test_buildEmbeddingModel_openRouter_returnsModel`
- [x] Added `test_buildEmbeddingModel_openRouter_customEndpoint_returnsModel`
- [x] Added `test_buildEmbeddingModel_openRouter_missingApiKey_throws` and `test_buildEmbeddingModel_openRouter_missingModel_throws`
- [x] `LangChain4jModelFactoryTest` passes locally (70/70)
- [x] Core module compiles cleanly

This PR fixes: #36808