### PR TITLE
fix(content-import): key fields not matched on multilingual CSV import

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessor.java
+++ b/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessor.java
@@ -435,6 +435,7 @@ public class ImportContentletsProcessor implements JobProcessor, Validator, Canc
                 .csvReader(csvReader)
                 .languageCodeHeaderColumn(headerInfo.languageCodeColumn)
                 .countryCodeHeaderColumn(headerInfo.countryCodeColumn)
+                .isMultilingual(headerInfo.languageCodeColumn != -1)
                 .workflowActionId(workflowActionId)
                 .fileTotalLines(fileTotalLines)
                 .request(httpReq)

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -2988,9 +2988,9 @@ public class ImportUtil {
                         .append(field.isUnique() ? ESUtils.sha256(contentType.getVelocityVarName()
                                         + StringPool.PERIOD + field.getVelocityVarName(), processedValue,
                                 language)
-                                : escapeLuceneSpecialCharacter(processedValue).contains(" ") ? "\""
-                                        + escapeLuceneSpecialCharacter(processedValue) + "\""
-                                        : escapeLuceneSpecialCharacter(processedValue));
+                                : escapeLuceneSpecialCharacter(processedValue.toLowerCase()).contains(" ") ? "\""
+                                        + escapeLuceneSpecialCharacter(processedValue.toLowerCase()) + "\""
+                                        : escapeLuceneSpecialCharacter(processedValue.toLowerCase()));
             }
 
             conditionValues.append(processedValue).append("-");

--- a/dotcms-integration/src/test/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessorIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessorIntegrationTest.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.jboss.weld.junit5.EnableWeld;
 import org.junit.jupiter.api.Assertions;
@@ -971,6 +973,97 @@ public class ImportContentletsProcessorIntegrationTest extends com.dotcms.Junit5
                 APILocator.getContentTypeAPI(systemUser).delete(testContentType);
             }
         }
+    }
+
+    /**
+     * Regression test for issue #35790.
+     * <p>
+     * Scenario: A multilingual CSV without an {@code identifier} column is imported using a
+     * mixed-case key field. The CSV carries {@code languageCode}/{@code countryCode} columns and
+     * French/Spanish rows for content that already exists in English.
+     * <p>
+     * Expected: The French and Spanish rows are recognised as language versions of the existing
+     * English contentlet (same identifier), not as brand-new content (different identifier).
+     * <p>
+     * Two bugs are covered:
+     * <ol>
+     *   <li>{@code isMultilingual} was never set in the {@code ImmutableImportFileParams} builder,
+     *       so {@code languageCode}/{@code countryCode} headers were treated as invalid and a
+     *       per-row {@code +languageId:X} constraint was added to the ES key-field query, making
+     *       cross-language matching impossible.</li>
+     *   <li>The {@code _dotraw} keyword query used the original-case CSV value; ES stores values
+     *       lowercased, causing a guaranteed miss for any mixed-case key value.</li>
+     * </ol>
+     *
+     * @throws Exception if there is an error during test execution
+     */
+    @Test
+    void test_multilingual_import_without_identifier_reuses_existing_identifier_via_key_field()
+            throws Exception {
+
+        ContentType testContentType = null;
+
+        try {
+            final var processor = new ImportContentletsProcessor();
+            testContentType = createTestContentType();
+
+            // Step 1: publish one English row — establishes the base contentlet
+            final File englishCsv = createCsvFile("title,body\nMixedCaseTitle,BodyEN\n");
+            final var englishJob = createTestJob(
+                    englishCsv, "publish", "en-US", testContentType.id(),
+                    WORKFLOW_PUBLISH_ACTION_ID, List.of("title")
+            );
+            processor.process(englishJob);
+
+            final List<Contentlet> afterEnglish = findImportedContent(testContentType.id());
+            assertEquals(1, afterEnglish.size(),
+                    "English import should create exactly one contentlet");
+            final String expectedIdentifier = afterEnglish.get(0).getIdentifier();
+
+            // Step 2: import French and Spanish rows via a multilingual CSV.
+            // No identifier column, mixed-case key value, no language parameter on the job.
+            final File multilingualCsv = createCsvFile(
+                    "languageCode,countryCode,title,body\n"
+                            + "fr,FR,MixedCaseTitle,BodyFR\n"
+                            + "es,ES,MixedCaseTitle,BodyES\n"
+            );
+            final var multilingualJob = createTestJob(
+                    multilingualCsv, "publish", null, testContentType.id(),
+                    WORKFLOW_PUBLISH_ACTION_ID, List.of("title")
+            );
+            processor.process(multilingualJob);
+
+            // Step 3: every language version must share the original English identifier.
+            // Before the fix, the French row created a brand-new identifier instead.
+            final List<Contentlet> allVersions = findImportedContent(testContentType.id());
+            final Set<String> distinctIdentifiers = allVersions.stream()
+                    .map(Contentlet::getIdentifier)
+                    .collect(Collectors.toSet());
+
+            assertEquals(1, distinctIdentifiers.size(),
+                    "All language versions (en/fr/es) must share exactly one identifier; "
+                            + "found " + distinctIdentifiers.size() + ": " + distinctIdentifiers);
+            assertEquals(expectedIdentifier, distinctIdentifiers.iterator().next(),
+                    "The single identifier must be the one established by the English import");
+
+        } finally {
+            if (testContentType != null) {
+                APILocator.getContentTypeAPI(systemUser).delete(testContentType);
+            }
+        }
+    }
+
+    /**
+     * Creates a temporary CSV file with the given content string.
+     *
+     * @param content the full CSV content, including the header row
+     * @return a temporary {@link File} containing the CSV data
+     * @throws IOException if there is an error creating or writing to the file
+     */
+    private File createCsvFile(final String content) throws IOException {
+        final File csvFile = File.createTempFile("test", ".csv");
+        Files.write(csvFile.toPath(), content.getBytes());
+        return csvFile;
     }
 
     /**


### PR DESCRIPTION
## Problem

When importing a multilingual CSV file without an \`identifier\` column, key fields are not used to match existing content. French and Spanish language versions create brand-new contentlets (new identifiers) instead of adding language versions to the existing English contentlet.

Closes #35790

## Root Cause

Two bugs compound to cause the failure.

**Bug 1 — \`isMultilingual\` never set in the job processor (\`ImportContentletsProcessor.java\`)**

The \`ImmutableImportFileParams\` builder sets \`.languageCodeHeaderColumn()\` and \`.countryCodeHeaderColumn()\` correctly, but never calls \`.isMultilingual(true)\`. The field defaults to \`false\`, which causes:
- \`languageCode\`/\`countryCode\` columns flagged as **invalid headers** (not recognized as special headers)
- The key-field ES search appends \`+languageId:<row_lang>\` — limiting matches to the exact target language, which doesn't exist yet → always returns 0 results → always creates a new contentlet

**Bug 2 — \`_dotraw\` query uses original-case value; ES stores lowercase (\`ImportUtil.java\`)**

\`ESMappingAPIImpl\` lowercases all string values before indexing into \`_dotraw\` fields. Since \`_dotraw\` maps to a keyword field (case-sensitive exact match), a query using the original CSV value (e.g. \`BugTest35790Alpha\`) never matches the stored lowercase value (\`bugtest35790alpha\`).

## Fix

**\`ImportContentletsProcessor.java\`** — derive \`isMultilingual\` from the already-detected header column index (mirrors the existing sentinel convention used throughout the file):
```java
.isMultilingual(headerInfo.languageCodeColumn != -1)
```

**\`ImportUtil.java\`** — lowercase the value before building the \`_dotraw\` query:
```java
escapeLuceneSpecialCharacter(processedValue.toLowerCase())
```

## Verification

Manually tested against a live dotCMS instance on port 8082:

1. Imported English content (\`title=BugTest35790Alpha\`) → identifier \`aff84090...\`
2. Imported multilingual CSV (fr/FR + es/ES rows, no identifier column, \`title\` as key field)
3. **Before fix:** \`languageCode\`/\`countryCode\` shown as invalid headers; French row created new identifier \`f5747876...\`; Spanish row used DB fallback (accident) to reuse English identifier
4. **After fix:** \`languageCode\`/\`countryCode\` recognized as special headers; both language versions correctly map to the existing English identifier

## Test

New regression test added to \`ImportContentletsProcessorIntegrationTest\`:

\`test_multilingual_import_without_identifier_reuses_existing_identifier_via_key_field\`

- Imports one English row with a mixed-case key field value
- Imports French and Spanish rows via multilingual CSV (no identifier column, no language param)
- Asserts all three language versions share exactly one identifier (the English one)
- Fails deterministically if either bug re-emerges

```bash
./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=ImportContentletsProcessorIntegrationTest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35790