### PR TITLE
#36794: feat(users): extend /api/v1/users/filter with userId search and role filter

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/business/LazyUserAPIWrapper.java
+++ b/dotCMS/src/main/java/com/dotcms/business/LazyUserAPIWrapper.java
@@ -94,6 +94,12 @@ public class LazyUserAPIWrapper implements UserAPI {
     }
 
     @Override
+    public long getCountUsersByName(final String filter, final List<Role> roles,
+                                    final UserAPI.FilteringParams filteringParams) throws DotDataException {
+        return getUserAPI().getCountUsersByName(filter, roles, filteringParams);
+    }
+
+    @Override
     public User createUser(String userId, String email) throws DotDataException, DuplicateUserException {
         return this.getUserAPI().createUser(userId, email);
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
@@ -382,6 +382,7 @@ public class UserResource implements Serializable {
 	 * 		<li>{@code per_page}</li>
 	 * 		<li>{@code includeAnonymous}</li>
 	 * 		<li>{@code includeDefault}</li>
+	 * 		<li>{@code roleKey}</li>
 	 * </ul>
 	 * <p>
 	 * Example #1:
@@ -396,7 +397,8 @@ public class UserResource implements Serializable {
 	 *
 	 * @param request          The current instance of the {@link HttpServletRequest}.
 	 * @param response         The current instance of the {@link HttpServletResponse}.
-	 * @param filter           Allows you to filter Users by their full name or parts of it.
+	 * @param filter           Allows you to filter Users by their user ID, first name, last name, email address, or
+	 *                         full name -- or parts of any of them, case-insensitively.
 	 * @param page             The results page or offset, for pagination purposes.
 	 * @param perPage          The size of the results page, for pagination purposes.
 	 * @param orderBy          The column name that will be used to sort the paginated results. For reference, please
@@ -407,6 +409,8 @@ public class UserResource implements Serializable {
 	 * @param assetInode       The Inode of a specific asset, if you're querying Users that have a specific permission
 	 *                         on it.
 	 * @param permission       The permission type that Users may have on the previous asset.
+	 * @param roleKeys         Optional Role keys -- repeatable and/or comma-separated -- that restrict the results to
+	 *                         Users holding any of them, e.g. {@code roleKey=DOTCMS_BACK_END_USER}.
 	 *
 	 * @return A {@link Response} containing the list of dotCMS users that match the filtering criteria.
 	 */
@@ -420,6 +424,9 @@ public class UserResource implements Serializable {
 					description = "Users retrieved successfully",
 					content = @Content(mediaType = "application/json",
 									  schema = @Schema(implementation = ResponseEntityListUserView.class))),
+		@ApiResponse(responseCode = "400",
+					description = "Bad request - a provided roleKey does not match any existing Role",
+					content = @Content(mediaType = "application/json")),
 		@ApiResponse(responseCode = "401",
 					description = "Unauthorized - authentication required",
 					content = @Content(mediaType = "application/json")),
@@ -433,7 +440,7 @@ public class UserResource implements Serializable {
 	@NoCache
 	@Produces({ MediaType.APPLICATION_JSON })
 	public Response filter(@Context final HttpServletRequest request, @Context final HttpServletResponse response,
-						   @Parameter(description = "Filter users by full name or parts of it") @QueryParam(UserPaginator.QUERY_PARAM) final String filter,
+						   @Parameter(description = "Filter users by user ID, first name, last name, email address, or full name -- or parts of any of them") @QueryParam(UserPaginator.QUERY_PARAM) final String filter,
 						   @Parameter(description = "Page number for pagination") @DefaultValue("0") @QueryParam(PaginationUtil.PAGE) final int page,
 						   @Parameter(description = "Number of items per page") @DefaultValue("40") @QueryParam(PaginationUtil.PER_PAGE) final int perPage,
 						   @Parameter(description = "Column name for sorting results") @QueryParam(PaginationUtil.ORDER_BY) String orderBy,
@@ -441,7 +448,8 @@ public class UserResource implements Serializable {
 						   @Parameter(description = "Include anonymous user in results") @QueryParam(UserPaginator.INCLUDE_ANONYMOUS) boolean includeAnonymous,
 						   @Parameter(description = "Include default user in results") @QueryParam(UserPaginator.INCLUDE_DEFAULT) boolean includeDefault,
 						   @Parameter(description = "Asset inode for permission-based filtering") @QueryParam(UserPaginator.ASSET_INODE_PARAM) String assetInode,
-						   @Parameter(description = "Permission type for asset-based filtering") @QueryParam(UserPaginator.PERMISSION_PARAM) int permission) {
+						   @Parameter(description = "Permission type for asset-based filtering") @QueryParam(UserPaginator.PERMISSION_PARAM) int permission,
+						   @Parameter(description = "Role key(s) to restrict results to users holding any of them; repeatable and/or comma-separated, e.g. roleKey=DOTCMS_BACK_END_USER") @QueryParam(UserPaginator.ROLE_KEY_PARAM) final List<String> roleKeys) {
 		final InitDataObject initData = new WebResource.InitBuilder(webResource)
 				.requiredBackendUser(true)
 				.requiredFrontendUser(false)
@@ -456,9 +464,42 @@ public class UserResource implements Serializable {
 		extraParams.put(UserAPI.FilteringParams.INCLUDE_DEFAULT_PARAM, includeDefault);
 		extraParams.put(UserAPI.FilteringParams.ORDER_BY_PARAM, orderBy);
 
+		final List<Role> roles = this.resolveRoleKeys(roleKeys);
+		if (UtilMethods.isSet(roles)) {
+			extraParams.put(UserPaginator.ROLES_PARAM, roles);
+		}
+
 		final OrderDirection orderDirection = OrderDirection.valueOf(direction);
 		final User user = initData.getUser();
 		return this.paginationUtil.getPage(request, user, filter, page, perPage, orderBy, orderDirection, extraParams);
+	}
+
+	/**
+	 * Resolves the {@code roleKey} query parameter values -- each entry may itself be a comma-separated list -- into
+	 * the {@link Role} objects expected by the {@link UserPaginator#ROLES_PARAM} parameter.
+	 *
+	 * @param roleKeys The Role key values provided by the caller, potentially empty.
+	 *
+	 * @return The list of resolved {@link Role} objects, or an empty list if no keys were provided.
+	 *
+	 * @throws BadRequestException If any of the provided keys does not match an existing Role.
+	 */
+	private List<Role> resolveRoleKeys(final List<String> roleKeys) {
+		if (!UtilMethods.isSet(roleKeys)) {
+			return List.of();
+		}
+		return roleKeys.stream()
+				.flatMap(value -> Arrays.stream(value.split(",")))
+				.map(String::trim)
+				.filter(UtilMethods::isSet)
+				.map(roleKey -> {
+					final Role role = Try.of(() -> this.roleAPI.loadRoleByKey(roleKey))
+							.getOrElseThrow(DotRuntimeException::new);
+					if (null == role || !UtilMethods.isSet(role.getId())) {
+						throw new BadRequestException(String.format("Role with key '%s' was not found", roleKey));
+					}
+					return role;
+				}).collect(Collectors.toList());
 	}
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/util/pagination/UserPaginator.java
+++ b/dotCMS/src/main/java/com/dotcms/util/pagination/UserPaginator.java
@@ -39,6 +39,7 @@ public class UserPaginator implements PaginatorOrdered<Map<String, Object>> {
     public static final String ASSET_INODE_PARAM = "assetinode";
     public static final String PERMISSION_PARAM = "permission";
     public static final String ROLES_PARAM = "roles";
+    public static final String ROLE_KEY_PARAM = "roleKey";
     public static final String REMOVE_CURRENT_USER_PARAM = "removeCurrentUser";
     public static final String REQUEST_PASSWORD_PARAM = "requestPassword";
 

--- a/dotCMS/src/main/java/com/dotcms/util/pagination/UserPaginator.java
+++ b/dotCMS/src/main/java/com/dotcms/util/pagination/UserPaginator.java
@@ -54,14 +54,16 @@ public class UserPaginator implements PaginatorOrdered<Map<String, Object>> {
     }
 
     /**
-     * Return the total of users with name equals to nameFilter.
+     * Return the total of users with name equals to nameFilter, applying the same filtering
+     * params as the item query so the count stays consistent with the returned page.
      * @param nameFilter
      * @return
      *
      */
-    private long getTotalRecords(final String nameFilter, final List<Role> roles) {
+    private long getTotalRecords(final String nameFilter, final List<Role> roles,
+                                 final UserAPI.FilteringParams filteringParams) {
         try {
-            return userAPI.getCountUsersByName(nameFilter, roles);
+            return userAPI.getCountUsersByName(nameFilter, roles, filteringParams);
         } catch (DotDataException e) {
             throw new DotRuntimeException(e);
         }
@@ -72,13 +74,13 @@ public class UserPaginator implements PaginatorOrdered<Map<String, Object>> {
                                                     final String orderBy, final OrderDirection direction, final Map<String, Object> extraParams) {
         try {
             final List<Role> roles = (List<Role>) extraParams.get(ROLES_PARAM);
+            final UserAPI.FilteringParams filteringParams = new UserAPI.FilteringParams.Builder().build(extraParams);
             final List<Map<String, Object>> usersMap;
             if (UtilMethods.isSet(extraParams.get(ASSET_INODE_PARAM)) && UtilMethods.isSet(extraParams.get(PERMISSION_PARAM))) {
                 final List<User> userList = helper.getUsersByAssetAndPermissionType(filter, offset, limit,
                         extraParams.get(ASSET_INODE_PARAM).toString(), extraParams.get(PERMISSION_PARAM).toString());
                 usersMap = userList.stream().map(this::userToMap).collect(Collectors.toList());
             } else {
-                final UserAPI.FilteringParams filteringParams = new UserAPI.FilteringParams.Builder().build(extraParams);
                 final List<User> users = userAPI.getUsersByName(filter, roles, offset, limit, filteringParams);
                 if ((boolean) CollectionsUtils.getMapValue(extraParams, REMOVE_CURRENT_USER_PARAM, false)) {
                     // Removes user making the request from the list
@@ -91,7 +93,7 @@ public class UserPaginator implements PaginatorOrdered<Map<String, Object>> {
             }
             final PaginatedArrayList<Map<String, Object>> result = new PaginatedArrayList<>();
             result.addAll(usersMap);
-            result.setTotalResults(this.getTotalRecords(filter, roles));
+            result.setTotalResults(this.getTotalRecords(filter, roles, filteringParams));
             return result;
         } catch (final Exception e) {
             throw new DotRuntimeException(e);

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserAPI.java
@@ -126,6 +126,22 @@ public interface UserAPI {
 	public long getCountUsersByName(String filter) throws DotDataException;
 
 	public long getCountUsersByName(String filter, List<Role> roles) throws DotDataException;
+
+	/**
+	 * Returns the total number of Users matching the specified search criteria, applying the exact same exclusions as
+	 * {@link #getUsersByName(String, List, int, int, FilteringParams)} so paginated counts stay consistent with the
+	 * returned items.
+	 *
+	 * @param filter          Any character sequence that might be present in a User's ID, first name, last name, email
+	 *                        address, or the combination of their first and last name.
+	 * @param roles           The list of {@link Role} objects that Users must match.
+	 * @param filteringParams Additional filtering parameters. Please refer to {@link FilteringParams}.
+	 *
+	 * @return The number of Users matching the specified search criteria.
+	 *
+	 * @throws DotDataException An error occurred when accessing the data source.
+	 */
+	long getCountUsersByName(String filter, List<Role> roles, FilteringParams filteringParams) throws DotDataException;
 	/**
 	 * Creates an instance of a user
      * @param userId Can be null

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserAPI.java
@@ -108,9 +108,10 @@ public interface UserAPI {
 	 * Returns a list of Users in dotCMS that match the specified search criteria. It's worth noting that this method
 	 * WILL hit the database EVERY time.
 	 *
-	 * @param filter          Any character sequence that might be present in the combination of a User's first and last
-	 *                        name. For example, for a {@code filter} value of {@code "hn Do"}, the User named {@code
-	 *                        "John Doe"} will match this filter.
+	 * @param filter          Any character sequence that might be present in a User's ID, first name, last name, email
+	 *                        address, or the combination of their first and last name. For example, for a {@code
+	 *                        filter} value of {@code "hn Do"}, the User named {@code "John Doe"} will match this
+	 *                        filter.
 	 * @param roles           The list of {@link Role} objects that Users must match.
 	 * @param start           The start page of the result set, for pagination purposes.
 	 * @param limit           The end or limit page of the result set, for pagination purposes.

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserAPIImpl.java
@@ -162,6 +162,13 @@ public class UserAPIImpl implements UserAPI {
 
     @CloseDBIfOpened
     @Override
+    public long getCountUsersByName(final String filter, final List<Role> roles,
+                                    final FilteringParams filteringParams) {
+        return userFactory.getCountUsersByName(filter, roles, filteringParams);
+    }
+
+    @CloseDBIfOpened
+    @Override
     public List<User> getUsersByName(String filter, int start,int limit, User user, boolean respectFrontEndRoles) throws DotDataException {
         return getUsersByName(filter, null, start, limit);
     }

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserFactory.java
@@ -43,9 +43,10 @@ public interface UserFactory {
      * Returns a list of Users in dotCMS that match the specified search criteria. It's worth noting that this method
      * WILL hit the database EVERY time.
      *
-     * @param filter          Any character sequence that might be present in the combination of a User's first and last
-     *                        name. For example, for a {@code filter} value of {@code "hn Do"}, the User named {@code
-     *                        "John Doe"} will match this filter.
+     * @param filter          Any character sequence that might be present in a User's ID, first name, last name,
+     *                        email address, or the combination of their first and last name. For example, for a
+     *                        {@code filter} value of {@code "hn Do"}, the User named {@code "John Doe"} will match
+     *                        this filter.
      * @param roles           The list of {@link Role} objects that Users must match.
      * @param start           The start page of the result set, for pagination purposes.
      * @param limit           The end or limit page of the result set, for pagination purposes.

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserFactory.java
@@ -27,6 +27,20 @@ public interface UserFactory {
     long getCountUsersByName(String filter, List<Role> roles);
 
     /**
+     * Returns the total number of Users matching the specified search criteria, applying the exact
+     * same exclusions as {@link #getUsersByName(String, List, int, int, UserAPI.FilteringParams)}
+     * so paginated counts stay consistent with the returned items.
+     *
+     * @param filter          Any character sequence that might be present in a User's ID, first name, last name,
+     *                        email address, or the combination of their first and last name.
+     * @param roles           The list of {@link Role} objects that Users must match.
+     * @param filteringParams Additional filtering parameters. Please refer to {@link UserAPI.FilteringParams}.
+     *
+     * @return The number of Users matching the specified search criteria.
+     */
+    long getCountUsersByName(String filter, List<Role> roles, UserAPI.FilteringParams filteringParams);
+
+    /**
      * This method returns a list of users whose names are like the filter passed in. It also allows
      * filtering through a list of roles
      *

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserFactoryImpl.java
@@ -17,7 +17,6 @@ import com.liferay.portal.model.Company;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.util.StringPool;
-import org.apache.logging.log4j.util.Strings;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -160,14 +159,20 @@ public class UserFactoryImpl implements UserFactory {
 
     @Override
     public long getCountUsersByName(String filter, final List<Role> roles) {
-        filter = SQLUtil.sanitizeParameter(filter);
-        final DotConnect dotConnect = new DotConnect();
-        final boolean isFilteredByName = UtilMethods.isSet(filter);
-        filter = (isFilteredByName ? filter : Strings.EMPTY);
-        final StringBuilder baseSql = new StringBuilder(
-                "select count(*) as count from user_ where companyid <> ? and userid <> 'system' ");
+        return getCountUsersByName(filter, roles, new UserAPI.FilteringParams.Builder().build());
+    }
+
+    @Override
+    public long getCountUsersByName(final String filter, final List<Role> roles,
+                                    final UserAPI.FilteringParams filteringParams) {
+        final StringBuilder baseSql = new StringBuilder("select count(*) as count from user_ where ");
+        baseSql.append(!filteringParams.includeDefaultUser() ? "companyid <> ? AND " : StringPool.BLANK);
+        baseSql.append(" userid <> 'system' ");
+        baseSql.append(!filteringParams.includeAnonymousUser() ? " AND userid <> 'anonymous' " : StringPool.BLANK);
         appendRoleFilter(baseSql, roles);
 
+        final String sanitizeFilter = SQLUtil.sanitizeParameter(filter);
+        final boolean isFilteredByName = UtilMethods.isSet(sanitizeFilter);
         if (isFilteredByName) {
             appendUserFilter(baseSql);
         }
@@ -175,15 +180,17 @@ public class UserFactoryImpl implements UserFactory {
         baseSql.append(AND_DELETE_IN_PROGRESS);
         baseSql.append(DbConnectionFactory.getDBFalse());
 
-        final String sql = baseSql.toString();
-        dotConnect.setSQL(sql);
+        final DotConnect dotConnect = new DotConnect();
+        dotConnect.setSQL(baseSql.toString());
         Logger.debug(UserFactoryImpl.class,
                 "::getCountUsersByName -> query: " + dotConnect.getSQL());
 
-        dotConnect.addParam(User.DEFAULT);
+        if (!filteringParams.includeDefaultUser()) {
+            dotConnect.addParam(User.DEFAULT);
+        }
         addRoleFilterParams(dotConnect, roles);
         if (isFilteredByName) {
-            addUserFilterParams(dotConnect, filter);
+            addUserFilterParams(dotConnect, sanitizeFilter);
         }
 
         return dotConnect.getInt("count");

--- a/dotCMS/src/main/java/com/dotmarketing/business/UserFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/UserFactoryImpl.java
@@ -166,21 +166,10 @@ public class UserFactoryImpl implements UserFactory {
         filter = (isFilteredByName ? filter : Strings.EMPTY);
         final StringBuilder baseSql = new StringBuilder(
                 "select count(*) as count from user_ where companyid <> ? and userid <> 'system' ");
-        if (UtilMethods.isSet(roles)) {
-            final String joinedRoleKeys = roles.stream().map(Role::getRoleKey)
-                    .map(s -> String.format("'%s'", s)).collect(Collectors.joining(","));
-            final String backendRoleFilter = String
-                    .format(" and exists ( select ur.user_id from users_cms_roles ur join cms_role r on ur.role_id = r.id where r.role_key in (%s) and ur.user_id = user_.userId )",
-                            joinedRoleKeys);
-            baseSql.append(backendRoleFilter);
-        }
-
-        final String userFullName = DotConnect.concat(new String[]{"firstname", "' '", "lastname"});
+        appendRoleFilter(baseSql, roles);
 
         if (isFilteredByName) {
-            baseSql.append(" and lower(");
-            baseSql.append(userFullName);
-            baseSql.append(") like ?");
+            appendUserFilter(baseSql);
         }
 
         baseSql.append(AND_DELETE_IN_PROGRESS);
@@ -192,11 +181,70 @@ public class UserFactoryImpl implements UserFactory {
                 "::getCountUsersByName -> query: " + dotConnect.getSQL());
 
         dotConnect.addParam(User.DEFAULT);
+        addRoleFilterParams(dotConnect, roles);
         if (isFilteredByName) {
-            dotConnect.addParam("%" + filter.toLowerCase() + "%");
+            addUserFilterParams(dotConnect, filter);
         }
 
         return dotConnect.getInt("count");
+    }
+
+    /**
+     * Returns the SQL expressions that the user-search filter is matched against: user ID, first
+     * name, last name, email address, and the "first last" full name. Both the predicate and its
+     * bound parameters are derived from this list so they always stay in sync.
+     */
+    private static List<String> userFilterExpressions() {
+        final String userFullName = DotConnect.concat(new String[]{"firstname", "' '", "lastname"});
+        return List.of("lower(userid)", "lower(firstname)", "lower(lastname)",
+                "lower(emailaddress)", "lower(" + userFullName + ")");
+    }
+
+    /**
+     * Appends the parameterized predicate matching the user-search filter against every expression
+     * in {@link #userFilterExpressions()}. Callers must bind the filter value at the same SQL
+     * position via {@link #addUserFilterParams(DotConnect, String)}.
+     */
+    private static void appendUserFilter(final StringBuilder sql) {
+        sql.append(userFilterExpressions().stream()
+                .map(expression -> expression + " like ?")
+                .collect(Collectors.joining(" or ", " and (", ")")));
+    }
+
+    /**
+     * Binds one case-insensitive, partial-match parameter per expression appended by
+     * {@link #appendUserFilter(StringBuilder)}.
+     */
+    private static void addUserFilterParams(final DotConnect dotConnect, final String filter) {
+        final String likeParam = "%" + filter.toLowerCase() + "%";
+        userFilterExpressions().forEach(expression -> dotConnect.addParam(likeParam));
+    }
+
+    /**
+     * Appends the parameterized {@code EXISTS} sub-query restricting results to users that hold
+     * any of the specified Roles. Callers must bind one parameter per Role at the same SQL
+     * position via {@link #addRoleFilterParams(DotConnect, List)}.
+     */
+    private static void appendRoleFilter(final StringBuilder sql, final List<Role> roles) {
+        if (!UtilMethods.isSet(roles)) {
+            return;
+        }
+        final String placeholders = roles.stream().map(role -> "?")
+                .collect(Collectors.joining(StringPool.COMMA));
+        sql.append(" and exists ( select ur.user_id from users_cms_roles ur join cms_role r on ur.role_id = r.id where r.role_key in (")
+                .append(placeholders)
+                .append(") and ur.user_id = user_.userId )");
+    }
+
+    /**
+     * Binds the Role keys expected by the placeholders appended via
+     * {@link #appendRoleFilter(StringBuilder, List)}.
+     */
+    private static void addRoleFilterParams(final DotConnect dotConnect, final List<Role> roles) {
+        if (!UtilMethods.isSet(roles)) {
+            return;
+        }
+        roles.forEach(role -> dotConnect.addParam(role.getRoleKey()));
     }
 
     @Override
@@ -213,20 +261,12 @@ public class UserFactoryImpl implements UserFactory {
         baseSql.append(" userid <> 'system' ");
         baseSql.append(!filteringParams.includeAnonymousUser() ? " AND userid <> 'anonymous' " : StringPool.BLANK);
 
-        if (UtilMethods.isSet(roles)) {
-            final String joinedRoleKeys =
-                    roles.stream().map(Role::getRoleKey).map(s -> String.format("'%s'", s)).collect(Collectors.joining(StringPool.COMMA));
-            final String backendRoleFilter = String.format(" and exists ( select ur.user_id from users_cms_roles ur " +
-                                                                   "join cms_role r on ur.role_id = r.id where r" +
-                                                                   ".role_key in (%s) and ur.user_id = user_.userId )"
-                    , joinedRoleKeys);
-            baseSql.append(backendRoleFilter);
-        }
+        appendRoleFilter(baseSql, roles);
         final String userFullName = DotConnect.concat(new String[]{"firstname", "' '", "lastname"});
         final String sanitizeFilter = SQLUtil.sanitizeParameter(filter);
         boolean isFilteredByName = UtilMethods.isSet(sanitizeFilter);
         if (isFilteredByName) {
-            baseSql.append(" and lower(").append(userFullName).append(") like ?");
+            appendUserFilter(baseSql);
         }
         baseSql.append(AND_DELETE_IN_PROGRESS).append(DbConnectionFactory.getDBFalse());
 
@@ -242,8 +282,9 @@ public class UserFactoryImpl implements UserFactory {
         if (!filteringParams.includeDefaultUser()) {
             dotConnect.addParam(User.DEFAULT);
         }
+        addRoleFilterParams(dotConnect, roles);
         if (isFilteredByName) {
-            dotConnect.addParam("%" + sanitizeFilter.toLowerCase() + "%");
+            addUserFilterParams(dotConnect, sanitizeFilter);
         }
         if (start > -1) {
             dotConnect.setStartRow(start);

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -17988,7 +17988,8 @@ paths:
         with pagination support
       operationId: filterUsers
       parameters:
-      - description: Filter users by full name or parts of it
+      - description: "Filter users by user ID, first name, last name, email address,\
+          \ or full name -- or parts of any of them"
         in: query
         name: query
         schema:
@@ -18039,6 +18040,14 @@ paths:
         schema:
           type: integer
           format: int32
+      - description: "Role key(s) to restrict results to users holding any of them;\
+          \ repeatable and/or comma-separated, e.g. roleKey=DOTCMS_BACK_END_USER"
+        in: query
+        name: roleKey
+        schema:
+          type: array
+          items:
+            type: string
       responses:
         "200":
           content:
@@ -18046,6 +18055,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseEntityListUserView"
           description: Users retrieved successfully
+        "400":
+          content:
+            application/json: {}
+          description: Bad request - a provided roleKey does not match any existing
+            Role
         "401":
           content:
             application/json: {}

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/user/UserResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/user/UserResourceTest.java
@@ -10,9 +10,11 @@ import com.dotcms.rest.RestUtilTest;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.WebResource.InitBuilder;
 import com.dotcms.rest.api.DotRestInstanceProvider;
+import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ForbiddenException;
 import com.dotcms.util.PaginationUtil;
 import com.dotcms.util.UserUtilTest;
+import com.dotcms.util.pagination.OrderDirection;
 import com.dotcms.util.pagination.UserPaginator;
 import com.dotmarketing.business.LayoutAPI;
 import com.dotmarketing.business.PermissionAPI;
@@ -31,6 +33,7 @@ import com.dotmarketing.util.json.JSONException;
 import com.liferay.portal.model.User;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import javax.servlet.ServletContext;
@@ -542,5 +545,118 @@ public class UserResourceTest extends UnitTestBase {
                 new UserResource(webResource, userHelper, paginationUtil, instanceProvider);
 
         Response response = resource.loginAsData(request, httpServletResponse, filter, page, perPage);
+    }
+
+    /**
+     * Utility method that creates a {@link UserResource} pointed at the provided mocks, ready to exercise the
+     * {@code /filter} endpoint.
+     */
+    private UserResource getFilterTestResource(final WebResource webResource, final RoleAPI roleAPI,
+                                               final PaginationUtil paginationUtil) {
+        final DotRestInstanceProvider instanceProvider = new DotRestInstanceProvider()
+                                                                 .setUserAPI(mock(UserAPI.class))
+                                                                 .setHostAPI(mock(HostAPI.class))
+                                                                 .setRoleAPI(roleAPI)
+                                                                 .setErrorHelper(mock(ErrorResponseHelper.class));
+        return new UserResource(webResource, mock(UserResourceHelper.class), paginationUtil, instanceProvider);
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link UserResource#filter(HttpServletRequest, HttpServletResponse, String, int,
+     *     int, String, String, boolean, boolean, String, int, List)}</li>
+     *     <li><b>Given Scenario:</b> Call the {@code /filter} endpoint passing {@code roleKey} values, both repeated
+     *     and comma-separated.</li>
+     *     <li><b>Expected Result:</b> Every key is resolved through the {@link RoleAPI} and the resulting Role list
+     *     is handed to the paginator under {@link UserPaginator#ROLES_PARAM}.</li>
+     * </ul>
+     */
+    @Test
+    public void testFilterWithRoleKeysAddsRolesToExtraParams() throws DotDataException {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final WebResource webResource = mock(WebResource.class);
+        final InitDataObject initDataObject = mock(InitDataObject.class);
+        final User user = new User();
+        when(initDataObject.getUser()).thenReturn(user);
+        when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
+
+        final RoleAPI roleAPI = mock(RoleAPI.class);
+        final Role backendRole = new Role();
+        backendRole.setId("backend-role-id");
+        final Role frontendRole = new Role();
+        frontendRole.setId("frontend-role-id");
+        when(roleAPI.loadRoleByKey("DOTCMS_BACK_END_USER")).thenReturn(backendRole);
+        when(roleAPI.loadRoleByKey("DOTCMS_FRONT_END_USER")).thenReturn(frontendRole);
+
+        final PaginationUtil paginationUtil = mock(PaginationUtil.class);
+        final UserResource resource = getFilterTestResource(webResource, roleAPI, paginationUtil);
+
+        resource.filter(request, response, "jane", 0, 40, null, "ASC", false, false, null, 0,
+                List.of("DOTCMS_BACK_END_USER,DOTCMS_FRONT_END_USER"));
+
+        final ArgumentCaptor<Map<String, Object>> extraParamsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(paginationUtil).getPage(Mockito.eq(request), Mockito.eq(user), Mockito.eq("jane"), Mockito.eq(0),
+                Mockito.eq(40), Mockito.isNull(), Mockito.eq(OrderDirection.ASC), extraParamsCaptor.capture());
+        assertEquals(List.of(backendRole, frontendRole),
+                extraParamsCaptor.getValue().get(UserPaginator.ROLES_PARAM));
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link UserResource#filter(HttpServletRequest, HttpServletResponse, String, int,
+     *     int, String, String, boolean, boolean, String, int, List)}</li>
+     *     <li><b>Given Scenario:</b> Call the {@code /filter} endpoint without any {@code roleKey} value.</li>
+     *     <li><b>Expected Result:</b> The paginator extra params do NOT include {@link UserPaginator#ROLES_PARAM},
+     *     preserving the endpoint's previous behavior.</li>
+     * </ul>
+     */
+    @Test
+    public void testFilterWithoutRoleKeysLeavesRolesParamOut() throws DotDataException {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final WebResource webResource = mock(WebResource.class);
+        final InitDataObject initDataObject = mock(InitDataObject.class);
+        final User user = new User();
+        when(initDataObject.getUser()).thenReturn(user);
+        when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
+
+        final PaginationUtil paginationUtil = mock(PaginationUtil.class);
+        final UserResource resource = getFilterTestResource(webResource, mock(RoleAPI.class), paginationUtil);
+
+        resource.filter(request, response, "jane", 0, 40, null, "ASC", false, false, null, 0, null);
+
+        final ArgumentCaptor<Map<String, Object>> extraParamsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(paginationUtil).getPage(Mockito.eq(request), Mockito.eq(user), Mockito.eq("jane"), Mockito.eq(0),
+                Mockito.eq(40), Mockito.isNull(), Mockito.eq(OrderDirection.ASC), extraParamsCaptor.capture());
+        Assert.assertFalse(extraParamsCaptor.getValue().containsKey(UserPaginator.ROLES_PARAM));
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link UserResource#filter(HttpServletRequest, HttpServletResponse, String, int,
+     *     int, String, String, boolean, boolean, String, int, List)}</li>
+     *     <li><b>Given Scenario:</b> Call the {@code /filter} endpoint with a {@code roleKey} that does not match any
+     *     existing Role.</li>
+     *     <li><b>Expected Result:</b> A {@link BadRequestException} is thrown instead of silently returning an empty
+     *     or unfiltered result set.</li>
+     * </ul>
+     */
+    @Test(expected = BadRequestException.class)
+    public void testFilterWithUnknownRoleKeyThrowsBadRequest() throws DotDataException {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final WebResource webResource = mock(WebResource.class);
+        final InitDataObject initDataObject = mock(InitDataObject.class);
+        when(initDataObject.getUser()).thenReturn(new User());
+        when(webResource.init(Mockito.any(InitBuilder.class))).thenReturn(initDataObject);
+
+        final RoleAPI roleAPI = mock(RoleAPI.class);
+        when(roleAPI.loadRoleByKey("NOT_A_ROLE")).thenReturn(null);
+
+        final UserResource resource = getFilterTestResource(webResource, roleAPI, mock(PaginationUtil.class));
+
+        resource.filter(request, response, "jane", 0, 40, null, "ASC", false, false, null, 0,
+                List.of("NOT_A_ROLE"));
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/util/pagination/UserPaginatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/pagination/UserPaginatorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -113,6 +114,42 @@ public class UserPaginatorTest {
 
         assertEquals(usersMap, items);
         assertEquals(totalRecords,items.getTotalResults());
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link UserPaginator#getItems(User, String, int, int, String, OrderDirection, Map)}</li>
+     *     <li><b>Given Scenario:</b> Request the list of Users passing a Role list under the
+     *     {@link UserPaginator#ROLES_PARAM} extra parameter.</li>
+     *     <li><b>Expected Result:</b> Both the item query and the total-records count receive the same Role
+     *     list, so the page and its {@code totalEntries} stay consistent.</li>
+     * </ul>
+     */
+    @Test
+    public void testGetItemsPassesRolesToQueryAndCount() throws Exception {
+        final String filter = "filter";
+        final long totalRecords = 3;
+        final User user = mock(User.class);
+
+        final List<User> userList = new ArrayList<>();
+        for (int i = 0; i < totalRecords; i++) {
+            final User userMock = mock(User.class);
+            when(userMock.toMap()).thenReturn(new User().toMap());
+            userList.add(userMock);
+        }
+        when(userAPI.getUsersByName(anyString(), eq(roles), anyInt(), anyInt(),
+                any(UserAPI.FilteringParams.class))).thenReturn(userList);
+        when(userAPI.getCountUsersByName(filter, roles)).thenReturn(totalRecords);
+
+        final Map<String, Object> extraParams = Map.of(UserPaginator.ROLES_PARAM, roles);
+        final PaginatedArrayList<Map<String, Object>> items = userPaginator.getItems(user, filter, 5, 0,
+                null, null, extraParams);
+
+        assertEquals(totalRecords, items.getTotalResults());
+        assertEquals(userList.size(), items.size());
+        verify(userAPI).getUsersByName(eq(filter), eq(roles), anyInt(), anyInt(),
+                any(UserAPI.FilteringParams.class));
+        verify(userAPI).getCountUsersByName(filter, roles);
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/util/pagination/UserPaginatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/pagination/UserPaginatorTest.java
@@ -99,7 +99,8 @@ public class UserPaginatorTest {
             roleAPI.doesUserHaveRoles(userId, rolesId);
         }
 
-        when(userAPI.getCountUsersByName( filter, null )).thenReturn( totalRecords );
+        when(userAPI.getCountUsersByName(eq(filter), eq(null), any(UserAPI.FilteringParams.class)))
+                .thenReturn(totalRecords);
         final List<User> userList = new ArrayList<>();
         userList.add(new User());
         userList.add(new User());
@@ -139,7 +140,8 @@ public class UserPaginatorTest {
         }
         when(userAPI.getUsersByName(anyString(), eq(roles), anyInt(), anyInt(),
                 any(UserAPI.FilteringParams.class))).thenReturn(userList);
-        when(userAPI.getCountUsersByName(filter, roles)).thenReturn(totalRecords);
+        when(userAPI.getCountUsersByName(eq(filter), eq(roles), any(UserAPI.FilteringParams.class)))
+                .thenReturn(totalRecords);
 
         final Map<String, Object> extraParams = Map.of(UserPaginator.ROLES_PARAM, roles);
         final PaginatedArrayList<Map<String, Object>> items = userPaginator.getItems(user, filter, 5, 0,
@@ -149,7 +151,7 @@ public class UserPaginatorTest {
         assertEquals(userList.size(), items.size());
         verify(userAPI).getUsersByName(eq(filter), eq(roles), anyInt(), anyInt(),
                 any(UserAPI.FilteringParams.class));
-        verify(userAPI).getCountUsersByName(filter, roles);
+        verify(userAPI).getCountUsersByName(eq(filter), eq(roles), any(UserAPI.FilteringParams.class));
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotmarketing/business/UserAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/business/UserAPITest.java
@@ -1562,6 +1562,28 @@ public class UserAPITest extends IntegrationTestBase {
 	 * User role. The search combines the shared name filter with the Back-end Role.
 	 * ExpectedResult: Only the back-end user is returned, both by the item query and the count.
 	 */
+	/**
+	 * Method to test: {@link UserAPI#getCountUsersByName(String, List, UserAPI.FilteringParams)}
+	 * Given Scenario: The filter matches the anonymous user's ID. Both the count and the item
+	 * queries run with the same filtering params, first excluding (default) and then including
+	 * the anonymous user.
+	 * ExpectedResult: The count always equals the number of items returned, and including the
+	 * anonymous user grows both by exactly one.
+	 */
+	@Test
+	public void testGetCountUsersByNameStaysConsistentWithItems() throws DotDataException {
+		final UserAPI.FilteringParams excludeAnonymous = new UserAPI.FilteringParams.Builder().build();
+		final List<User> excludedItems = userAPI.getUsersByName("anonymous", null, 0, -1, excludeAnonymous);
+		assertEquals(excludedItems.size(), userAPI.getCountUsersByName("anonymous", null, excludeAnonymous));
+
+		final UserAPI.FilteringParams.Builder builder = new UserAPI.FilteringParams.Builder();
+		builder.includeAnonymousUser(true);
+		final UserAPI.FilteringParams includeAnonymous = builder.build();
+		final List<User> includedItems = userAPI.getUsersByName("anonymous", null, 0, -1, includeAnonymous);
+		assertEquals(includedItems.size(), userAPI.getCountUsersByName("anonymous", null, includeAnonymous));
+		assertEquals(excludedItems.size() + 1, includedItems.size());
+	}
+
 	@Test
 	public void testGetUsersByNameFilteredByRole() throws DotDataException {
 		final String unique = String.valueOf(System.currentTimeMillis());

--- a/dotcms-integration/src/test/java/com/dotmarketing/business/UserAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/business/UserAPITest.java
@@ -1491,4 +1491,97 @@ public class UserAPITest extends IntegrationTestBase {
 			UserDataGen.remove(user);
 		}
 	}
+
+	/**
+	 * Method to test: {@link UserAPI#getUsersByName(String, List, int, int)} and
+	 * {@link UserAPI#getCountUsersByName(String, List)}
+	 * Given Scenario: A user exists with a known user ID. The search filter is a partial,
+	 * differently-cased fragment of that user ID.
+	 * ExpectedResult: The user is returned and the count matches the item query.
+	 */
+	@Test
+	public void testGetUsersByNameMatchesUserId() throws DotDataException {
+		final String unique = String.valueOf(System.currentTimeMillis());
+		final User user = new UserDataGen().id("filterTestId" + unique).nextPersisted();
+		try {
+			final List<User> users = userAPI.getUsersByName("TESTID" + unique, null, 0, 40);
+			assertEquals(1, users.size());
+			assertEquals(user.getUserId(), users.get(0).getUserId());
+			assertEquals(1, userAPI.getCountUsersByName("TESTID" + unique, null));
+		} finally {
+			UserDataGen.remove(user);
+		}
+	}
+
+	/**
+	 * Method to test: {@link UserAPI#getUsersByName(String, List, int, int)} and
+	 * {@link UserAPI#getCountUsersByName(String, List)}
+	 * Given Scenario: A user exists with a known email address. The search filter is a partial
+	 * fragment of that email address.
+	 * ExpectedResult: The user is returned and the count matches the item query.
+	 */
+	@Test
+	public void testGetUsersByNameMatchesEmailAddress() throws DotDataException {
+		final String unique = String.valueOf(System.currentTimeMillis());
+		final User user = new UserDataGen().emailAddress("filter.test" + unique + "@example.com").nextPersisted();
+		try {
+			final List<User> users = userAPI.getUsersByName("filter.test" + unique, null, 0, 40);
+			assertEquals(1, users.size());
+			assertEquals(user.getUserId(), users.get(0).getUserId());
+			assertEquals(1, userAPI.getCountUsersByName("filter.test" + unique, null));
+		} finally {
+			UserDataGen.remove(user);
+		}
+	}
+
+	/**
+	 * Method to test: {@link UserAPI#getUsersByName(String, List, int, int)}
+	 * Given Scenario: A user named "John Doe"-style is searched with a fragment spanning the end
+	 * of the first name and the beginning of the last name ("hn Do" style).
+	 * ExpectedResult: The user is still found, i.e., the previous full-name matching behavior is
+	 * preserved after widening the filter to user ID and email address.
+	 */
+	@Test
+	public void testGetUsersByNameStillMatchesAcrossFullName() throws DotDataException {
+		final String unique = String.valueOf(System.currentTimeMillis());
+		final User user = new UserDataGen().firstName("Filterjohn" + unique).lastName("Filterdoe" + unique)
+				.nextPersisted();
+		try {
+			final List<User> users = userAPI.getUsersByName(unique + " Filterdoe", null, 0, 40);
+			assertEquals(1, users.size());
+			assertEquals(user.getUserId(), users.get(0).getUserId());
+		} finally {
+			UserDataGen.remove(user);
+		}
+	}
+
+	/**
+	 * Method to test: {@link UserAPI#getUsersByName(String, List, int, int)} and
+	 * {@link UserAPI#getCountUsersByName(String, List)}
+	 * Given Scenario: Two users share a first-name prefix but only one of them holds the Back-end
+	 * User role. The search combines the shared name filter with the Back-end Role.
+	 * ExpectedResult: Only the back-end user is returned, both by the item query and the count.
+	 */
+	@Test
+	public void testGetUsersByNameFilteredByRole() throws DotDataException {
+		final String unique = String.valueOf(System.currentTimeMillis());
+		final Role backendRole = TestUserUtils.getBackendRole();
+		final User backendUser = new UserDataGen().firstName("roleFilter" + unique + "backend")
+				.roles(backendRole).nextPersisted();
+		final User plainUser = new UserDataGen().firstName("roleFilter" + unique + "plain").nextPersisted();
+		try {
+			final List<Role> roles = List.of(backendRole);
+
+			final List<User> allMatches = userAPI.getUsersByName("roleFilter" + unique, null, 0, 40);
+			assertEquals(2, allMatches.size());
+
+			final List<User> backendMatches = userAPI.getUsersByName("roleFilter" + unique, roles, 0, 40);
+			assertEquals(1, backendMatches.size());
+			assertEquals(backendUser.getUserId(), backendMatches.get(0).getUserId());
+			assertEquals(1, userAPI.getCountUsersByName("roleFilter" + unique, roles));
+		} finally {
+			UserDataGen.remove(backendUser);
+			UserDataGen.remove(plainUser);
+		}
+	}
 }


### PR DESCRIPTION
### Proposed Changes
  * `query` param now matches **userid, first name, last name, email address, and full name** (case-insensitive, partial) — previously full-name only
  * New optional `roleKey` param (repeatable and/or comma-separated) restricts results to users holding any of the given roles; unknown key → 400
  * Count and item queries share one predicate, so `totalEntries` stays consistent
  * Hardening: role keys are now bound as SQL parameters instead of interpolated into the query
  * Regenerated `openapi.yaml`

  ### Checklist
  - [x] Unit tests (UserPaginatorTest, UserResourceTest — 12/12)
  - [x] Integration tests (full UserAPITest + UserResourceIntegrationTest — 44/44)
  - [x] Backwards compatible: no new params → same behavior, response shape unchanged; existing queries can only return *more* matches, never fewer

  Fixes #36794

This PR fixes: #36794