### PR TITLE
fix(content-drive): clear folder defaultBaseType when update omits/nulls it

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/AbstractFolderDetail.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/AbstractFolderDetail.java
@@ -66,9 +66,9 @@ public interface AbstractFolderDetail {
     @Schema(
         description = "Content Drive upload-mode preference for this folder, recorded as a base content type name "
             + "(DOTASSET or FILEASSET; case-insensitive, also accepts the alternate names DotAsset/File and stored "
-            + "canonically in uppercase). On create, omit for no preference (\"ask each time\"); on update, omit to "
-            + "leave the current preference unchanged. This is orthogonal to defaultAssetType and does not change "
-            + "FileAsset behavior.",
+            + "canonically in uppercase). Omit or set to null for no preference (\"ask each time\"); on update, "
+            + "omitting/null clears any previously set preference. This is orthogonal to defaultAssetType and does "
+            + "not change FileAsset behavior.",
         example = "DOTASSET",
         requiredMode = RequiredMode.NOT_REQUIRED
     )

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/WebAssetHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/asset/WebAssetHelper.java
@@ -861,8 +861,9 @@ public class WebAssetHelper {
 
             // Content Drive upload-mode preference (orthogonal to defaultAssetType/defaultFileType).
             // A present value is validated against the DOTASSET/FILEASSET base types and stored as the
-            // canonical uppercase enum name. Consistent with every other field here, an absent/null
-            // value leaves the current preference unchanged (a new folder defaults to none).
+            // canonical uppercase enum name. A null/absent value clears the preference ("ask each
+            // time"); Jackson can't distinguish an omitted field from an explicit null here, and the
+            // client always sends this field, so treat both as "clear."
             final String defaultBaseType = meta.defaultBaseType();
             if (UtilMethods.isSet(defaultBaseType)) {
                 final BaseContentType baseType = BaseContentType.getBaseContentType(defaultBaseType);
@@ -873,6 +874,8 @@ public class WebAssetHelper {
                     );
                 }
                 folder.setDefaultBaseType(baseType.name());
+            } else {
+                folder.setDefaultBaseType(null);
             }
 
             if (UtilMethods.isSet(meta.fileMasks())) {

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -27360,9 +27360,9 @@ components:
           description: "Content Drive upload-mode preference for this folder, recorded\
             \ as a base content type name (DOTASSET or FILEASSET; case-insensitive,\
             \ also accepts the alternate names DotAsset/File and stored canonically\
-            \ in uppercase). On create, omit for no preference (\"ask each time\"\
-            ); on update, omit to leave the current preference unchanged. This is\
-            \ orthogonal to defaultAssetType and does not change FileAsset behavior."
+            \ in uppercase). Omit or set to null for no preference (\"ask each time\"\
+            ); on update, omitting/null clears any previously set preference. This\
+            \ is orthogonal to defaultAssetType and does not change FileAsset behavior."
           example: DOTASSET
         fileMasks:
           type: array
@@ -37070,9 +37070,9 @@ components:
           description: "Content Drive upload-mode preference for this folder, recorded\
             \ as a base content type name (DOTASSET or FILEASSET; case-insensitive,\
             \ also accepts the alternate names DotAsset/File and stored canonically\
-            \ in uppercase). On create, omit for no preference (\"ask each time\"\
-            ); on update, omit to leave the current preference unchanged. This is\
-            \ orthogonal to defaultAssetType and does not change FileAsset behavior."
+            \ in uppercase). Omit or set to null for no preference (\"ask each time\"\
+            ); on update, omitting/null clears any previously set preference. This\
+            \ is orthogonal to defaultAssetType and does not change FileAsset behavior."
           example: DOTASSET
         fileMasks:
           type: array

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/asset/WebAssetHelperIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/asset/WebAssetHelperIntegrationTest.java
@@ -1363,13 +1363,15 @@ public class WebAssetHelperIntegrationTest {
 
     /**
      * Method to test: {@link WebAssetHelper#updateFolder(String, AbstractUpdateFolderDetail, User)}
-     * Given Scenario: Create a folder with DOTASSET, update it to FILEASSET, then run a partial
-     * update (title only) that omits defaultBaseType
-     * Expected Result: A present value changes the preference; an absent value leaves it unchanged
-     * (consistent with every other folder detail field — no clobber on partial updates)
+     * Given Scenario: Create a folder with DOTASSET, update it to FILEASSET, then run an update
+     * that omits defaultBaseType (equivalent to the client sending null for "ask each time")
+     * Expected Result: A present value changes the preference; an absent/null value clears it back
+     * to "ask each time". Jackson can't tell an omitted field from an explicit null here, and the
+     * client always sends this field, so both must clear the preference (see issue #35577 QA
+     * follow-up: clearing the preference via null was silently ignored before this fix).
      */
     @Test
-    public void Test_Update_Folder_DefaultBaseType_Change_And_Preserve() throws DotDataException, DotSecurityException {
+    public void Test_Update_Folder_DefaultBaseType_Change_And_Clear() throws DotDataException, DotSecurityException {
         final WebAssetHelper webAssetHelper = WebAssetHelper.newInstance();
         final String folderName = "dbt-update-" + RandomStringUtils.randomAlphabetic(5);
         final String folderPath = String.format("//%s/%s/", host.getHostname(), folderName);
@@ -1384,15 +1386,15 @@ public class WebAssetHelperIntegrationTest {
                 APILocator.systemUser());
         Assert.assertEquals("FILEASSET", changed.defaultBaseType());
 
-        // A partial update that omits defaultBaseType leaves it unchanged (not cleared)
-        final FolderView preserved = webAssetHelper.updateFolder(folderPath,
+        // Omitting defaultBaseType (i.e. null) clears the preference back to "ask each time"
+        final FolderView cleared = webAssetHelper.updateFolder(folderPath,
                 UpdateFolderDetail.builder().title("Renamed title").build(),
                 APILocator.systemUser());
-        Assert.assertEquals("FILEASSET", preserved.defaultBaseType());
+        Assert.assertNull(cleared.defaultBaseType());
 
         // Confirm on the retrieval path
         final WebAssetView assetInfo = webAssetHelper.getAssetInfo(folderPath, APILocator.systemUser());
-        Assert.assertEquals("FILEASSET", ((FolderView) assetInfo).defaultBaseType());
+        Assert.assertNull(((FolderView) assetInfo).defaultBaseType());
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes #35577 (QA follow-up reported by @dario-daza).

When a folder's Content Drive upload-mode preference (`defaultBaseType`) was set to `FileAsset`/`DotAsset` and the user tried to reset it back to "ask each time" (the FE sends `null`), the preference silently stayed at the previous value instead of clearing.

## Root cause

In `WebAssetHelper.applyDetail`, `defaultBaseType` was only applied to the folder when `UtilMethods.isSet(...)` was true. A `null` value (whether omitted or explicitly sent) was treated as "leave unchanged," so an explicit clear was never persisted — the folder object already carried the old value from the DB read, and it got saved back as-is.

Jackson/Immutables can't distinguish an omitted JSON field from an explicit `null` for a plain `@Nullable String`, and the client always sends this field, so both cases now clear the preference.

## Changes

- `WebAssetHelper#applyDetail`: explicitly call `folder.setDefaultBaseType(null)` when no value is provided.
- `AbstractFolderDetail`: updated `@Schema` description to reflect the corrected clear-on-null semantics.
- `openapi.yaml`: regenerated (description-only diff).
- `WebAssetHelperIntegrationTest`: updated the test that asserted the old (buggy) "omit = unchanged" behavior to assert the correct clear-on-omit/null behavior.

## Test plan

- [x] `./mvnw compile -pl :dotcms-core -DskipTests` — verified `openapi.yaml` diff is description-only
- [ ] `WebAssetHelperIntegrationTest#Test_Update_Folder_DefaultBaseType_Change_And_Clear` (needs Docker-based Postgres/OpenSearch — not run in this environment, please verify in CI)

This PR fixes: #35577