### PR TITLE
fix(migration): guard activateIndex against a missing OpenSearch counterpart (#36360)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1927,6 +1927,15 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     public static final String ALLOW_ACTIVE_INDEX_DELETE = "ALLOW_ACTIVE_INDEX_DELETE";
 
     /**
+     * Config override to bypass the migration guard that refuses to activate an index whose
+     * OpenSearch counterpart does not exist (issue #36360). Default {@code false}. Set {@code true}
+     * only to force a rollback to a pre-migration index, accepting that OpenSearch is left pointing
+     * at a missing index until it is rebuilt.
+     */
+    public static final String ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR =
+            "ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR";
+
+    /**
      * Rejects a destructive operation ({@code operation}, e.g. {@code "deleted"} / {@code "cleared"})
      * on an index that is currently active (working/live) or being rebuilt (a reindex slot). The
      * protected set is collected phase-aware and, in the dual-write phases, from <strong>both</strong>
@@ -3278,6 +3287,27 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         } else {
             Logger.info(this, "Index activation (" + indexName
                     + ") performed by system user at " + new Date());
+        }
+
+        // Guard (issue #36360): during the OpenSearch migration, refuse to activate an index whose
+        // OpenSearch counterpart does not exist. activateIndex only repoints both stores by name (no
+        // create/reconcile), so pointing at a missing .os index silently diverges ES from OS and
+        // breaks reads at Phase 3, where there is no ES fallback. A rollback to a migration-era index
+        // that DOES have its .os copy still works. Override with ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR
+        // =true to force it (OS left pointing at a missing index until rebuilt).
+        if (isMigrationStarted()
+                && !Config.getBooleanProperty(ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR, false)) {
+            final String osCounterpart = operationsOS.toPhysicalName(indexName);
+            final boolean osExists = Try.of(
+                    () -> operationsOS.indexAPI().indexExists(osCounterpart)).getOrElse(false);
+            if (!osExists) {
+                throw new DotStateException(String.format(
+                        "Cannot activate index '%s' during the OpenSearch migration: its OpenSearch "
+                        + "copy '%s' does not exist, so activating it would leave OpenSearch pointing "
+                        + "at a missing index and break search at Phase 3. Rebuild it (run a full "
+                        + "reindex) before activating, or set %s=true to override.",
+                        indexName, osCounterpart, ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR));
+            }
         }
 
         if (isMigrationComplete()) {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -3301,16 +3301,17 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             final boolean osExists = Try.of(
                     () -> operationsOS.indexAPI().indexExists(osCounterpart)).getOrElse(false);
             if (!osExists) {
-                // Full diagnostic goes to the operator log (physical counterpart name + override);
-                // the exception message that reaches the UI stays friendly and migration-neutral, so a
-                // regular admin is not exposed to the migration (issue #36360).
+                // Full ops diagnostic (physical counterpart name + override key) goes to the log; the
+                // exception message that reaches the UI is honest and actionable for support without
+                // dumping the physical name or the config key (issue #36360).
                 Logger.warn(this, String.format(
                         "Blocked activation of '%s': its OpenSearch counterpart '%s' does not exist. "
-                        + "Rebuild it, or set %s=true to override.",
+                        + "Suspend the migration (phase 0), reindex, or set %s=true to override.",
                         indexName, osCounterpart, ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR));
                 throw new DotStateException(String.format(
-                        "'%s' can't be set as the active index right now because its search data isn't "
-                        + "ready yet. Run a full reindex and try again.", indexName));
+                        "'%s' can't be activated because it has no OpenSearch counterpart. To activate "
+                        + "it, suspend the migration first, or run a full reindex to rebuild the "
+                        + "indexes.", indexName));
             }
         }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -3301,12 +3301,16 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             final boolean osExists = Try.of(
                     () -> operationsOS.indexAPI().indexExists(osCounterpart)).getOrElse(false);
             if (!osExists) {
-                throw new DotStateException(String.format(
-                        "Cannot activate index '%s' during the OpenSearch migration: its OpenSearch "
-                        + "copy '%s' does not exist, so activating it would leave OpenSearch pointing "
-                        + "at a missing index and break search at Phase 3. Rebuild it (run a full "
-                        + "reindex) before activating, or set %s=true to override.",
+                // Full diagnostic goes to the operator log (physical counterpart name + override);
+                // the exception message that reaches the UI stays friendly and migration-neutral, so a
+                // regular admin is not exposed to the migration (issue #36360).
+                Logger.warn(this, String.format(
+                        "Blocked activation of '%s': its OpenSearch counterpart '%s' does not exist. "
+                        + "Rebuild it, or set %s=true to override.",
                         indexName, osCounterpart, ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR));
+                throw new DotStateException(String.format(
+                        "'%s' can't be set as the active index right now because its search data isn't "
+                        + "ready yet. Run a full reindex and try again.", indexName));
             }
         }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -616,9 +616,14 @@ public class ESIndexResource {
 
             }
         } catch (final DotStateException e) {
-            // CLEAR is delete + recreate, so it is guarded like delete: an active/building index
-            // is rejected with a readable 400 instead of a stack trace (issue #35640, TC-018).
-            Logger.warn(this, "Rejected '" + action + "' on index '" + resolvedName + "': " + e.getMessage());
+            // A guarded operation — deleting/clearing an active/building index (#35640, TC-018), or
+            // activating an index whose OpenSearch counterpart is missing during the migration
+            // (#36360) — is rejected with a readable 400 instead of a stack trace. Log the resolved
+            // action (not the raw, possibly-null query param) and surface the reason to the operator
+            // as a toast, so it is visible in the UI, not only in the server log.
+            Logger.warn(this, "Rejected '" + indexAction + "' on index '" + resolvedName + "': "
+                    + e.getMessage());
+            sendAdminMessage(e.getMessage(), MessageSeverity.ERROR, init.getUser(), 8000);
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(new ResponseEntityView<>(List.of(new ErrorEntity("INDEX_NOT_MODIFIABLE", e.getMessage())))).build();
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -623,7 +623,7 @@ public class ESIndexResource {
             // as a toast, so it is visible in the UI, not only in the server log.
             Logger.warn(this, "Rejected '" + indexAction + "' on index '" + resolvedName + "': "
                     + e.getMessage());
-            sendAdminMessage(e.getMessage(), MessageSeverity.ERROR, init.getUser(), 8000);
+            sendAdminMessage(e.getMessage(), MessageSeverity.WARNING, init.getUser(), 8000);
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(new ResponseEntityView<>(List.of(new ErrorEntity("INDEX_NOT_MODIFIABLE", e.getMessage())))).build();
         }

--- a/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplActivateGuardTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplActivateGuardTest.java
@@ -1,0 +1,103 @@
+package com.dotcms.content.elasticsearch.business;
+
+import static com.dotcms.content.index.IndexConfigHelper.MigrationPhase.FLAG_KEY;
+import static org.junit.Assert.assertThrows;
+
+import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplDeleteTest.RecordingIndexAPI;
+import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplDeleteTest.RecordingOps;
+import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplPhaseTest.FakeIndexAPI;
+import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplPhaseTest.FakeIndiciesAPI;
+import com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplPhaseTest.FakeVersionedIndicesAPI;
+import com.dotcms.content.index.IndexTag;
+import com.dotmarketing.business.DotStateException;
+import com.dotmarketing.util.Config;
+import java.util.List;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link ContentletIndexAPIImpl#activateIndex(String)} migration guard (issue
+ * #36360): during the OpenSearch migration it refuses to activate an index whose OpenSearch
+ * counterpart does not exist — repointing to a missing {@code .os} index would silently diverge ES
+ * from OS and break reads at Phase 3. A rollback to a migration-era index that DOES have its {@code
+ * .os} copy still works, and the guard does not apply in Phase 0 or when the override flag is set.
+ *
+ * <p>Both engine leaves are set-backed fakes ({@link RecordingOps}/{@link RecordingIndexAPI}) so the
+ * OpenSearch counterpart's existence is controlled per test; no live cluster is needed.</p>
+ */
+public class ContentletIndexAPIImplActivateGuardTest {
+
+    private static final String CLUSTER_PREFIX = "cluster_test.";
+    private static final String BARE = "working_T0";
+    private static final String ES_PHYSICAL = CLUSTER_PREFIX + BARE;
+    private static final String OS_PHYSICAL = CLUSTER_PREFIX + BARE + ".os";
+
+    @After
+    public void clear() {
+        Config.setProperty(FLAG_KEY, null);
+        Config.setProperty(ContentletIndexAPIImpl.ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR, null);
+    }
+
+    private static void setPhase(final int ordinal) {
+        Config.setProperty(FLAG_KEY, String.valueOf(ordinal));
+    }
+
+    /** ES always holds the index; OS holds it only when {@code osIndices} contains its {@code .os} name. */
+    private static ContentletIndexAPIImpl apiWith(final Set<String> osIndices) {
+        return new ContentletIndexAPIImpl(
+                new RecordingOps(new RecordingIndexAPI(Set.of(ES_PHYSICAL)), IndexTag.ES),
+                new RecordingOps(new RecordingIndexAPI(osIndices), IndexTag.OS),
+                new FakeIndexAPI(List.of()),
+                new FakeIndiciesAPI(),
+                new FakeVersionedIndicesAPI());
+    }
+
+    // =========================================================================
+    // Blocked: OS counterpart missing during the migration
+    // =========================================================================
+
+    @Test
+    public void phase1_missingOsCounterpart_blocks() {
+        setPhase(1);
+        assertThrows(DotStateException.class, () -> apiWith(Set.of()).activateIndex(BARE));
+    }
+
+    @Test
+    public void phase2_missingOsCounterpart_blocks() {
+        setPhase(2);
+        assertThrows(DotStateException.class, () -> apiWith(Set.of()).activateIndex(BARE));
+    }
+
+    @Test
+    public void phase3_missingOsCounterpart_blocks() {
+        setPhase(3);
+        assertThrows(DotStateException.class, () -> apiWith(Set.of()).activateIndex(BARE));
+    }
+
+    // =========================================================================
+    // Allowed: guard passes / does not apply
+    // =========================================================================
+
+    /** OS counterpart exists → a migration-era rollback proceeds normally. */
+    @Test
+    public void phase1_osCounterpartPresent_allowed() throws Exception {
+        setPhase(1);
+        apiWith(Set.of(OS_PHYSICAL)).activateIndex(BARE); // must not throw
+    }
+
+    /** Phase 0 has no OpenSearch store, so the guard does not apply. */
+    @Test
+    public void phase0_notGuarded() throws Exception {
+        setPhase(0);
+        apiWith(Set.of()).activateIndex(BARE); // must not throw
+    }
+
+    /** The override flag forces the activation even when the OS counterpart is missing. */
+    @Test
+    public void overrideFlag_bypassesGuard() throws Exception {
+        setPhase(1);
+        Config.setProperty(ContentletIndexAPIImpl.ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR, "true");
+        apiWith(Set.of()).activateIndex(BARE); // must not throw
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplActivateGuardTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplActivateGuardTest.java
@@ -93,6 +93,17 @@ public class ContentletIndexAPIImplActivateGuardTest {
         apiWith(Set.of()).activateIndex(BARE); // must not throw
     }
 
+    /**
+     * No migration phase configured (flag removed/absent) → {@code MigrationPhase.current()} defaults
+     * to Phase 0 → the guard does not apply, so a rollback works once migration is turned off. This is
+     * the intended escape: set the phase to 0 (or remove the flag) to re-enable unrestricted rollback.
+     */
+    @Test
+    public void noPhaseConfigured_notGuarded() throws Exception {
+        // deliberately do NOT set FLAG_KEY — it is cleared by @After, so it is absent here
+        apiWith(Set.of()).activateIndex(BARE); // must not throw
+    }
+
     /** The override flag forces the activation even when the OS counterpart is missing. */
     @Test
     public void overrideFlag_bypassesGuard() throws Exception {

--- a/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplPhaseTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplPhaseTest.java
@@ -627,7 +627,16 @@ public class ContentletIndexAPIImplPhaseTest {
 
         @Override
         public IndexAPI indexAPI() {
-            throw new UnsupportedOperationException("indexAPI() not used by tests");
+            // The activateIndex migration guard probes the OpenSearch counterpart's existence through
+            // this API (issue #36360); report "exists" so the default fake drives the activation path.
+            // Tests that need to control existence (e.g. the guard's missing-counterpart case) override
+            // this with a set-backed fake instead.
+            return new FakeIndexAPI(List.of()) {
+                @Override
+                public boolean indexExists(final String indexName) {
+                    return true;
+                }
+            };
         }
 
         // ── unneeded methods ─────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Activating an old/inactive index is dotCMS's **rollback** mechanism (revert to a previous reindex). But if that index **predates the migration**, it never went through the OpenSearch create fan-out, so it has **no OpenSearch counterpart**. `ContentletIndexAPIImpl.activateIndex` is phase-aware but only **repoints both stores by name** (`toPhysicalName` → `cluster_X.<name>.os`) — no `indexExists`, no create, no reconcile. Reactivating such an index during the migration is unguarded:

- **Phase 1:** silent divergence (OS points at a `.os` index that doesn't exist; shadow writes swallowed).
- **Phase 2:** the ES read-fallback masks it (logs ERROR per read).
- **Phase 3 (the cliff):** ES is decommissioned, no fallback → OS points at a missing index → **empty results / errors** = "content lost" for the customer.

`delete` already has a phase-aware guard (`assertIndexNotActive`); `activate` had none.

## Fix — a narrow guard

During the migration (phases 1/2/3), `activateIndex` now refuses to activate an index whose **OpenSearch counterpart does not exist**, throwing `DotStateException` (→ 400) with a clear message.

- It is **narrow**: a rollback to a **migration-era** index that DOES have its `.os` copy still works. Only the genuinely-broken case (no OS copy) is blocked.
- Phase 0 is not guarded (no OpenSearch store).
- Escape hatch: `ALLOW_ACTIVATE_INDEX_WITHOUT_OS_MIRROR=true` forces the activation (accepting that OpenSearch is left pointing at a missing index until rebuilt) — mirroring the `ALLOW_ACTIVE_INDEX_DELETE` override on the delete guard.

### Known trade-off (deliberate, "simple first")

A hard block conflicts with rollback: you can't roll back to a pre-migration index during the migration without first rebuilding it (or setting the override). The **non-blocking** alternative — allow the rollback, repoint ES instantly (stays transparent), and rebuild the OpenSearch copy **asynchronously** via the existing reindex machinery, with the readiness gate refusing Phase 3 until it's ready — is the intended **follow-up**. This PR is the cheap, safe first step that stops the silent Phase-3 detonation.

## Tests

- **`ContentletIndexAPIImplActivateGuardTest`** (6, surefire): blocks in phases 1/2/3 when the OS counterpart is missing; allows when it's present, in Phase 0, and under the override flag. Set-backed engine fakes control OS existence — no cluster needed.
- Fixed the shared `FakeContentletIndexOperations.indexAPI()` (previously threw) to report existence, so the existing phase-2/3 `activateIndex` tests in **`ContentletIndexAPIImplPhaseTest`** (14) keep passing under the new precondition.

**CI note:** migration integration tests that activate an index in a dual/OS phase now require the OS counterpart to exist (real bootstrap normally provides it). Watch the OpenSearch upgrade / phase suites.

## Notes

- Independent of the readiness endpoint (#36849) and the mirror-reconciliation PR (#36825); based on `main`. Tied to #36360 (no new issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
