### PR TITLE
Fix side panel accordion labels overlapping content on scroll

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-section/dot-edit-content-sidebar-section.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-section/dot-edit-content-sidebar-section.component.html
@@ -1,48 +1,28 @@
 <section
     class="dot-section flex flex-col border-b border-surface-200 py-3"
     data-testid="dot-section">
-    @if ($title()) {
-        <div
-            class="sticky top-0 z-10 flex min-h-12 shrink-0 cursor-pointer items-center justify-between rounded-md px-2 py-1 transition-colors hover:bg-surface-50"
-            role="button"
-            tabindex="0"
-            [attr.aria-expanded]="!$collapsed()"
-            data-testid="dot-section-toggle"
-            (click)="toggle()"
-            (keydown.enter)="toggle()"
-            (keydown.space)="$event.preventDefault(); toggle()">
-            <h2
-                class="m-0 text-sm leading-none font-bold tracking-[0.08em] text-gray-500 lowercase first-letter:uppercase"
-                data-testid="dot-section-title">
-                {{ $title() }}
-            </h2>
-            <div class="flex items-center gap-2">
-                @if (actionTemplate) {
-                    <div
-                        class="text-sm text-primary-500"
-                        data-testid="dot-section-action"
-                        (click)="$event.stopPropagation()"
-                        (keydown)="$event.stopPropagation()">
-                        <ng-container *ngTemplateOutlet="actionTemplate" />
-                    </div>
-                }
-                <i
-                    class="pi pi-chevron-down text-xs text-gray-500 transition-transform"
-                    [class.rotate-180]="!$collapsed()"
-                    data-testid="dot-section-chevron"></i>
-            </div>
-        </div>
-    }
-    <!-- Collapsible body: real slide down/up by animating the actual height via a
-         grid-template-rows transition (0fr <-> 1fr). Pure CSS, eased, works for any
-         content height. The inner pt-2 is the header/content gap and collapses too. -->
-    <div
-        class="grid transition-[grid-template-rows] duration-200 ease-in-out"
-        [style.grid-template-rows]="$collapsed() ? '0fr' : '1fr'">
-        <div class="min-h-0 overflow-hidden">
-            <div class="pt-2" data-testid="dot-section-content">
-                <ng-content />
-            </div>
-        </div>
-    </div>
+    <!-- Single-panel accordion: PrimeNG drives the click/keyboard toggle, the slide
+         motion and `aria-expanded`; this template only supplies the header/content look. -->
+    <p-accordion [value]="$accordionValue()" (valueChange)="onValueChange($event)">
+        <p-accordion-panel [value]="key()">
+            @if ($title()) {
+                <p-accordion-header data-testid="dot-section-toggle">
+                    <span data-testid="dot-section-title">{{ $title() }}</span>
+                    @if (actionTemplate) {
+                        <div
+                            data-testid="dot-section-action"
+                            (click)="$event.stopPropagation()"
+                            (keydown)="$event.stopPropagation()">
+                            <ng-container *ngTemplateOutlet="actionTemplate" />
+                        </div>
+                    }
+                </p-accordion-header>
+            }
+            <p-accordion-content [pt]="{ content: { class: '!p-0' } }">
+                <div class="pt-2" data-testid="dot-section-content">
+                    <ng-content />
+                </div>
+            </p-accordion-content>
+        </p-accordion-panel>
+    </p-accordion>
 </section>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-section/dot-edit-content-sidebar-section.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-section/dot-edit-content-sidebar-section.component.spec.ts
@@ -53,10 +53,6 @@ describe('DotEditContentSidebarSectionComponent', () => {
             expect(title).toHaveText('Test Section');
         });
 
-        it('should render the chevron icon', () => {
-            expect(spectator.query(byTestId('dot-section-chevron'))).toBeTruthy();
-        });
-
         it('should render action section', fakeAsync(() => {
             tick();
 
@@ -157,7 +153,10 @@ describe('DotEditContentSidebarSectionComponent', () => {
             spectator.detectChanges();
 
             const header = spectator.query(byTestId('dot-section-toggle')) as HTMLElement;
-            header.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            // PrimeNG's accordion header switches on `event.code`, not `event.key`.
+            header.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', bubbles: true })
+            );
             spectator.detectChanges();
 
             expect(spectator.component.$collapsed()).toBe(true);
@@ -180,20 +179,20 @@ describe('DotEditContentSidebarSectionComponent', () => {
             expect(spectator.component.$collapsed()).toBe(true);
         });
 
-        it('should rotate the chevron up when expanded (collapsed has it pointing down)', () => {
+        it('should mark the header aria-expanded when expanded', () => {
             localStorageService.getItem.mockReturnValue(false);
             spectator.detectChanges();
 
-            const chevron = spectator.query(byTestId('dot-section-chevron'));
-            expect(chevron).toHaveClass('rotate-180');
+            const header = spectator.query(byTestId('dot-section-toggle'));
+            expect(header).toHaveAttribute('aria-expanded', 'true');
         });
 
-        it('should not rotate the chevron when collapsed', () => {
+        it('should mark the header aria-expanded false when collapsed', () => {
             localStorageService.getItem.mockReturnValue(true);
             spectator.detectChanges();
 
-            const chevron = spectator.query(byTestId('dot-section-chevron'));
-            expect(chevron).not.toHaveClass('rotate-180');
+            const header = spectator.query(byTestId('dot-section-toggle'));
+            expect(header).toHaveAttribute('aria-expanded', 'false');
         });
 
         it('should not collapse when clicking the action slot', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-section/dot-edit-content-sidebar-section.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-section/dot-edit-content-sidebar-section.component.ts
@@ -4,10 +4,13 @@ import {
     Component,
     ContentChild,
     TemplateRef,
+    computed,
     inject,
     input,
     linkedSignal
 } from '@angular/core';
+
+import { AccordionModule } from 'primeng/accordion';
 
 import { DotLocalstorageService } from '@dotcms/data-access';
 
@@ -23,10 +26,14 @@ const SECTION_STORAGE_PREFIX = 'dot-edit-content.section.';
  *  header, and the collapsed state is persisted in localstorage under
  *  `dot-edit-content.section.<key>`. When no `key` is provided the section stays
  *  expanded and no storage writes happen (backward-compatible behaviour).
+ *
+ *  Internally this wraps a single-panel `p-accordion`: PrimeNG owns the slide motion,
+ *  the click/keyboard (Enter/Space) handling and the `aria-expanded` wiring on the
+ *  header; this component only adds the localstorage persistence on top of it.
  */
 @Component({
     selector: 'dot-edit-content-sidebar-section',
-    imports: [NgTemplateOutlet],
+    imports: [NgTemplateOutlet, AccordionModule],
     templateUrl: './dot-edit-content-sidebar-section.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
@@ -43,12 +50,15 @@ export class DotEditContentSidebarSectionComponent {
 
     /**
      * Unique key used to persist the collapsed state. When empty the section is
-     * not collapsible-persistent and stays expanded with no storage writes.
+     * not collapsible-persistent and stays expanded with no storage writes. Also
+     * doubles as the single panel's `value` inside the internal `p-accordion`.
      */
     key = input<string>('');
 
     /**
-     * Writable signal holding the collapsed state of the section.
+     * The internal `p-accordion`'s value: the section's own `key` while expanded,
+     * `undefined` while collapsed — the shape a single-panel (non-`multiple`)
+     * PrimeNG accordion expects.
      *
      * Initialised reactively once the `key` input is bound: when a key is present
      * it seeds from localstorage (default expanded when absent), otherwise it
@@ -59,13 +69,20 @@ export class DotEditContentSidebarSectionComponent {
      * change-detection cycle. If DotLocalstorageService ever becomes signal-backed, this would
      * snap back to the stored state on each read and the user's in-session toggle would be lost.
      */
-    $collapsed = linkedSignal<boolean>(() => {
+    $accordionValue = linkedSignal<string | undefined>(() => {
         const key = this.key();
-
-        return key
+        const collapsed = key
             ? !!this.#dotLocalstorageService.getItem<boolean>(SECTION_STORAGE_PREFIX + key)
             : false;
+
+        return collapsed ? undefined : key;
     });
+
+    /**
+     * Whether the section is currently collapsed, derived from `$accordionValue` for
+     * callers that only care about the boolean state (template bindings, tests).
+     */
+    $collapsed = computed<boolean>(() => this.$accordionValue() !== this.key());
 
     /**
      * The action template for the section.
@@ -74,16 +91,21 @@ export class DotEditContentSidebarSectionComponent {
     actionTemplate: TemplateRef<unknown>;
 
     /**
-     * Toggles the collapsed state of the section. When a `key` is present the new
-     * state is persisted to localstorage.
+     * Handles the accordion opening/closing its single panel: mirrors the new value into
+     * `$accordionValue` and, when a `key` is present, persists the resulting collapsed
+     * state to localstorage.
+     *
+     * @param value - The accordion's new value: the panel's `key` once it opens, or
+     * anything else (PrimeNG sends `undefined`) once it closes.
      */
-    toggle(): void {
-        const collapsed = !this.$collapsed();
-        this.$collapsed.set(collapsed);
-
+    onValueChange(value: unknown): void {
         const key = this.key();
+        const opened = value === key;
+
+        this.$accordionValue.set(opened ? key : undefined);
+
         if (key) {
-            this.#dotLocalstorageService.setItem<boolean>(SECTION_STORAGE_PREFIX + key, collapsed);
+            this.#dotLocalstorageService.setItem<boolean>(SECTION_STORAGE_PREFIX + key, !opened);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the custom collapsible section component (`dot-edit-content-sidebar-section`) with a single-panel PrimeNG `p-accordion` internally, keeping the same public API (`title`, `key`, `sectionAction` content template) so the 5 existing consumers (Actions tab + History tab) needed no changes.
- Fixes the label/content overlap on scroll by removing the custom `position: sticky` header — PrimeNG's default (non-sticky) header now handles click/keyboard toggling, `aria-expanded`, and the collapse/expand motion.
- Removes all custom CSS/markup on top of the accordion (custom chevron icon, header classes, title typography) so the sections render with PrimeNG's defaults, per the additional scope added to the issue.
- Persistence of each section's expanded/collapsed state in localstorage is preserved (`dot-edit-content.section.<key>`).

Fixes #36630

## Test plan
- [x] `dot-edit-content-sidebar-section` unit tests updated and passing (persistence, keyboard toggle, action-slot click doesn't collapse the section)
- [x] Full `edit-content` test suite passing (2158 tests)
- [ ] Manual QA: open a contentlet, expand/collapse Locales/Workflow/Details/History sections, scroll while a section is open — confirm the label no longer overlaps content
- [ ] Manual QA: confirm the Push Publish section's "..." menu still works and doesn't toggle the section when clicked

This PR fixes: #36630