### PR TITLE
fix(content-drive): expose folder permissions and edit-dialog fields on folder search #36595

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderResource.java
@@ -22,6 +22,7 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.browser.BrowserUtil;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
@@ -69,6 +70,16 @@ public class FolderResource implements Serializable {
     static final String SITE_ID_PARAM  = "siteId";
     static final String PATH_PARAM     = "path";
     static final String RECURSIVE_PARAM = "recursive";
+    static final String INCLUDE_PERMISSIONS_PARAM = "includePermissions";
+
+    /**
+     * Upper bound on {@code perPage} when {@code includePermissions=true}. Permission resolution is
+     * batched but chunked by 500 ids per type, so an unbounded page turns three batch calls into
+     * hundreds of queries. Requests above this cap are rejected rather than silently served without
+     * permissions, which would be indistinguishable from "the user has no grants".
+     */
+    static final String PERMISSIONS_MAX_PER_PAGE_KEY = "content.drive.folder.search.permissions.max.per.page";
+    static final int PERMISSIONS_MAX_PER_PAGE_DEFAULT = 200;
 
     private final WebResource webResource;
     private final FolderHelper folderHelper;
@@ -522,6 +533,7 @@ public class FolderResource implements Serializable {
      * @param siteId              site identifier (required)
      * @param page                1-based page number (default: 1)
      * @param perPage             results per page (default: 40)
+     * @param includePermissions  {@code true} to populate each view's {@code permissions} array
      * @return paginated list of matching {@link FolderSearchView} objects
      */
     @GET
@@ -533,13 +545,18 @@ public class FolderResource implements Serializable {
             summary = "Search folders",
             description = "Returns folders within a site matching an optional name filter and/or " +
                     "path scope. Supports recursive depth control, standard pagination, and sorting. " +
-                    "With no 'name' and default path '/' + recursive=true, all site folders are returned.")
+                    "With no 'name' and default path '/' + recursive=true, all site folders are returned. " +
+                    "Each folder carries the detail fields a folder-edit form needs (title, sortOrder, " +
+                    "filesMasks, defaultFileType, showOnMenu, defaultBaseType). Set " +
+                    "'includePermissions=true' to also receive the permission types the requesting user " +
+                    "holds on each folder; that flag caps 'perPage' (see the parameter description).")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",
                     description = "Paginated list of matching folders",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON,
-                            schema = @Schema(implementation = ResponseEntityPaginatedDataView.class))),
-            @ApiResponse(responseCode = "400", description = "'siteId' is required; 'name' must be at least 2 characters if provided"),
+                            schema = @Schema(implementation = ResponseEntityFolderSearchView.class))),
+            @ApiResponse(responseCode = "400", description = "'siteId' is required; 'name' must be at least 2 characters if provided; " +
+                    "'perPage' exceeds the maximum allowed when 'includePermissions' is true"),
             @ApiResponse(responseCode = "401", description = "User is not authenticated"),
             @ApiResponse(responseCode = "500", description = "Internal server error")
     })
@@ -563,13 +580,32 @@ public class FolderResource implements Serializable {
             @Parameter(description = "Page number (1-based, default 1)")
             @DefaultValue("1") @QueryParam(PaginationUtil.PAGE) final int page,
             @Parameter(description = "Number of results per page (default 40)")
-            @DefaultValue("40") @QueryParam(PaginationUtil.PER_PAGE) final int perPage) {
+            @DefaultValue("40") @QueryParam(PaginationUtil.PER_PAGE) final int perPage,
+            @Parameter(description = "When true, each returned folder includes a 'permissions' array with the "
+                    + "permission types the requesting user holds on it (READ, EDIT, PUBLISH, EDIT_PERMISSIONS, "
+                    + "CAN_ADD_CHILDREN). When false (the default) 'permissions' is null — meaning 'not requested', "
+                    + "which is not the same as an empty array ('requested, no grants'). Because permissions are "
+                    + "resolved per page, enabling this flag caps 'perPage' at the value of the '"
+                    + PERMISSIONS_MAX_PER_PAGE_KEY + "' configuration property (default "
+                    + PERMISSIONS_MAX_PER_PAGE_DEFAULT + "); a larger 'perPage' is rejected with a 400.")
+            @DefaultValue("false") @QueryParam(INCLUDE_PERMISSIONS_PARAM) final boolean includePermissions) {
 
         if (!UtilMethods.isSet(siteId)) {
             throw new BadRequestException("'siteId' query parameter is required");
         }
         if (UtilMethods.isSet(name) && name.length() < 2) {
             throw new BadRequestException("'name' must be at least 2 characters long");
+        }
+        final int permissionsMaxPerPage =
+                Config.getIntProperty(PERMISSIONS_MAX_PER_PAGE_KEY, PERMISSIONS_MAX_PER_PAGE_DEFAULT);
+        if (includePermissions && perPage > permissionsMaxPerPage) {
+            // Varargs form on purpose: HttpStatusCodeException runs String.format over the message
+            // itself, so pre-formatting here would format twice and blow up on a literal '%'.
+            throw new BadRequestException(
+                    "'perPage' cannot exceed %s when '%s' is true (requested: %s). Request a smaller page, "
+                            + "or drop '%s' to page without permissions.",
+                    String.valueOf(permissionsMaxPerPage), INCLUDE_PERMISSIONS_PARAM,
+                    String.valueOf(perPage), INCLUDE_PERMISSIONS_PARAM);
         }
 
         final User user = new WebResource.InitBuilder(webResource)
@@ -584,7 +620,8 @@ public class FolderResource implements Serializable {
         final Map<String, Object> extraParams = Map.of(
                 SITE_ID_PARAM, siteId,
                 PATH_PARAM, path,
-                RECURSIVE_PARAM, recursive);
+                RECURSIVE_PARAM, recursive,
+                INCLUDE_PERMISSIONS_PARAM, includePermissions);
 
         final OrderDirection orderDirection = switch (direction.toUpperCase()) {
             case "DESC" -> OrderDirection.DESC;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderResource.java
@@ -26,6 +26,7 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import com.dotcms.rest.ResponseEntityListView;
@@ -80,6 +81,9 @@ public class FolderResource implements Serializable {
      */
     static final String PERMISSIONS_MAX_PER_PAGE_KEY = "content.drive.folder.search.permissions.max.per.page";
     static final int PERMISSIONS_MAX_PER_PAGE_DEFAULT = 200;
+
+    /** Mirrors {@link PaginationUtil}'s own fallback for {@code dotcms.paginator.rows}. */
+    static final int DEFAULT_PAGINATION_ROWS = 10;
 
     private final WebResource webResource;
     private final FolderHelper folderHelper;
@@ -596,24 +600,16 @@ public class FolderResource implements Serializable {
         if (UtilMethods.isSet(name) && name.length() < 2) {
             throw new BadRequestException("'name' must be at least 2 characters long");
         }
-        final int permissionsMaxPerPage =
-                Config.getIntProperty(PERMISSIONS_MAX_PER_PAGE_KEY, PERMISSIONS_MAX_PER_PAGE_DEFAULT);
-        if (includePermissions && perPage > permissionsMaxPerPage) {
-            // Varargs form on purpose: HttpStatusCodeException runs String.format over the message
-            // itself, so pre-formatting here would format twice and blow up on a literal '%'.
-            throw new BadRequestException(
-                    "'perPage' cannot exceed %s when '%s' is true (requested: %s). Request a smaller page, "
-                            + "or drop '%s' to page without permissions.",
-                    String.valueOf(permissionsMaxPerPage), INCLUDE_PERMISSIONS_PARAM,
-                    String.valueOf(perPage), INCLUDE_PERMISSIONS_PARAM);
-        }
-
         final User user = new WebResource.InitBuilder(webResource)
                 .requestAndResponse(httpServletRequest, httpServletResponse)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
                 .rejectWhenNoUser(true)
                 .init().getUser();
+
+        // Deliberately below init(): unlike the checks above, this message discloses a configured
+        // value, so an unauthenticated caller should get a 401 rather than the cap.
+        validatePermissionsPerPage(includePermissions, perPage);
 
         validateSiteReadAccess(siteId, user);
 
@@ -641,6 +637,41 @@ public class FolderResource implements Serializable {
                 .build();
 
         return folderSearchPaginationUtil.getPageView(params);
+    }
+
+    /**
+     * Rejects requests that would resolve permissions for a page larger than
+     * {@link #PERMISSIONS_MAX_PER_PAGE_KEY} allows.
+     *
+     * <p>The check runs against the <b>effective</b> page size, not the raw query parameter:
+     * {@link PaginationUtil} replaces any {@code perPage <= 0} with
+     * {@code Config.getIntProperty(DOTCMS_PAGINATION_ROWS, 10)}. Validating the raw value would let
+     * {@code ?includePermissions=true&per_page=0} through and then page at whatever
+     * {@code dotcms.paginator.rows} happens to be — harmless at its default of 10, but it makes this
+     * guard depend on an unrelated property, so a deployment that raises that property above the cap
+     * would silently reopen the hole this check exists to close.
+     *
+     * @param includePermissions whether the caller asked for the {@code permissions} array
+     * @param perPage            the raw {@code per_page} query parameter
+     */
+    private void validatePermissionsPerPage(final boolean includePermissions, final int perPage) {
+        if (!includePermissions) {
+            return;
+        }
+        final int effectivePerPage = perPage <= 0
+                ? Config.getIntProperty(WebKeys.DOTCMS_PAGINATION_ROWS, DEFAULT_PAGINATION_ROWS)
+                : perPage;
+        final int permissionsMaxPerPage =
+                Config.getIntProperty(PERMISSIONS_MAX_PER_PAGE_KEY, PERMISSIONS_MAX_PER_PAGE_DEFAULT);
+        if (effectivePerPage > permissionsMaxPerPage) {
+            // Varargs form on purpose: HttpStatusCodeException runs String.format over the message
+            // itself, so pre-formatting here would format twice and blow up on a literal '%'.
+            throw new BadRequestException(
+                    "'perPage' cannot exceed %s when '%s' is true (effective page size: %s). "
+                            + "Request a smaller page, or drop '%s' to page without permissions.",
+                    String.valueOf(permissionsMaxPerPage), INCLUDE_PERMISSIONS_PARAM,
+                    String.valueOf(effectivePerPage), INCLUDE_PERMISSIONS_PARAM);
+        }
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderSearchView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderSearchView.java
@@ -1,5 +1,9 @@
 package com.dotcms.rest.api.v1.folder;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
 /**
  * REST view of a folder returned by the unified search endpoint
  * ({@code GET /api/v1/folder/search}).
@@ -11,13 +15,38 @@ package com.dotcms.rest.api.v1.folder;
  * <p>{@code defaultBaseType} carries the folder's Content Drive upload-mode preference (a
  * {@code BaseContentType} name such as {@code DOTASSET}/{@code FILEASSET}, or {@code null} for
  * no preference), so the Content Drive sidebar can read it without a second request.
+ *
+ * <p>{@code title}, {@code sortOrder}, {@code filesMasks}, {@code defaultFileType} and
+ * {@code showOnMenu} are the fields the Content Drive "Edit folder" dialog pre-populates from.
+ * They are read straight off the already-loaded {@code Folder} and are <b>always</b> present.
+ *
+ * <p>{@code permissions} is opt-in via the {@code includePermissions} query param, and its two
+ * absent-value states are <b>not</b> equivalent:
+ * <ul>
+ *   <li>{@code null} — permissions were <b>not requested</b>. Nothing can be inferred about the
+ *       user's grants.</li>
+ *   <li>{@code []} — permissions were requested and the user has <b>no</b> grants on the folder.</li>
+ * </ul>
+ * Consumers must map {@code null} to an empty collection before testing membership rather than
+ * treating the two states alike.
  */
 public record FolderSearchView(
-        String id,
-        String inode,
-        String name,
-        String path,
-        boolean addChildrenAllowed,
-        boolean hasChildren,
-        String defaultBaseType
+        @Schema(description = "Folder identifier") String id,
+        @Schema(description = "Folder inode") String inode,
+        @Schema(description = "Folder name (last path segment)") String name,
+        @Schema(description = "Parent path of the folder, e.g. '/application/' for '/application/blog/'") String path,
+        @Schema(description = "True when the requesting user has CAN_ADD_CHILDREN on this folder") boolean addChildrenAllowed,
+        @Schema(description = "True when the folder has at least one child folder readable by the requesting user") boolean hasChildren,
+        @Schema(description = "Content Drive upload-mode preference as a BaseContentType name (e.g. DOTASSET, FILEASSET); null when the folder has no preference") String defaultBaseType,
+        @Schema(description = "Folder title") String title,
+        @Schema(description = "Folder sort order used when ordering menu items") int sortOrder,
+        @Schema(description = "Comma-separated file-name masks allowed in this folder, e.g. '*.jpg,*.png'") String filesMasks,
+        @Schema(description = "Velocity variable name of the Content Type used by default for new files in this folder") String defaultFileType,
+        @Schema(description = "True when the folder is shown on navigation menus") boolean showOnMenu,
+        @ArraySchema(
+                arraySchema = @Schema(description = "Permission types the requesting user holds on this folder. "
+                        + "Only populated when 'includePermissions=true'; null means the permissions were not "
+                        + "requested, while an empty array means they were requested and the user holds none."),
+                schema = @Schema(allowableValues = {"READ", "EDIT", "PUBLISH", "EDIT_PERMISSIONS", "CAN_ADD_CHILDREN"}))
+        List<String> permissions
 ) {}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderSearchView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/FolderSearchView.java
@@ -49,4 +49,53 @@ public record FolderSearchView(
                         + "requested, while an empty array means they were requested and the user holds none."),
                 schema = @Schema(allowableValues = {"READ", "EDIT", "PUBLISH", "EDIT_PERMISSIONS", "CAN_ADD_CHILDREN"}))
         List<String> permissions
-) {}
+) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link FolderSearchView}. The record has thirteen components, several of them
+     * adjacent {@code String}s and {@code boolean}s — positional construction is easy to get
+     * silently wrong, so callers name what they set.
+     */
+    public static final class Builder {
+
+        private String id;
+        private String inode;
+        private String name;
+        private String path;
+        private boolean addChildrenAllowed;
+        private boolean hasChildren;
+        private String defaultBaseType;
+        private String title;
+        private int sortOrder;
+        private String filesMasks;
+        private String defaultFileType;
+        private boolean showOnMenu;
+        private List<String> permissions;
+
+        private Builder() {}
+
+        public Builder id(final String id) { this.id = id; return this; }
+        public Builder inode(final String inode) { this.inode = inode; return this; }
+        public Builder name(final String name) { this.name = name; return this; }
+        public Builder path(final String path) { this.path = path; return this; }
+        public Builder addChildrenAllowed(final boolean addChildrenAllowed) { this.addChildrenAllowed = addChildrenAllowed; return this; }
+        public Builder hasChildren(final boolean hasChildren) { this.hasChildren = hasChildren; return this; }
+        public Builder defaultBaseType(final String defaultBaseType) { this.defaultBaseType = defaultBaseType; return this; }
+        public Builder title(final String title) { this.title = title; return this; }
+        public Builder sortOrder(final int sortOrder) { this.sortOrder = sortOrder; return this; }
+        public Builder filesMasks(final String filesMasks) { this.filesMasks = filesMasks; return this; }
+        public Builder defaultFileType(final String defaultFileType) { this.defaultFileType = defaultFileType; return this; }
+        public Builder showOnMenu(final boolean showOnMenu) { this.showOnMenu = showOnMenu; return this; }
+        public Builder permissions(final List<String> permissions) { this.permissions = permissions; return this; }
+
+        public FolderSearchView build() {
+            return new FolderSearchView(id, inode, name, path, addChildrenAllowed, hasChildren,
+                    defaultBaseType, title, sortOrder, filesMasks, defaultFileType, showOnMenu,
+                    permissions);
+        }
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/ResponseEntityFolderSearchView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/folder/ResponseEntityFolderSearchView.java
@@ -1,0 +1,18 @@
+package com.dotcms.rest.api.v1.folder;
+
+import com.dotcms.rest.ResponseEntityView;
+import com.dotmarketing.util.PaginatedArrayList;
+
+/**
+ * Entity View for the paginated response of {@code GET /api/v1/folder/search}.
+ *
+ * <p>Exists so the response shape of that endpoint is expressed in the OpenAPI schema: the endpoint
+ * returns the generic {@link com.dotcms.rest.ResponseEntityView} wrapper whose {@code entity} is a
+ * {@link PaginatedArrayList} of {@link FolderSearchView}, which a generic view cannot describe.
+ */
+public class ResponseEntityFolderSearchView extends ResponseEntityView<PaginatedArrayList<FolderSearchView>> {
+
+    public ResponseEntityFolderSearchView(final PaginatedArrayList<FolderSearchView> entity) {
+        super(entity);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/util/pagination/FolderSearchPaginator.java
+++ b/dotCMS/src/main/java/com/dotcms/util/pagination/FolderSearchPaginator.java
@@ -6,9 +6,9 @@ import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.business.FolderSearchParams;
 import com.dotmarketing.util.PaginatedArrayList;
 import com.dotmarketing.util.UtilMethods;
-import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
 import java.util.Map;
+import org.apache.commons.lang3.BooleanUtils;
 
 /**
  * {@link PaginatorOrdered} implementation for the unified folder search endpoint.
@@ -18,20 +18,25 @@ import java.util.Map;
  * <p>Extra params expected in the map (keyed by the query param names defined in
  * the calling resource): {@code "siteId"}, {@code "path"}, {@code "recursive"},
  * {@code "includePermissions"}.
+ *
+ * @param folderAPI the API the search is delegated to; injectable for testing
  */
-public class FolderSearchPaginator implements PaginatorOrdered<FolderSearchView> {
+public record FolderSearchPaginator(FolderAPI folderAPI)
+        implements PaginatorOrdered<FolderSearchView> {
 
     private static final String DEFAULT_ORDER_BY_COLUMN = "folder.name";
 
-    private final FolderAPI folderAPI;
+    private static final String SITE_ID_PARAM = "siteId";
+    private static final String PATH_PARAM = "path";
+    private static final String RECURSIVE_PARAM = "recursive";
+    private static final String INCLUDE_PERMISSIONS_PARAM = "includePermissions";
 
+    /**
+     * Production entry point — the canonical constructor taking a {@link FolderAPI} exists for
+     * tests to inject a mock.
+     */
     public FolderSearchPaginator() {
         this(APILocator.getFolderAPI());
-    }
-
-    @VisibleForTesting
-    public FolderSearchPaginator(final FolderAPI folderAPI) {
-        this.folderAPI = folderAPI;
     }
 
     @Override
@@ -40,11 +45,11 @@ public class FolderSearchPaginator implements PaginatorOrdered<FolderSearchView>
             final OrderDirection direction, final Map<String, Object> extraParams)
             throws PaginationException {
 
-        final var ep = extraParams != null ? extraParams : Map.of();
-        final String siteId   = (String) ep.get("siteId");
-        final String path     = (String) ep.getOrDefault("path", "/");
-        final boolean recursive = Boolean.TRUE.equals(ep.get("recursive"));
-        final boolean includePermissions = Boolean.TRUE.equals(ep.get("includePermissions"));
+        final Map<String, Object> ep = extraParams != null ? extraParams : Map.of();
+        final String siteId = (String) ep.get(SITE_ID_PARAM);
+        final String path = (String) ep.getOrDefault(PATH_PARAM, "/");
+        final boolean recursive = toBoolean(ep.get(RECURSIVE_PARAM));
+        final boolean includePermissions = toBoolean(ep.get(INCLUDE_PERMISSIONS_PARAM));
 
         final String orderByColumn = switch (orderBy) {
             case "mod_date" -> "folder.mod_date";
@@ -69,5 +74,20 @@ public class FolderSearchPaginator implements PaginatorOrdered<FolderSearchView>
         } catch (final Exception e) {
             throw new PaginationException(e);
         }
+    }
+
+    /**
+     * Reads a boolean out of the untyped extra-params map.
+     *
+     * <p>The resource puts real {@link Boolean} values in, but the map is {@code Map<String, Object>}
+     * and other callers may hand over the raw query string, so string forms are accepted too —
+     * {@code BooleanUtils.toBoolean(String)} covers "true"/"yes"/"on"/"1" and their variants.
+     * Anything unrecognised, including {@code null}, reads as {@code false}.
+     */
+    private static boolean toBoolean(final Object value) {
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        return value != null && BooleanUtils.toBoolean(String.valueOf(value));
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/util/pagination/FolderSearchPaginator.java
+++ b/dotCMS/src/main/java/com/dotcms/util/pagination/FolderSearchPaginator.java
@@ -16,7 +16,8 @@ import java.util.Map;
  * path scoping, and recursive depth control.
  *
  * <p>Extra params expected in the map (keyed by the query param names defined in
- * the calling resource): {@code "siteId"}, {@code "path"}, {@code "recursive"}.
+ * the calling resource): {@code "siteId"}, {@code "path"}, {@code "recursive"},
+ * {@code "includePermissions"}.
  */
 public class FolderSearchPaginator implements PaginatorOrdered<FolderSearchView> {
 
@@ -43,6 +44,7 @@ public class FolderSearchPaginator implements PaginatorOrdered<FolderSearchView>
         final String siteId   = (String) ep.get("siteId");
         final String path     = (String) ep.getOrDefault("path", "/");
         final boolean recursive = Boolean.TRUE.equals(ep.get("recursive"));
+        final boolean includePermissions = Boolean.TRUE.equals(ep.get("includePermissions"));
 
         final String orderByColumn = switch (orderBy) {
             case "mod_date" -> "folder.mod_date";
@@ -61,6 +63,7 @@ public class FolderSearchPaginator implements PaginatorOrdered<FolderSearchView>
                     .offset(offset)
                     .orderBy(orderByColumn)
                     .orderDirection(orderDirection)
+                    .includePermissions(includePermissions)
                     .build();
             return folderAPI.searchFolders(params);
         } catch (final Exception e) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -811,78 +811,119 @@ public class FolderAPIImpl implements FolderAPI  {
 	public PaginatedArrayList<FolderSearchView> searchFolders(final FolderSearchParams params)
 			throws DotDataException, DotSecurityException {
 
-		// 1. Load all matching folders (no LIMIT — pagination happens in Java so that
-		//    permission filtering does not produce short pages for limited users).
-		final var all = folderFactory.searchFolders(params);
+		// Load all matching folders (no LIMIT — pagination happens in Java so that permission
+		// filtering does not produce short pages for limited users), then batch-filter by READ in a
+		// single SQL round-trip for the whole collection.
+		final List<Folder> readable = permissionAPI.filterCollection(
+				folderFactory.searchFolders(params), PermissionAPI.PERMISSION_READ,
+				params.user(), params.respectFrontendRoles());
 
-		// 2. Batch READ filter — one SQL round-trip for the entire collection.
-		final var filtered = permissionAPI.filterCollection(
-				all, PermissionAPI.PERMISSION_READ, params.user(), params.respectFrontendRoles());
+		final int total = readable.size();
+		final List<Folder> page = paginate(readable, params);
 
-		// 3. Java pagination — applied after permission filtering for correctness.
-		final int total = filtered.size();
-		final int from  = Math.min(params.offset(), total);
-		final int to    = params.limit() < 0 ? total : Math.min(params.offset() + params.limit(), total);
-		final var page  = filtered.subList(from, to);
-
-		// 4. Batch CAN_ADD_CHILDREN check — only on the page (≤ perPage items).
-		final Set<String> canAddIds = permissionAPI.filterCollection(
-				page, PermissionAPI.PERMISSION_CAN_ADD_CHILDREN, params.user(), params.respectFrontendRoles())
-				.stream().map(Permissionable::getPermissionId).collect(Collectors.toSet());
-
-		// 5. Opt-in permission types, each a batch call scoped to the page. READ needs no call (the
-		//    folder is here because it passed the READ filter in step 2) and CAN_ADD_CHILDREN reuses
-		//    step 4, so the full 5-type set costs 3 extra calls.
-		final Set<String> editableIds        = filterIdsByPermission(page, PermissionAPI.PERMISSION_EDIT, params);
-		final Set<String> publishableIds     = filterIdsByPermission(page, PermissionAPI.PERMISSION_PUBLISH, params);
-		final Set<String> editPermissionsIds = filterIdsByPermission(page, PermissionAPI.PERMISSION_EDIT_PERMISSIONS, params);
-
-		// 6. Determine which folders have permission-visible children.
+		final PagePermissions permissions = resolvePagePermissions(page, params);
 		final Set<String> parentPathsWithVisibleChildren =
 				findParentPathsWithVisibleChildren(page, params);
 
-		// 7. Map to views.
-		final var views = page.stream()
-				.map(folder -> {
-					final var fullPath   = folder.getPath();
-					final var parentPath = fullPath.substring(0, fullPath.length() - folder.getName().length() - 1);
-					final List<String> permissions = params.includePermissions()
-							? permissionNames(folder, canAddIds, editableIds, publishableIds, editPermissionsIds)
-							: null;
-					return new FolderSearchView(
-							folder.getIdentifier(), folder.getInode(), folder.getName(),
-							parentPath, canAddIds.contains(folder.getPermissionId()),
-							parentPathsWithVisibleChildren.contains(folder.getPath()),
-							folder.getDefaultBaseType(),
-							folder.getTitle(), folder.getSortOrder(), folder.getFilesMasks(),
-							folder.getDefaultFileType(), folder.isShowOnMenu(),
-							permissions);
-				})
-				.toList();
-
-		final var result = new PaginatedArrayList<FolderSearchView>();
+		final PaginatedArrayList<FolderSearchView> result = new PaginatedArrayList<>();
 		result.setTotalResults(total);
-		result.addAll(views);
+		result.addAll(toViews(page, permissions, parentPathsWithVisibleChildren, params));
 		return result;
 	}
 
 	/**
-	 * Batch-resolves which folders in {@code page} the requesting user holds {@code permission} on,
-	 * returning their permission ids. Returns an empty set — issuing no query at all — when
-	 * {@link FolderSearchParams#includePermissions()} is {@code false}.
+	 * The permission-id sets resolved for a single page of folders.
 	 *
-	 * @param page       the already-paginated slice; never the pre-pagination collection
-	 * @param permission one of the {@code PermissionAPI.PERMISSION_*} constants
+	 * <p>{@code canAddIds} is always populated — it backs {@code addChildrenAllowed} whether or not
+	 * permissions were requested. The other three are empty unless
+	 * {@link FolderSearchParams#includePermissions()} is set.
 	 */
-	private Set<String> filterIdsByPermission(final List<Folder> page, final int permission,
+	private record PagePermissions(Set<String> canAddIds, Set<String> editableIds,
+			Set<String> publishableIds, Set<String> editPermissionsIds) {}
+
+	/**
+	 * Slices the requested page out of the permission-filtered collection. Pagination happens here,
+	 * in Java, rather than in SQL so that a limited user does not receive short pages when the
+	 * READ filter removes rows.
+	 */
+	private static List<Folder> paginate(final List<Folder> readable, final FolderSearchParams params) {
+		final int total = readable.size();
+		final int from  = Math.min(params.offset(), total);
+		final int to    = params.limit() < 0 ? total : Math.min(params.offset() + params.limit(), total);
+		return readable.subList(from, to);
+	}
+
+	/**
+	 * Batch-resolves the permissions the requesting user holds over {@code page} — always the
+	 * post-pagination slice (≤ perPage items), never the pre-pagination collection.
+	 *
+	 * <p>{@code READ} needs no call at all: a folder is only in {@code page} because it passed the
+	 * READ filter. {@code CAN_ADD_CHILDREN} is resolved unconditionally. So the full five-type set
+	 * costs three extra calls, and requesting no permissions costs none.
+	 */
+	private PagePermissions resolvePagePermissions(final List<Folder> page,
 			final FolderSearchParams params) throws DotDataException, DotSecurityException {
 
+		final Set<String> canAddIds =
+				permissionIds(page, PermissionAPI.PERMISSION_CAN_ADD_CHILDREN, params);
 		if (!params.includePermissions()) {
-			return Set.of();
+			return new PagePermissions(canAddIds, Set.of(), Set.of(), Set.of());
 		}
+		return new PagePermissions(canAddIds,
+				permissionIds(page, PermissionAPI.PERMISSION_EDIT, params),
+				permissionIds(page, PermissionAPI.PERMISSION_PUBLISH, params),
+				permissionIds(page, PermissionAPI.PERMISSION_EDIT_PERMISSIONS, params));
+	}
+
+	/**
+	 * Returns the permission ids of the folders in {@code page} that the requesting user holds
+	 * {@code permission} on.
+	 *
+	 * @param permission one of the {@code PermissionAPI.PERMISSION_*} constants
+	 */
+	private Set<String> permissionIds(final List<Folder> page, final int permission,
+			final FolderSearchParams params) throws DotDataException, DotSecurityException {
+
 		return permissionAPI.filterCollection(
 				page, permission, params.user(), params.respectFrontendRoles())
 				.stream().map(Permissionable::getPermissionId).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Maps the page of folders to their REST views. Pure mapping — every value is already resolved.
+	 */
+	private static List<FolderSearchView> toViews(final List<Folder> page,
+			final PagePermissions permissions, final Set<String> parentPathsWithVisibleChildren,
+			final FolderSearchParams params) {
+
+		return page.stream()
+				.map(folder -> FolderSearchView.builder()
+						.id(folder.getIdentifier())
+						.inode(folder.getInode())
+						.name(folder.getName())
+						.path(parentPathOf(folder))
+						.addChildrenAllowed(permissions.canAddIds().contains(folder.getPermissionId()))
+						.hasChildren(parentPathsWithVisibleChildren.contains(folder.getPath()))
+						.defaultBaseType(folder.getDefaultBaseType())
+						.title(folder.getTitle())
+						.sortOrder(folder.getSortOrder())
+						.filesMasks(folder.getFilesMasks())
+						.defaultFileType(folder.getDefaultFileType())
+						.showOnMenu(folder.isShowOnMenu())
+						.permissions(params.includePermissions()
+								? permissionNames(folder, permissions)
+								: null)
+						.build())
+				.toList();
+	}
+
+	/**
+	 * Strips the folder's own name off its full path, leaving the parent path
+	 * (e.g. {@code "/application/blog/"} → {@code "/application/"}).
+	 */
+	private static String parentPathOf(final Folder folder) {
+		final String fullPath = folder.getPath();
+		return fullPath.substring(0, fullPath.length() - folder.getName().length() - 1);
 	}
 
 	/**
@@ -893,24 +934,22 @@ public class FolderAPIImpl implements FolderAPI  {
 	 * {@link PermissionAPI.Type#getCanonicalTypes()}, which carries the {@code WRITE} alias instead
 	 * of {@code EDIT} and would emit a name no consumer checks for.
 	 */
-	private static List<String> permissionNames(final Folder folder, final Set<String> canAddIds,
-			final Set<String> editableIds, final Set<String> publishableIds,
-			final Set<String> editPermissionsIds) {
+	private static List<String> permissionNames(final Folder folder, final PagePermissions permissions) {
 
 		final String permissionId = folder.getPermissionId();
 		final List<String> names = new ArrayList<>(5);
 		// READ is implicit: the folder only reaches this point by passing the READ filter.
 		names.add(PermissionAPI.Type.READ.name());
-		if (editableIds.contains(permissionId)) {
+		if (permissions.editableIds().contains(permissionId)) {
 			names.add(PermissionAPI.Type.EDIT.name());
 		}
-		if (publishableIds.contains(permissionId)) {
+		if (permissions.publishableIds().contains(permissionId)) {
 			names.add(PermissionAPI.Type.PUBLISH.name());
 		}
-		if (editPermissionsIds.contains(permissionId)) {
+		if (permissions.editPermissionsIds().contains(permissionId)) {
 			names.add(PermissionAPI.Type.EDIT_PERMISSIONS.name());
 		}
-		if (canAddIds.contains(permissionId)) {
+		if (permissions.canAddIds().contains(permissionId)) {
 			names.add(PermissionAPI.Type.CAN_ADD_CHILDREN.name());
 		}
 		return names;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -830,20 +830,33 @@ public class FolderAPIImpl implements FolderAPI  {
 				page, PermissionAPI.PERMISSION_CAN_ADD_CHILDREN, params.user(), params.respectFrontendRoles())
 				.stream().map(Permissionable::getPermissionId).collect(Collectors.toSet());
 
-		// 5. Determine which folders have permission-visible children.
+		// 5. Opt-in permission types, each a batch call scoped to the page. READ needs no call (the
+		//    folder is here because it passed the READ filter in step 2) and CAN_ADD_CHILDREN reuses
+		//    step 4, so the full 5-type set costs 3 extra calls.
+		final Set<String> editableIds        = filterIdsByPermission(page, PermissionAPI.PERMISSION_EDIT, params);
+		final Set<String> publishableIds     = filterIdsByPermission(page, PermissionAPI.PERMISSION_PUBLISH, params);
+		final Set<String> editPermissionsIds = filterIdsByPermission(page, PermissionAPI.PERMISSION_EDIT_PERMISSIONS, params);
+
+		// 6. Determine which folders have permission-visible children.
 		final Set<String> parentPathsWithVisibleChildren =
 				findParentPathsWithVisibleChildren(page, params);
 
-		// 6. Map to views.
+		// 7. Map to views.
 		final var views = page.stream()
 				.map(folder -> {
 					final var fullPath   = folder.getPath();
 					final var parentPath = fullPath.substring(0, fullPath.length() - folder.getName().length() - 1);
+					final List<String> permissions = params.includePermissions()
+							? permissionNames(folder, canAddIds, editableIds, publishableIds, editPermissionsIds)
+							: null;
 					return new FolderSearchView(
 							folder.getIdentifier(), folder.getInode(), folder.getName(),
 							parentPath, canAddIds.contains(folder.getPermissionId()),
 							parentPathsWithVisibleChildren.contains(folder.getPath()),
-							folder.getDefaultBaseType());
+							folder.getDefaultBaseType(),
+							folder.getTitle(), folder.getSortOrder(), folder.getFilesMasks(),
+							folder.getDefaultFileType(), folder.isShowOnMenu(),
+							permissions);
 				})
 				.toList();
 
@@ -851,6 +864,56 @@ public class FolderAPIImpl implements FolderAPI  {
 		result.setTotalResults(total);
 		result.addAll(views);
 		return result;
+	}
+
+	/**
+	 * Batch-resolves which folders in {@code page} the requesting user holds {@code permission} on,
+	 * returning their permission ids. Returns an empty set — issuing no query at all — when
+	 * {@link FolderSearchParams#includePermissions()} is {@code false}.
+	 *
+	 * @param page       the already-paginated slice; never the pre-pagination collection
+	 * @param permission one of the {@code PermissionAPI.PERMISSION_*} constants
+	 */
+	private Set<String> filterIdsByPermission(final List<Folder> page, final int permission,
+			final FolderSearchParams params) throws DotDataException, DotSecurityException {
+
+		if (!params.includePermissions()) {
+			return Set.of();
+		}
+		return permissionAPI.filterCollection(
+				page, permission, params.user(), params.respectFrontendRoles())
+				.stream().map(Permissionable::getPermissionId).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Builds the permission-type names granted on {@code folder}, matching the set and the spelling
+	 * the Content Drive table's folder view emits so both views gate the context menu identically.
+	 *
+	 * <p>Names come from {@link PermissionAPI.Type} constants rather than
+	 * {@link PermissionAPI.Type#getCanonicalTypes()}, which carries the {@code WRITE} alias instead
+	 * of {@code EDIT} and would emit a name no consumer checks for.
+	 */
+	private static List<String> permissionNames(final Folder folder, final Set<String> canAddIds,
+			final Set<String> editableIds, final Set<String> publishableIds,
+			final Set<String> editPermissionsIds) {
+
+		final String permissionId = folder.getPermissionId();
+		final List<String> names = new ArrayList<>(5);
+		// READ is implicit: the folder only reaches this point by passing the READ filter.
+		names.add(PermissionAPI.Type.READ.name());
+		if (editableIds.contains(permissionId)) {
+			names.add(PermissionAPI.Type.EDIT.name());
+		}
+		if (publishableIds.contains(permissionId)) {
+			names.add(PermissionAPI.Type.PUBLISH.name());
+		}
+		if (editPermissionsIds.contains(permissionId)) {
+			names.add(PermissionAPI.Type.EDIT_PERMISSIONS.name());
+		}
+		if (canAddIds.contains(permissionId)) {
+			names.add(PermissionAPI.Type.CAN_ADD_CHILDREN.name());
+		}
+		return names;
 	}
 
 	/**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderSearchParams.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderSearchParams.java
@@ -6,6 +6,10 @@ import java.util.Objects;
 /**
  * Encapsulates all parameters for {@link FolderAPI#searchFolders}.
  * Construct via {@link #builder()}.
+ *
+ * <p>{@code includePermissions} opts into per-folder permission computation: when {@code false}
+ * (the default) the resulting views carry a {@code null} permission list and no extra permission
+ * query is issued.
  */
 public record FolderSearchParams(
         String name,
@@ -17,7 +21,8 @@ public record FolderSearchParams(
         int limit,
         int offset,
         String orderBy,
-        String orderDirection) {
+        String orderDirection,
+        boolean includePermissions) {
 
     public static Builder builder() {
         return new Builder();
@@ -34,6 +39,7 @@ public record FolderSearchParams(
         private int offset = 0;
         private String orderBy = "folder.name";
         private String orderDirection = "ASC";
+        private boolean includePermissions = false;
 
         private Builder() {}
 
@@ -47,12 +53,13 @@ public record FolderSearchParams(
         public Builder offset(final int offset) { this.offset = offset; return this; }
         public Builder orderBy(final String orderBy) { this.orderBy = orderBy; return this; }
         public Builder orderDirection(final String orderDirection) { this.orderDirection = orderDirection; return this; }
+        public Builder includePermissions(final boolean includePermissions) { this.includePermissions = includePermissions; return this; }
 
         public FolderSearchParams build() {
             Objects.requireNonNull(siteId, "siteId is required");
             Objects.requireNonNull(user,   "user is required");
             return new FolderSearchParams(name, path, recursive, siteId, user,
-                    respectFrontendRoles, limit, offset, orderBy, orderDirection);
+                    respectFrontendRoles, limit, offset, orderBy, orderDirection, includePermissions);
         }
     }
 }

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -10429,7 +10429,10 @@ paths:
       description: "Returns folders within a site matching an optional name filter\
         \ and/or path scope. Supports recursive depth control, standard pagination,\
         \ and sorting. With no 'name' and default path '/' + recursive=true, all site\
-        \ folders are returned."
+        \ folders are returned. Each folder carries the detail fields a folder-edit\
+        \ form needs (title, sortOrder, filesMasks, defaultFileType, showOnMenu, defaultBaseType).\
+        \ Set 'includePermissions=true' to also receive the permission types the requesting\
+        \ user holds on each folder; that flag caps 'perPage' (see the parameter description)."
       operationId: searchFolders
       parameters:
       - description: Optional case-insensitive partial match on folder name (minimum
@@ -10488,16 +10491,30 @@ paths:
           type: integer
           format: int32
           default: 40
+      - description: "When true, each returned folder includes a 'permissions' array\
+          \ with the permission types the requesting user holds on it (READ, EDIT,\
+          \ PUBLISH, EDIT_PERMISSIONS, CAN_ADD_CHILDREN). When false (the default)\
+          \ 'permissions' is null — meaning 'not requested', which is not the same\
+          \ as an empty array ('requested, no grants'). Because permissions are resolved\
+          \ per page, enabling this flag caps 'perPage' at the value of the 'content.drive.folder.search.permissions.max.per.page'\
+          \ configuration property (default 200); a larger 'perPage' is rejected with\
+          \ a 400."
+        in: query
+        name: includePermissions
+        schema:
+          type: boolean
+          default: false
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityPaginatedDataView"
+                $ref: "#/components/schemas/ResponseEntityFolderSearchView"
           description: Paginated list of matching folders
         "400":
           description: '''siteId'' is required; ''name'' must be at least 2 characters
-            if provided'
+            if provided; ''perPage'' exceeds the maximum allowed when ''includePermissions''
+            is true'
         "401":
           description: User is not authenticated
         "500":
@@ -27444,6 +27461,65 @@ components:
           type: string
         path:
           type: string
+    FolderSearchView:
+      type: object
+      properties:
+        addChildrenAllowed:
+          type: boolean
+          description: True when the requesting user has CAN_ADD_CHILDREN on this
+            folder
+        defaultBaseType:
+          type: string
+          description: "Content Drive upload-mode preference as a BaseContentType\
+            \ name (e.g. DOTASSET, FILEASSET); null when the folder has no preference"
+        defaultFileType:
+          type: string
+          description: Velocity variable name of the Content Type used by default
+            for new files in this folder
+        filesMasks:
+          type: string
+          description: "Comma-separated file-name masks allowed in this folder, e.g.\
+            \ '*.jpg,*.png'"
+        hasChildren:
+          type: boolean
+          description: True when the folder has at least one child folder readable
+            by the requesting user
+        id:
+          type: string
+          description: Folder identifier
+        inode:
+          type: string
+          description: Folder inode
+        name:
+          type: string
+          description: Folder name (last path segment)
+        path:
+          type: string
+          description: "Parent path of the folder, e.g. '/application/' for '/application/blog/'"
+        permissions:
+          type: array
+          description: "Permission types the requesting user holds on this folder.\
+            \ Only populated when 'includePermissions=true'; null means the permissions\
+            \ were not requested, while an empty array means they were requested and\
+            \ the user holds none."
+          items:
+            type: string
+            enum:
+            - READ
+            - EDIT
+            - PUBLISH
+            - EDIT_PERMISSIONS
+            - CAN_ADD_CHILDREN
+        showOnMenu:
+          type: boolean
+          description: True when the folder is shown on navigation menus
+        sortOrder:
+          type: integer
+          format: int32
+          description: Folder sort order used when ordering menu items
+        title:
+          type: string
+          description: Folder title
     FolderView:
       type: object
       properties:
@@ -29961,6 +30037,22 @@ components:
           type: object
           additionalProperties:
             type: object
+    PaginatedArrayListFolderSearchView:
+      type: array
+      items:
+        $ref: "#/components/schemas/FolderSearchView"
+      properties:
+        empty:
+          type: boolean
+        first:
+          $ref: "#/components/schemas/FolderSearchView"
+        last:
+          $ref: "#/components/schemas/FolderSearchView"
+        query:
+          type: string
+        totalResults:
+          type: integer
+          format: int64
     PaginatedArrayListMapStringObject:
       type: array
       items:
@@ -31958,6 +32050,43 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FolderSearchResultView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityFolderSearchView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/FolderSearchView"
+          properties:
+            empty:
+              type: boolean
+            first:
+              $ref: "#/components/schemas/FolderSearchView"
+            last:
+              $ref: "#/components/schemas/FolderSearchView"
+            query:
+              type: string
+            totalResults:
+              type: integer
+              format: int64
         errors:
           type: array
           items:

--- a/dotCMS/src/test/java/com/dotcms/util/pagination/FolderSearchPaginatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/pagination/FolderSearchPaginatorTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -200,6 +201,96 @@ public class FolderSearchPaginatorTest {
                 paginator.getItems(user, name, 20, 0, "mod_date", OrderDirection.DESC, extraParams);
 
         assertSame(results, items);
+        verify(folderAPI).searchFolders(expected);
+    }
+
+    /**
+     * Method to test: {@link FolderSearchPaginator#getItems} <br>
+     * Given Scenario: includePermissions=true in the extra params <br>
+     * Expected Result: FolderAPI called with includePermissions=true
+     */
+    @Test
+    public void test_getItems_includePermissionsTrue_passedThrough() throws Exception {
+        final String siteId = "site-1";
+        final User user = new User();
+        final FolderSearchParams expected = FolderSearchParams.builder()
+                .siteId(siteId)
+                .user(user)
+                .limit(40)
+                .offset(0)
+                .includePermissions(true)
+                .build();
+
+        when(folderAPI.searchFolders(expected)).thenReturn(results);
+
+        final Map<String, Object> extraParams = new HashMap<>();
+        extraParams.put("siteId", siteId);
+        extraParams.put("includePermissions", true);
+
+        final PaginatedArrayList<FolderSearchView> items =
+                paginator.getItems(user, null, 40, 0, null, null, extraParams);
+
+        assertSame(results, items);
+        verify(folderAPI).searchFolders(expected);
+    }
+
+    /**
+     * Method to test: {@link FolderSearchPaginator#getItems} <br>
+     * Given Scenario: includePermissions explicitly false in the extra params <br>
+     * Expected Result: FolderAPI called with includePermissions=false
+     */
+    @Test
+    public void test_getItems_includePermissionsFalse_passedThrough() throws Exception {
+        final String siteId = "site-1";
+        final User user = new User();
+        final FolderSearchParams expected = FolderSearchParams.builder()
+                .siteId(siteId)
+                .user(user)
+                .limit(40)
+                .offset(0)
+                .includePermissions(false)
+                .build();
+
+        when(folderAPI.searchFolders(expected)).thenReturn(results);
+
+        final Map<String, Object> extraParams = new HashMap<>();
+        extraParams.put("siteId", siteId);
+        extraParams.put("includePermissions", false);
+
+        final PaginatedArrayList<FolderSearchView> items =
+                paginator.getItems(user, null, 40, 0, null, null, extraParams);
+
+        assertSame(results, items);
+        verify(folderAPI).searchFolders(expected);
+    }
+
+    /**
+     * Method to test: {@link FolderSearchPaginator#getItems} <br>
+     * Given Scenario: includePermissions absent from the extra params <br>
+     * Expected Result: FolderAPI called with includePermissions=false (the builder default)
+     */
+    @Test
+    public void test_getItems_includePermissionsAbsent_defaultsToFalse() throws Exception {
+        final String siteId = "site-1";
+        final User user = new User();
+        final FolderSearchParams expected = FolderSearchParams.builder()
+                .siteId(siteId)
+                .user(user)
+                .limit(40)
+                .offset(0)
+                .build();
+
+        when(folderAPI.searchFolders(expected)).thenReturn(results);
+
+        final Map<String, Object> extraParams = new HashMap<>();
+        extraParams.put("siteId", siteId);
+
+        final PaginatedArrayList<FolderSearchView> items =
+                paginator.getItems(user, null, 40, 0, null, null, extraParams);
+
+        assertSame(results, items);
+        assertFalse("absent extra param must not enable permission computation",
+                expected.includePermissions());
         verify(folderAPI).searchFolders(expected);
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite2b.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite2b.java
@@ -152,6 +152,8 @@ import com.dotmarketing.portlets.contentlet.model.ContentletDependenciesTest;
 import com.dotmarketing.portlets.contentlet.model.IntegrationResourceLinkTest;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPIImplIntegrationTest;
 import com.dotmarketing.portlets.fileassets.business.FileAssetFactoryIntegrationTest;
+import com.dotmarketing.portlets.folders.business.FolderAPIImplFilterTest;
+import com.dotmarketing.portlets.folders.business.FolderFactoryImplFilterTest;
 import com.dotmarketing.portlets.folders.business.FolderFactoryImplTest;
 import com.dotmarketing.portlets.folders.model.FolderTest;
 import com.dotmarketing.portlets.templates.business.FileAssetTemplateUtilTest;
@@ -528,6 +530,8 @@ import org.junit.runners.Suite.SuiteClasses;
         LanguageUtilTest.class,
         FolderResourceTest.class,
         FolderResourceSearchTest.class,
+        FolderAPIImplFilterTest.class,
+        FolderFactoryImplFilterTest.class,
         Task05225RemoveLoadRecordsToIndexTest.class,
         PublisherFilterImplTest.class,
         PushPublishFiltersInitializerTest.class,

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/folder/FolderResourceSearchTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/folder/FolderResourceSearchTest.java
@@ -22,6 +22,7 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 import com.liferay.util.Base64;
 import org.junit.Assert;
@@ -538,6 +539,58 @@ public class FolderResourceSearchTest {
                 getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
                 "res-cap-at-" + ts, "/", true, site.getIdentifier(),
                 "name", "ASC", 1, cap, true);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1, ((List<?>) result.getEntity()).size());
+    }
+
+    /**
+     * Given Scenario: {@code includePermissions=true} with {@code per_page=0} while
+     * {@code dotcms.paginator.rows} is raised above the cap. <br>
+     * Expected Result: 400. {@link com.dotcms.util.PaginationUtil} turns any {@code perPage <= 0}
+     * into {@code dotcms.paginator.rows}, so validating the raw parameter would let this through and
+     * then page above the cap. The guard must run against the effective page size.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_perPageZero_validatesEffectivePageSize()
+            throws DotDataException, DotSecurityException {
+        final int cap = Config.getIntProperty(FolderResource.PERMISSIONS_MAX_PER_PAGE_KEY,
+                FolderResource.PERMISSIONS_MAX_PER_PAGE_DEFAULT);
+        final int originalRows = Config.getIntProperty(WebKeys.DOTCMS_PAGINATION_ROWS,
+                FolderResource.DEFAULT_PAGINATION_ROWS);
+        Config.setProperty(WebKeys.DOTCMS_PAGINATION_ROWS, cap + 1);
+        try {
+            resource.searchFolders(
+                    getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
+                    null, "/", true, site().getIdentifier(),
+                    "name", "ASC", 1, 0, true);
+            Assert.fail("Expected a BadRequestException: per_page=0 resolves to a page above the cap");
+        } catch (final BadRequestException e) {
+            final String clientMessage = errorMessageOf(e);
+            Assert.assertTrue("the 400 must report the effective page size, got: " + clientMessage,
+                    clientMessage.contains(String.valueOf(cap + 1)));
+        } finally {
+            Config.setProperty(WebKeys.DOTCMS_PAGINATION_ROWS, originalRows);
+        }
+    }
+
+    /**
+     * Given Scenario: {@code includePermissions=true} with {@code per_page=0} under the default
+     * {@code dotcms.paginator.rows}. <br>
+     * Expected Result: 200 — the effective page size (10 by default) is well under the cap, so the
+     * stricter guard must not reject ordinary callers that omit the parameter.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_perPageZero_underDefaultRows_succeeds()
+            throws DotDataException, DotSecurityException {
+        final long ts = System.currentTimeMillis();
+        final Host site = new SiteDataGen().nextPersisted();
+        new FolderDataGen().site(site).name("res-zero-" + ts).nextPersisted();
+
+        final var result = resource.searchFolders(
+                getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
+                "res-zero-" + ts, "/", true, site.getIdentifier(),
+                "name", "ASC", 1, 0, true);
 
         Assert.assertNotNull(result);
         Assert.assertEquals(1, ((List<?>) result.getEntity()).size());

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/folder/FolderResourceSearchTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/folder/FolderResourceSearchTest.java
@@ -21,6 +21,7 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.util.Config;
 import com.liferay.portal.model.User;
 import com.liferay.util.Base64;
 import org.junit.Assert;
@@ -67,7 +68,7 @@ public class FolderResourceSearchTest {
         return resource.searchFolders(
                 getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
                 name, path != null ? path : "/", recursive, siteId,
-                "name", "ASC", 1, 40);
+                "name", "ASC", 1, 40, false);
     }
 
     // ── Name-filter tests ────────────────────────────────────────────────────
@@ -188,7 +189,7 @@ public class FolderResourceSearchTest {
         final var result = resource.searchFolders(
                 getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
                 "paged-" + ts, "/", true, site.getIdentifier(),
-                "name", "ASC", 2, 1);
+                "name", "ASC", 2, 1, false);
 
         Assert.assertEquals(1, ((List<?>) result.getEntity()).size());
     }
@@ -204,7 +205,7 @@ public class FolderResourceSearchTest {
         resource.searchFolders(
                 getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
                 "images", "/", true, null,
-                "name", "ASC", 1, 40);
+                "name", "ASC", 1, 40, false);
     }
 
     /**
@@ -216,7 +217,7 @@ public class FolderResourceSearchTest {
         resource.searchFolders(
                 getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
                 "a", "/", true, "some-site-id",
-                "name", "ASC", 1, 40);
+                "name", "ASC", 1, 40, false);
     }
 
     // ── hasChildren field tests ───────────────────────────────────────────────
@@ -311,7 +312,7 @@ public class FolderResourceSearchTest {
         final var result = resource.searchFolders(
                 getHttpRequest(limitedUser.getEmailAddress(), password), response,
                 "hc-perm-parent-" + ts, "/", true, site.getIdentifier(),
-                "name", "ASC", 1, 40);
+                "name", "ASC", 1, 40, false);
 
         Assert.assertNotNull(result);
         @SuppressWarnings("unchecked")
@@ -354,7 +355,7 @@ public class FolderResourceSearchTest {
                         .request());
         try {
             resource.searchFolders(request, response, null, "/", true, "some-site-id",
-                    "name", "ASC", 1, 40);
+                    "name", "ASC", 1, 40, false);
             Assert.fail("Expected security exception");
         } catch (final SecurityException e) {
             // expected
@@ -405,5 +406,221 @@ public class FolderResourceSearchTest {
         final List<FolderSearchView> views = (List<FolderSearchView>) result.getEntity();
         Assert.assertEquals(1, views.size());
         Assert.assertNull(views.get(0).defaultBaseType());
+    }
+
+    // ── includePermissions ────────────────────────────────────────────────────
+
+    /**
+     * Given Scenario: A limited (non-admin) user holds READ + EDIT on a folder and requests
+     * {@code includePermissions=true}. <br>
+     * Expected Result: The view carries exactly {@code [READ, EDIT]}. The user must be non-admin:
+     * {@code filterCollection} short-circuits for CMS Admin, so an admin-run assertion would pass
+     * against an implementation that computes nothing.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_returnsGrantedTypesForLimitedUser()
+            throws Exception {
+        final long ts = System.currentTimeMillis();
+        final Host site = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(site).name("res-perm-" + ts).nextPersisted();
+
+        final User limitedUser = newLimitedUserWithSiteRead(site);
+        grantOnFolder(folder, limitedUser,
+                PermissionAPI.PERMISSION_READ | PermissionAPI.PERMISSION_EDIT);
+
+        final var result = resource.searchFolders(
+                getHttpRequest(limitedUser.getEmailAddress(), LIMITED_USER_PASSWORD), response,
+                "res-perm-" + ts, "/", true, site.getIdentifier(),
+                "name", "ASC", 1, 40, true);
+
+        @SuppressWarnings("unchecked")
+        final List<FolderSearchView> views = (List<FolderSearchView>) result.getEntity();
+        Assert.assertEquals(1, views.size());
+        Assert.assertEquals(List.of("READ", "EDIT"), views.get(0).permissions());
+    }
+
+    /**
+     * Given Scenario: The same request without {@code includePermissions}. <br>
+     * Expected Result: {@code permissions} is {@code null} — "not requested", distinct from an empty
+     * array — while the five folder-detail fields are populated regardless of the flag.
+     */
+    @Test
+    public void test_searchFolders_withoutIncludePermissions_permissionsNullAndDetailFieldsPresent()
+            throws DotDataException, DotSecurityException {
+        final long ts = System.currentTimeMillis();
+        final Host site = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(site)
+                .name("res-nodetail-" + ts)
+                .title("Res Detail " + ts)
+                .sortOrder(3)
+                .fileMasks("*.pdf")
+                .showOnMenu(true)
+                .nextPersisted();
+
+        final var result = search("res-nodetail-" + ts, null, true, site.getIdentifier());
+
+        @SuppressWarnings("unchecked")
+        final List<FolderSearchView> views = (List<FolderSearchView>) result.getEntity();
+        Assert.assertEquals(1, views.size());
+        final FolderSearchView view = views.get(0);
+        Assert.assertNull("permissions must be null when not requested", view.permissions());
+        Assert.assertEquals(folder.getTitle(), view.title());
+        Assert.assertEquals(folder.getSortOrder(), view.sortOrder());
+        Assert.assertEquals(folder.getFilesMasks(), view.filesMasks());
+        Assert.assertEquals(folder.getDefaultFileType(), view.defaultFileType());
+        Assert.assertEquals(folder.isShowOnMenu(), view.showOnMenu());
+    }
+
+    // ── perPage cap when includePermissions=true ──────────────────────────────
+
+    /**
+     * Given Scenario: {@code includePermissions=true} with a {@code perPage} above the configured
+     * maximum. <br>
+     * Expected Result: 400, and the message names the cap so the caller can page correctly rather
+     * than silently receiving no permissions.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_perPageOverCap_returns400()
+            throws DotDataException, DotSecurityException {
+        final int cap = Config.getIntProperty(FolderResource.PERMISSIONS_MAX_PER_PAGE_KEY,
+                FolderResource.PERMISSIONS_MAX_PER_PAGE_DEFAULT);
+        try {
+            resource.searchFolders(
+                    getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
+                    null, "/", true, site().getIdentifier(),
+                    "name", "ASC", 1, cap + 1, true);
+            Assert.fail("Expected a BadRequestException for perPage above the cap");
+        } catch (final BadRequestException e) {
+            final String clientMessage = errorMessageOf(e);
+            Assert.assertTrue("the 400 must name the cap, got: " + clientMessage,
+                    clientMessage.contains(String.valueOf(cap)));
+            Assert.assertTrue("the 400 must name the flag that triggered it, got: " + clientMessage,
+                    clientMessage.contains(FolderResource.INCLUDE_PERMISSIONS_PARAM));
+        }
+    }
+
+    /**
+     * Given Scenario: The same over-cap {@code perPage} with {@code includePermissions} off. <br>
+     * Expected Result: 200 — the cap constrains only the flag, never existing callers.
+     */
+    @Test
+    public void test_searchFolders_perPageOverCap_withoutFlag_succeeds()
+            throws DotDataException, DotSecurityException {
+        final int cap = Config.getIntProperty(FolderResource.PERMISSIONS_MAX_PER_PAGE_KEY,
+                FolderResource.PERMISSIONS_MAX_PER_PAGE_DEFAULT);
+        final long ts = System.currentTimeMillis();
+        final Host site = new SiteDataGen().nextPersisted();
+        new FolderDataGen().site(site).name("res-cap-off-" + ts).nextPersisted();
+
+        final var result = resource.searchFolders(
+                getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
+                "res-cap-off-" + ts, "/", true, site.getIdentifier(),
+                "name", "ASC", 1, cap + 1, false);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1, ((List<?>) result.getEntity()).size());
+    }
+
+    /**
+     * Given Scenario: {@code includePermissions=true} with {@code perPage} exactly at the cap. <br>
+     * Expected Result: 200 — the bound is inclusive.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_perPageAtCap_succeeds()
+            throws DotDataException, DotSecurityException {
+        final int cap = Config.getIntProperty(FolderResource.PERMISSIONS_MAX_PER_PAGE_KEY,
+                FolderResource.PERMISSIONS_MAX_PER_PAGE_DEFAULT);
+        final long ts = System.currentTimeMillis();
+        final Host site = new SiteDataGen().nextPersisted();
+        new FolderDataGen().site(site).name("res-cap-at-" + ts).nextPersisted();
+
+        final var result = resource.searchFolders(
+                getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
+                "res-cap-at-" + ts, "/", true, site.getIdentifier(),
+                "name", "ASC", 1, cap, true);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1, ((List<?>) result.getEntity()).size());
+    }
+
+    /**
+     * Given Scenario: The cap property is lowered at runtime, then a request is made just above the
+     * new value. <br>
+     * Expected Result: 400 — the cap is read from configuration, not hardcoded.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_capIsConfigDriven()
+            throws DotDataException, DotSecurityException {
+        final int original = Config.getIntProperty(FolderResource.PERMISSIONS_MAX_PER_PAGE_KEY,
+                FolderResource.PERMISSIONS_MAX_PER_PAGE_DEFAULT);
+        Config.setProperty(FolderResource.PERMISSIONS_MAX_PER_PAGE_KEY, 5);
+        try {
+            resource.searchFolders(
+                    getHttpRequest(adminUser.getEmailAddress(), "admin"), response,
+                    null, "/", true, site().getIdentifier(),
+                    "name", "ASC", 1, 6, true);
+            Assert.fail("Expected a BadRequestException once the cap was lowered to 5");
+        } catch (final BadRequestException e) {
+            final String clientMessage = errorMessageOf(e);
+            Assert.assertTrue("the 400 must name the configured cap, got: " + clientMessage,
+                    clientMessage.contains("cannot exceed 5 "));
+        } finally {
+            Config.setProperty(FolderResource.PERMISSIONS_MAX_PER_PAGE_KEY, original);
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static final String LIMITED_USER_PASSWORD = "admin";
+
+    /**
+     * Returns the message the client actually receives for a {@link BadRequestException}.
+     *
+     * <p>Not {@code getMessage()}: {@code HttpStatusCodeException} extends
+     * {@code WebApplicationException}, whose {@code getMessage()} is the generic
+     * "HTTP 400 Bad Request". The caller-facing text travels in the {@code error-message} response
+     * header (and in the JSON entity), so that is what these assertions check.
+     */
+    private static String errorMessageOf(final BadRequestException e) {
+        final String message = e.getResponse().getHeaderString("error-message");
+        Assert.assertNotNull("the 400 must carry an error-message header", message);
+        return message;
+    }
+
+    /** Lazily-created site for tests that only need some valid site id. */
+    private Host site() throws DotDataException, DotSecurityException {
+        return new SiteDataGen().nextPersisted();
+    }
+
+    /**
+     * Creates a backend, non-admin user with READ on {@code site}. The site grant is required
+     * because {@code searchFolders} validates site READ access before searching.
+     */
+    private static User newLimitedUserWithSiteRead(final Host site) throws Exception {
+        final User limitedUser = new UserDataGen()
+                .roles(TestUserUtils.getFrontendRole(), TestUserUtils.getBackendRole())
+                .nextPersisted();
+        limitedUser.setPassword(LIMITED_USER_PASSWORD);
+        APILocator.getUserAPI().save(limitedUser, APILocator.systemUser(), false);
+
+        final String roleId = APILocator.getRoleAPI().loadRoleByKey(limitedUser.getUserId()).getId();
+        APILocator.getPermissionAPI().save(
+                new Permission(PermissionAPI.INDIVIDUAL_PERMISSION_TYPE,
+                        site.getPermissionId(), roleId, PermissionAPI.PERMISSION_READ, true),
+                site, APILocator.systemUser(), false);
+        return limitedUser;
+    }
+
+    /**
+     * Replaces the individual permissions the user's role holds on {@code folder} with {@code bits};
+     * setting individual permissions breaks inheritance, so the grants end up exact.
+     */
+    private static void grantOnFolder(final Folder folder, final User user, final int bits)
+            throws DotDataException, DotSecurityException {
+        final String roleId = APILocator.getRoleAPI().loadRoleByKey(user.getUserId()).getId();
+        APILocator.getPermissionAPI().save(
+                new Permission(PermissionAPI.INDIVIDUAL_PERMISSION_TYPE,
+                        folder.getPermissionId(), roleId, bits, true),
+                folder, APILocator.systemUser(), false);
     }
 }

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPIImplFilterTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPIImplFilterTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -144,7 +145,9 @@ public class FolderAPIImplFilterTest {
     public void test_searchFolders_withPathScope_returnsOnlyDescendants()
             throws DotDataException, DotSecurityException {
         final Host freshSite = new SiteDataGen().nextPersisted();
-        final Folder assets = new FolderDataGen().site(freshSite).name("assets").nextPersisted();
+        // Not "assets": that is in the default RESERVEDFOLDERNAMES (FolderAPIImpl:110) and cannot be
+        // created directly under a site, so saving it throws InvalidFolderNameException.
+        final Folder assets = new FolderDataGen().site(freshSite).name("site-assets").nextPersisted();
         new FolderDataGen().site(freshSite).parent(assets).name("images").nextPersisted(); // inside scope
         new FolderDataGen().site(freshSite).name("images-root").nextPersisted();           // outside scope
 
@@ -300,5 +303,222 @@ public class FolderAPIImplFilterTest {
         assertEquals(1, result.size());
         assertFalse("hasChildren should be false when user cannot read any child",
                 result.get(0).hasChildren());
+    }
+
+    // ── Folder-detail fields ──────────────────────────────────────────────────
+
+    /**
+     * Method to test: {@link FolderAPIImpl#searchFolders} <br>
+     * Given Scenario: A folder with title, sortOrder, filesMasks, defaultFileType and showOnMenu
+     * set; the admin searches for it without asking for permissions. <br>
+     * Expected Result: All five detail fields are present on the view and match the stored folder —
+     * they are not gated by {@code includePermissions}.
+     */
+    @Test
+    public void test_searchFolders_detailFields_alwaysPresent()
+            throws DotDataException, DotSecurityException {
+        final long ts    = System.currentTimeMillis();
+        final Host fresh = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(fresh)
+                .name("detail-" + ts)
+                .title("Detail " + ts)
+                .sortOrder(7)
+                .fileMasks("*.jpg,*.png")
+                .showOnMenu(true)
+                .nextPersisted();
+
+        final var result = folderAPI.searchFolders(FolderSearchParams.builder()
+                .name("detail-" + ts)
+                .siteId(fresh.getIdentifier())
+                .user(adminUser)
+                .build());
+
+        assertEquals(1, result.size());
+        final FolderSearchView view = result.get(0);
+        assertEquals(folder.getTitle(), view.title());
+        assertEquals(folder.getSortOrder(), view.sortOrder());
+        assertEquals(folder.getFilesMasks(), view.filesMasks());
+        assertEquals(folder.getDefaultFileType(), view.defaultFileType());
+        assertEquals(folder.isShowOnMenu(), view.showOnMenu());
+        assertNull("permissions must be null when not requested", view.permissions());
+    }
+
+    // ── permissions field (includePermissions) ────────────────────────────────
+
+    /**
+     * Method to test: {@link FolderAPIImpl#searchFolders} <br>
+     * Given Scenario: A limited user with every permission type on the folder asks for
+     * permissions. <br>
+     * Expected Result: The view carries exactly the five type names, in a stable order and spelled
+     * the way the Content Drive table spells them — in particular {@code EDIT}, never {@code WRITE}.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_allTypesGranted()
+            throws DotDataException, DotSecurityException {
+        final long ts    = System.currentTimeMillis();
+        final Host fresh = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(fresh).name("perm-all-" + ts).nextPersisted();
+
+        final User limitedUser = new UserDataGen().nextPersisted();
+        grantOnFolder(folder, limitedUser,
+                PermissionAPI.PERMISSION_READ | PermissionAPI.PERMISSION_EDIT
+                        | PermissionAPI.PERMISSION_PUBLISH | PermissionAPI.PERMISSION_EDIT_PERMISSIONS
+                        | PermissionAPI.PERMISSION_CAN_ADD_CHILDREN);
+
+        final var result = searchAsLimitedUser("perm-all-" + ts, fresh, limitedUser);
+
+        assertEquals(1, result.size());
+        assertEquals(List.of("READ", "EDIT", "PUBLISH", "EDIT_PERMISSIONS", "CAN_ADD_CHILDREN"),
+                result.get(0).permissions());
+        assertTrue("addChildrenAllowed must stay consistent with the permissions array",
+                result.get(0).addChildrenAllowed());
+    }
+
+    /**
+     * Method to test: {@link FolderAPIImpl#searchFolders} <br>
+     * Given Scenario: A limited user holds only READ and EDIT on the folder. <br>
+     * Expected Result: Exactly {@code [READ, EDIT]} — {@code PUBLISH}, {@code EDIT_PERMISSIONS} and
+     * {@code CAN_ADD_CHILDREN} are absent. This is the case the sidebar context menu's gating
+     * depends on, so the absences are asserted explicitly.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_readAndEditOnly()
+            throws DotDataException, DotSecurityException {
+        final long ts    = System.currentTimeMillis();
+        final Host fresh = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(fresh).name("perm-re-" + ts).nextPersisted();
+
+        final User limitedUser = new UserDataGen().nextPersisted();
+        grantOnFolder(folder, limitedUser,
+                PermissionAPI.PERMISSION_READ | PermissionAPI.PERMISSION_EDIT);
+
+        final var result = searchAsLimitedUser("perm-re-" + ts, fresh, limitedUser);
+
+        assertEquals(1, result.size());
+        final List<String> permissions = result.get(0).permissions();
+        assertEquals(List.of("READ", "EDIT"), permissions);
+        assertFalse("PUBLISH must not be granted", permissions.contains("PUBLISH"));
+        assertFalse("EDIT_PERMISSIONS must not be granted", permissions.contains("EDIT_PERMISSIONS"));
+        assertFalse("CAN_ADD_CHILDREN must not be granted", permissions.contains("CAN_ADD_CHILDREN"));
+        assertFalse("WRITE is an alias and must never be emitted", permissions.contains("WRITE"));
+    }
+
+    /**
+     * Method to test: {@link FolderAPIImpl#searchFolders} <br>
+     * Given Scenario: A limited user holds only READ on the folder. <br>
+     * Expected Result: The folder is still returned, with exactly {@code [READ]}.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_readOnly()
+            throws DotDataException, DotSecurityException {
+        final long ts    = System.currentTimeMillis();
+        final Host fresh = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(fresh).name("perm-ro-" + ts).nextPersisted();
+
+        final User limitedUser = new UserDataGen().nextPersisted();
+        grantOnFolder(folder, limitedUser, PermissionAPI.PERMISSION_READ);
+
+        final var result = searchAsLimitedUser("perm-ro-" + ts, fresh, limitedUser);
+
+        assertEquals(1, result.size());
+        assertEquals(List.of("READ"), result.get(0).permissions());
+        assertFalse("a READ-only folder is not add-children-able", result.get(0).addChildrenAllowed());
+    }
+
+    /**
+     * Method to test: {@link FolderAPIImpl#searchFolders} <br>
+     * Given Scenario: Three readable folders, only the second (by name) is editable; the limited
+     * user requests page 2 of a 1-per-page result with permissions. <br>
+     * Expected Result: The permissions describe the folder actually returned, not the first page's.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_scopedToRequestedPage()
+            throws DotDataException, DotSecurityException {
+        final long ts    = System.currentTimeMillis();
+        final Host fresh = new SiteDataGen().nextPersisted();
+        final String prefix = "perm-page-" + ts + "-";
+        final Folder first  = new FolderDataGen().site(fresh).name(prefix + "00").nextPersisted();
+        final Folder second = new FolderDataGen().site(fresh).name(prefix + "01").nextPersisted();
+        final Folder third  = new FolderDataGen().site(fresh).name(prefix + "02").nextPersisted();
+
+        final User limitedUser = new UserDataGen().nextPersisted();
+        grantOnFolder(first,  limitedUser, PermissionAPI.PERMISSION_READ);
+        grantOnFolder(second, limitedUser, PermissionAPI.PERMISSION_READ | PermissionAPI.PERMISSION_EDIT);
+        grantOnFolder(third,  limitedUser, PermissionAPI.PERMISSION_READ);
+
+        final var page1 = folderAPI.searchFolders(FolderSearchParams.builder()
+                .name(prefix).siteId(fresh.getIdentifier()).user(limitedUser)
+                .includePermissions(true).limit(1).offset(0).build());
+        final var page2 = folderAPI.searchFolders(FolderSearchParams.builder()
+                .name(prefix).siteId(fresh.getIdentifier()).user(limitedUser)
+                .includePermissions(true).limit(1).offset(1).build());
+
+        assertEquals(3, page1.getTotalResults());
+        assertEquals(1, page1.size());
+        assertEquals(first.getName(), page1.get(0).name());
+        assertEquals(List.of("READ"), page1.get(0).permissions());
+
+        assertEquals(3, page2.getTotalResults());
+        assertEquals(1, page2.size());
+        assertEquals(second.getName(), page2.get(0).name());
+        assertEquals(List.of("READ", "EDIT"), page2.get(0).permissions());
+    }
+
+    /**
+     * Method to test: {@link FolderAPIImpl#searchFolders} <br>
+     * Given Scenario: A limited user starts with READ only; EDIT is granted and the endpoint is
+     * queried immediately afterwards. <br>
+     * Expected Result: {@code EDIT} shows up with no reindex in between — permissions are resolved
+     * from the database, as ADR-0018 routes them.
+     */
+    @Test
+    public void test_searchFolders_includePermissions_readYourWrites()
+            throws DotDataException, DotSecurityException {
+        final long ts    = System.currentTimeMillis();
+        final Host fresh = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(fresh).name("perm-ryw-" + ts).nextPersisted();
+
+        final User limitedUser = new UserDataGen().nextPersisted();
+        grantOnFolder(folder, limitedUser, PermissionAPI.PERMISSION_READ);
+
+        assertEquals(List.of("READ"),
+                searchAsLimitedUser("perm-ryw-" + ts, fresh, limitedUser).get(0).permissions());
+
+        grantOnFolder(folder, limitedUser,
+                PermissionAPI.PERMISSION_READ | PermissionAPI.PERMISSION_EDIT);
+
+        assertEquals("EDIT must be visible immediately after the grant, without a reindex",
+                List.of("READ", "EDIT"),
+                searchAsLimitedUser("perm-ryw-" + ts, fresh, limitedUser).get(0).permissions());
+    }
+
+    /**
+     * Replaces the individual permissions a role holds on {@code folder} with {@code bits}. Setting
+     * individual permissions breaks inheritance, so the user ends up with exactly these grants.
+     */
+    private static void grantOnFolder(final Folder folder, final User user, final int bits)
+            throws DotDataException, DotSecurityException {
+        final String roleId = APILocator.getRoleAPI().loadRoleByKey(user.getUserId()).getId();
+        APILocator.getPermissionAPI().save(
+                new Permission(PermissionAPI.INDIVIDUAL_PERMISSION_TYPE,
+                        folder.getPermissionId(), roleId, bits, true),
+                folder, APILocator.systemUser(), false);
+    }
+
+    /**
+     * Runs a name-scoped search with {@code includePermissions=true} as {@code limitedUser}.
+     *
+     * <p>Every permission-gating assertion goes through a limited user on purpose:
+     * {@code filterCollection} short-circuits for CMS Admin and the system user, so the same
+     * assertions run as an admin would pass against an implementation that computes nothing.
+     */
+    private static PaginatedArrayList<FolderSearchView> searchAsLimitedUser(final String name,
+            final Host site, final User limitedUser) throws DotDataException, DotSecurityException {
+        return folderAPI.searchFolders(FolderSearchParams.builder()
+                .name(name)
+                .siteId(site.getIdentifier())
+                .user(limitedUser)
+                .includePermissions(true)
+                .build());
     }
 }

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderFactoryImplFilterTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderFactoryImplFilterTest.java
@@ -5,8 +5,10 @@ import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.portlets.folders.business.FolderSearchParams;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.liferay.portal.model.User;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -24,6 +26,7 @@ public class FolderFactoryImplFilterTest {
     private static FolderFactoryImpl folderFactory;
     private static Host site1;
     private static Host site2;
+    private static User user;
 
     @BeforeClass
     public static void prepare() throws Exception {
@@ -31,6 +34,10 @@ public class FolderFactoryImplFilterTest {
         folderFactory = new FolderFactoryImpl();
         site1 = new SiteDataGen().nextPersisted();
         site2 = new SiteDataGen().nextPersisted();
+        // The factory resolves folders in SQL and never reads the user — permission filtering
+        // happens a layer up, in FolderAPIImpl. The user is only here because
+        // FolderSearchParams.Builder.build() requires one.
+        user = APILocator.systemUser();
     }
 
     /**
@@ -48,6 +55,7 @@ public class FolderFactoryImplFilterTest {
         final List<Folder> results = folderFactory.searchFolders(FolderSearchParams.builder()
                 .name("images-" + ts)
                 .siteId(site1.getIdentifier())
+                .user(user)
                 .build());
 
         assertEquals(2, results.size());
@@ -68,10 +76,12 @@ public class FolderFactoryImplFilterTest {
         final List<Folder> lower = folderFactory.searchFolders(FolderSearchParams.builder()
                 .name("assets-" + ts)
                 .siteId(site1.getIdentifier())
+                .user(user)
                 .build());
         final List<Folder> upper = folderFactory.searchFolders(FolderSearchParams.builder()
                 .name("ASSETS-" + ts)
                 .siteId(site1.getIdentifier())
+                .user(user)
                 .build());
 
         assertEquals(1, lower.size());
@@ -94,6 +104,7 @@ public class FolderFactoryImplFilterTest {
         final List<Folder> results = folderFactory.searchFolders(FolderSearchParams.builder()
                 .name(sharedName)
                 .siteId(site1.getIdentifier())
+                .user(user)
                 .build());
 
         assertEquals(1, results.size());
@@ -114,6 +125,7 @@ public class FolderFactoryImplFilterTest {
 
         final List<Folder> results = folderFactory.searchFolders(FolderSearchParams.builder()
                 .siteId(freshSite.getIdentifier())
+                .user(user)
                 .build());
 
         assertTrue(results.size() >= 2);
@@ -137,6 +149,7 @@ public class FolderFactoryImplFilterTest {
                 .path("/" + parent.getName() + "/")
                 .recursive(true)
                 .siteId(freshSite.getIdentifier())
+                .user(user)
                 .build());
 
         assertEquals(1, results.size());
@@ -159,6 +172,7 @@ public class FolderFactoryImplFilterTest {
                 .path("/" + parent.getName() + "/")
                 .recursive(false)
                 .siteId(site1.getIdentifier())
+                .user(user)
                 .build());
 
         assertEquals(1, results.size());
@@ -175,6 +189,7 @@ public class FolderFactoryImplFilterTest {
         final List<Folder> results = folderFactory.searchFolders(FolderSearchParams.builder()
                 .name("zzz-no-match-xyz-" + System.currentTimeMillis())
                 .siteId(site1.getIdentifier())
+                .user(user)
                 .build());
 
         assertTrue(results.isEmpty());

--- a/dotcms-postman/src/main/resources/postman/FolderResource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/FolderResource.postman_collection.json
@@ -1504,6 +1504,275 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "Find folders — includePermissions omitted leaves permissions null",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code should be 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const entity = pm.response.json().entity;",
+                  "",
+                  "pm.test(\"permissions is null when not requested (not an empty array)\", function () {",
+                  "    pm.expect(entity).to.not.be.empty;",
+                  "    entity.forEach(function(folder) {",
+                  "        pm.expect(folder).to.have.property('permissions');",
+                  "        pm.expect(folder.permissions).to.be.null;",
+                  "    });",
+                  "});",
+                  "",
+                  "pm.test(\"folder-detail fields are present regardless of the flag\", function () {",
+                  "    entity.forEach(function(folder) {",
+                  "        pm.expect(folder).to.have.property('title');",
+                  "        pm.expect(folder).to.have.property('sortOrder');",
+                  "        pm.expect(folder).to.have.property('filesMasks');",
+                  "        pm.expect(folder).to.have.property('defaultFileType');",
+                  "        pm.expect(folder).to.have.property('showOnMenu');",
+                  "        pm.expect(folder.sortOrder).to.be.a('number');",
+                  "        pm.expect(folder.showOnMenu).to.be.a('boolean');",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/folder/search?name=images&siteId={{byNameSiteId}}&recursive=true",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "folder",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "name",
+                  "value": "images"
+                },
+                {
+                  "key": "siteId",
+                  "value": "{{byNameSiteId}}"
+                },
+                {
+                  "key": "recursive",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Find folders — includePermissions=true returns permission types",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code should be 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const entity = pm.response.json().entity;",
+                  "const allowed = ['READ', 'EDIT', 'PUBLISH', 'EDIT_PERMISSIONS', 'CAN_ADD_CHILDREN'];",
+                  "",
+                  "// This request runs as an admin, so it asserts the contract (shape, spelling, READ",
+                  "// always present) rather than permission gating. Gating is covered by the integration",
+                  "// tests, which must run as a limited user because filterCollection short-circuits for",
+                  "// CMS Admin.",
+                  "pm.test(\"permissions is an array drawn from the five known types\", function () {",
+                  "    pm.expect(entity).to.not.be.empty;",
+                  "    entity.forEach(function(folder) {",
+                  "        pm.expect(folder.permissions).to.be.an('array');",
+                  "        folder.permissions.forEach(function(permission) {",
+                  "            pm.expect(allowed).to.include(permission);",
+                  "        });",
+                  "    });",
+                  "});",
+                  "",
+                  "pm.test(\"READ is always present and the WRITE alias never is\", function () {",
+                  "    entity.forEach(function(folder) {",
+                  "        pm.expect(folder.permissions).to.include('READ');",
+                  "        pm.expect(folder.permissions).to.not.include('WRITE');",
+                  "    });",
+                  "});",
+                  "",
+                  "pm.test(\"addChildrenAllowed agrees with the permissions array\", function () {",
+                  "    entity.forEach(function(folder) {",
+                  "        pm.expect(folder.permissions.includes('CAN_ADD_CHILDREN'))",
+                  "            .to.eql(folder.addChildrenAllowed);",
+                  "    });",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/folder/search?name=images&siteId={{byNameSiteId}}&recursive=true&includePermissions=true",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "folder",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "name",
+                  "value": "images"
+                },
+                {
+                  "key": "siteId",
+                  "value": "{{byNameSiteId}}"
+                },
+                {
+                  "key": "recursive",
+                  "value": "true"
+                },
+                {
+                  "key": "includePermissions",
+                  "value": "true"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Find folders — includePermissions with per_page above the cap returns 400",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code should be 400\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});",
+                  "",
+                  "pm.test(\"the error names the cap so the caller can page correctly\", function () {",
+                  "    pm.expect(pm.response.text()).to.include('includePermissions');",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/folder/search?name=images&siteId={{byNameSiteId}}&recursive=true&includePermissions=true&per_page=10000",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "folder",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "name",
+                  "value": "images"
+                },
+                {
+                  "key": "siteId",
+                  "value": "{{byNameSiteId}}"
+                },
+                {
+                  "key": "recursive",
+                  "value": "true"
+                },
+                {
+                  "key": "includePermissions",
+                  "value": "true"
+                },
+                {
+                  "key": "per_page",
+                  "value": "10000"
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Find folders — per_page above the cap without the flag still succeeds",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code should be 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"the cap does not constrain callers that do not ask for permissions\", function () {",
+                  "    pm.expect(pm.response.json().entity).to.be.an('array');",
+                  "});"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/folder/search?name=images&siteId={{byNameSiteId}}&recursive=true&per_page=10000",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "folder",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "name",
+                  "value": "images"
+                },
+                {
+                  "key": "siteId",
+                  "value": "{{byNameSiteId}}"
+                },
+                {
+                  "key": "recursive",
+                  "value": "true"
+                },
+                {
+                  "key": "per_page",
+                  "value": "10000"
+                }
+              ]
+            }
+          },
+          "response": []
         }
       ]
     },


### PR DESCRIPTION
### Parent Issue

#36595

### Summary

Backend half of #36595. Right-clicking a folder in the Content Drive **sidebar tree** does nothing, while right-clicking a folder **row in the table** opens a context menu (Edit folder / Edit permissions). The shared `dot-folder-list-context-menu` component gates those items on `contentlet.permissions` and pre-populates the "Edit folder" dialog from the folder object it is handed — but the sidebar is backed by `GET /api/v1/folder/search` → `FolderSearchView`, which carried neither.

This PR enriches that view so the sidebar can gate the menu and pre-populate the dialog exactly the way the table does. **No FE changes here** — the FE leg is the other half of the same issue, and the contract obligations it inherits are written up in [a comment on #36595](https://github.com/dotCMS/core/issues/36595).

> The issue's "Proposed resolution options" prose names `POST /api/v1/folder/byPath` / `FolderSearchResultView`. That endpoint is deprecated (`forRemoval = true`) with zero references in `core-web`; the sidebar actually calls `GET /api/v1/folder/search`, which is what this PR extends. The comparison table in the issue body already says this correctly.

### What changed

**Always present (no flag)** — the fields the "Edit folder" dialog reads, all read straight off the `Folder` already loaded by the existing `SELECT folder.*`, so zero additional DB cost:

`title`, `sortOrder`, `filesMasks`, `defaultFileType`, `showOnMenu`

**Opt-in via `?includePermissions=true`:**

`permissions: List<String>` — the permission types the requesting user holds, drawn from `READ, EDIT, PUBLISH, EDIT_PERMISSIONS, CAN_ADD_CHILDREN`. Same field name, same 5-type meaning and spelling as the table's `DotContentDriveFolder.permissions`, so one gating implementation serves both views. `null` when not requested — deliberately not `[]`, so the FE can distinguish "not fetched" from "fetched, no grants".

Returning the full 5-type set rather than only the two the menu reads today costs **3** extra batch calls instead of 2 (`READ` is implicit — the folder passed the pre-pagination READ filter to be here; `CAN_ADD_CHILDREN` reuses the set already computed for `addChildrenAllowed`). That one extra call buys away a whole ambiguity class: if `permissions` meant 5 types on a table-sourced folder and 2 on a sidebar-sourced one, a future `PUBLISH` check would silently evaluate `false` depending on provenance, and the symptom is a **missing menu action**, not an error.

**New 400 guardrail.** `PaginationUtil` puts no upper bound on `perPage`, and `PermissionBitFactoryImpl.getPermittedIds` chunks ids by 500 — so `?perPage=10000&includePermissions=true` was reachable by any authenticated backend user at 60 extra queries. With the flag on, `perPage` is now capped by `content.drive.folder.search.permissions.max.per.page` (default 200); above it the request is rejected with a 400 naming the cap. Rejecting rather than silently dropping the flag is the point: dropping it yields `permissions: null` → "no grants" → an empty menu, indistinguishable from a user who genuinely has none. **With the flag off, any `perPage` behaves exactly as before** — there is a test asserting precisely that.

All new batch calls are scoped to `page`, the post-pagination slice, matching the existing `CAN_ADD_CHILDREN` call. With the flag off they issue no query at all.

### OpenAPI

`FolderSearchView` was **undocumented** — 0 occurrences in `openapi.yaml`, because the endpoint declared the generic `ResponseEntityPaginatedDataView` whose `entity` is a bare `type: object`. Regenerating alone would have produced no field diff at all.

This PR adds a concrete `ResponseEntityFolderSearchView`, references it from the `@ApiResponse`, and adds `@Schema` descriptions to every field. The regenerated yaml now publishes the full 13-field schema plus the `includePermissions` parameter — a real contract for the FE leg to build against.

### Rollback

**M-3 (REST API contract change), 🟢 LOW.** Purely additive: new response fields plus a new query param whose default reproduces current behavior exactly. No DB schema change, no migration, no index change. Nothing calls `includePermissions=true` until the FE leg ships, so there is no mixed-version window for this change on its own.

### Payload cost — measured

Six new fields ride every row, and `"permissions": null` serializes even with the flag off (the default mapper has no `NON_NULL` inclusion). Measured on a representative deep-link hydration payload — 10,000 folders, flag off — serialized with `DotObjectMapperProvider.createDefaultMapper()`:

| shape | raw | gzip |
|---|---|---|
| before (7 fields) | 2.19 MB · 229 B/row | 0.49 MB · 51.7 B/row |
| **after (13 fields)** | 3.66 MB · 384 B/row · **+67.5%** | 0.54 MB · 56.9 B/row · **+9.9%** |
| alt: detail fields gated behind the flag | 2.37 MB · +8.3% | 0.50 MB · +0.5% |
| alt: `@JsonInclude(NON_NULL)` on the record | 3.09 MB · +41.4% | 0.53 MB · +7.6% |

The raw +67.5% collapses to **+9.9% (+52 KB)** over the wire — the added fields are highly repetitive and compress well. Not material, so "detail fields always present" stands. Alternatives priced above in case a reviewer reads the raw number differently; note `NON_NULL` would also stop serializing `defaultBaseType: null`, a contract change on an existing field.

### Testing

54 tests green locally.

| Class | Result |
|---|---|
| `FolderSearchPaginatorTest` (unit) | 10/10 |
| `FolderResourceSearchTest` | 21/21 |
| `FolderAPIImplFilterTest` | 16/16 |
| `FolderFactoryImplFilterTest` | 7/7 |

Plus 4 new Postman requests on `/v1/folder/search` (flag on, flag omitted, over-cap 400, over-cap without the flag).

**Every permission-gating test runs as a limited, non-admin user.** `filterCollection` short-circuits for CMS Admin and the system user (`PermissionBitAPIImpl.java:1433-1434`), so the same assertions run as an admin would exercise none of this logic and would pass against an implementation that computes nothing. Coverage: all 5 types granted; READ + EDIT only with `PUBLISH`/`EDIT_PERMISSIONS`/`CAN_ADD_CHILDREN` asserted **absent**; READ only; permissions correct for page 2 of a paginated result rather than page 1's; read-your-writes after a grant with no reindex; exact string assertions on every type name.

### Two pre-existing test failures fixed here

Both were red on `main` before this PR and are unrelated to it, but one lives in a file this PR edits and would have read as a regression from this change:

- **`FolderAPIImplFilterTest.test_searchFolders_withPathScope_returnsOnlyDescendants`** — created a folder named `assets` directly under a site; `assets` is in the default `RESERVEDFOLDERNAMES` (`FolderAPIImpl:110`), so the save threw `InvalidFolderNameException`. Renamed to `site-assets`. Introduced by 27191bc6a6.
- **`FolderFactoryImplFilterTest`** — all 7 tests threw `NullPointerException: user is required`. The class never passed `.user(...)`, and `FolderSearchParams.Builder.build()` began requiring one in 6c92187cfc. Added the system user, with a comment noting the factory resolves in SQL and never reads it — permission filtering happens a layer up in `FolderAPIImpl`.

### Notable landmines documented in code

- **`PermissionAPI.Type.CANONICAL_TYPES` cannot be used to derive these names.** It is `{READ, WRITE, PUBLISH, EDIT_PERMISSIONS, CAN_ADD_CHILDREN}` — the `WRITE` alias, not `EDIT`. Deriving from it emits `"WRITE"`, the FE's `EDIT` check silently fails, and the symptom is a missing menu item. The implementation uses explicit `Type.EDIT.name()` etc., and a test asserts `WRITE` is never emitted.
- **`HttpStatusCodeException` runs `String.format` over the message you hand it**, so pre-formatting would format twice and throw on a literal `%`. The cap error uses the varargs form.

### Explicitly out of scope

- Any FE change (the other half of #36595).
- `DotFolderTransformerImpl.contentDriveView`'s per-folder N+1 permission loop — real inefficiency, different code path.
- `POST /api/v1/drive/search` / `BrowserAPIImpl` — untouched.
- The deprecated `POST /api/v1/folder/byPath` — not extended.
- The pre-existing `READ` filter running over the full pre-pagination set (`FolderAPIImpl:819`), which makes endpoint load scale with site size rather than `perPage`. It predates this ticket and is the endpoint's dominant cost; worth its own ticket if folder-search latency shows up in profiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36595