### PR TITLE
refactor(search): split SearchHit into a lean content shape and a Site Search one (#36360)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/ContentSearchHit.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/ContentSearchHit.java
@@ -1,0 +1,49 @@
+package com.dotcms.content.index.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The lean {@link SearchHit} shape: everything a content search result needs and nothing else.
+ *
+ * <p>This is the hit every content query produces. It deliberately carries no highlight state — not
+ * even an empty map reference — because highlighting is a Site Search concern and content queries
+ * never request it. {@link SearchHit#highlightsFor(String)} therefore answers with an empty list here,
+ * inherited straight from the interface, so a caller holding a {@code SearchHit} needs no type check.
+ *
+ * <p>Instances come from {@link SearchHit.Builder#build()}, which selects this shape whenever the
+ * engine response carried no highlight fragments. It is also the deserialization target for the
+ * {@link SearchHit} interface.</p>
+ *
+ * @param getId          the unique identifier of this search hit (the document ID)
+ * @param getIndex       the index name where this search hit was found, or {@code null} if not available
+ * @param getSourceAsMap the source document as a map of field names to values
+ * @param getScore       the search relevance score for this hit
+ * @param getFields      the document fields retrieved by the search query (additional fields beyond
+ *                       the source document that were explicitly requested), empty if none were requested
+ * @param getSortValues  the per-hit sort values the engine returns when the query sorts by a field
+ *                       (e.g. the computed distance for a {@code _geo_distance} sort), in the order the
+ *                       {@code sort} clause declared; empty for relevance-only (unsorted) queries
+ * @author Fabrizio Araya
+ * @see SearchHit
+ * @see SiteSearchHit
+ */
+public record ContentSearchHit(
+        @JsonProperty("id") String getId,
+        @JsonProperty("index") String getIndex,
+        @JsonProperty("sourceAsMap") Map<String, Object> getSourceAsMap,
+        @JsonProperty("score") float getScore,
+        @JsonProperty("fields") Map<String, Object> getFields,
+        @JsonProperty("sortValues") List<Object> getSortValues) implements SearchHit {
+
+    /**
+     * Canonical constructor. Collection components default to an empty map/list when {@code null} so
+     * the accessors never return {@code null} (mirrors the previous Immutables collection defaults).
+     */
+    public ContentSearchHit {
+        getSourceAsMap = getSourceAsMap == null ? Map.of() : getSourceAsMap;
+        getFields = getFields == null ? Map.of() : getFields;
+        getSortValues = getSortValues == null ? List.of() : getSortValues;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/SearchHit.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/SearchHit.java
@@ -1,6 +1,6 @@
 package com.dotcms.content.index.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -10,14 +10,36 @@ import java.util.stream.Collectors;
 /**
  * Immutable domain representation of a single search result hit from any search engine.
  *
- * <p>This record provides a unified abstraction layer for individual search results,
- * allowing the application to work with search hits without depending on specific
- * search engine libraries (Elasticsearch, OpenSearch, etc.).</p>
+ * <p>This type provides a unified abstraction layer for individual search results, allowing the
+ * application to work with search hits without depending on specific search engine libraries
+ * (Elasticsearch, OpenSearch, etc.).</p>
+ *
+ * <p><strong>Two shapes, one contract.</strong> Content search results are the hot path — they must
+ * stay as small as possible — while Site Search results carry an extra concern nothing else asks
+ * for: the per-field highlight fragments used to render result snippets. Rather than widening every
+ * hit with a field only one caller reads, this is a sealed interface over two records:</p>
+ * <ul>
+ *   <li>{@link ContentSearchHit} — the lean shape: six components, no highlight state at all.</li>
+ *   <li>{@link SiteSearchHit} — the same six plus the highlight fragments.</li>
+ * </ul>
+ *
+ * <p>Callers never choose: {@link Builder#build()} picks the shape from the data, returning the lean
+ * record unless the engine actually returned highlight fragments. Since the only queries that request
+ * highlighting are the Site Search ones ({@code ESSiteSearchAPI} / {@code OSSiteSearchAPI}), a content
+ * hit is always a {@link ContentSearchHit} and pays nothing — not even a null reference — for a
+ * concern it does not use. If a content query ever requests highlighting, it would get the
+ * highlight-bearing shape and the names here would be worth revisiting.</p>
+ *
+ * <p>Highlights are read through {@link #highlightsFor(String)}, which defaults to an empty list, so
+ * a caller holding a plain {@code SearchHit} never has to know or ask which shape it got.</p>
  *
  * <p>Accessors are bean-style ({@code getId()}, {@code getSourceAsMap()}, …) so the type works
- * directly from Velocity templates (e.g. {@code $hit.id}) without any extra alias methods.
- * The record components are named accordingly and the {@link JsonProperty} annotations keep the
- * JSON contract clean ({@code id}, {@code index}, …) for the caches/REST paths backed by this type.</p>
+ * directly from Velocity templates (e.g. {@code $hit.id}) without any extra alias methods. The record
+ * components are named accordingly and the {@code JsonProperty} annotations keep the JSON contract
+ * clean ({@code id}, {@code index}, …) for the caches/REST paths backed by this type. Deserialization
+ * of the interface targets {@link ContentSearchHit}: nothing serializes a Site Search hit today, and
+ * the alternative (polymorphic {@code JsonTypeInfo}) would add a type discriminator to a JSON shape
+ * those caches depend on.</p>
  *
  * <p><strong>Usage Examples:</strong></p>
  * <pre>
@@ -31,55 +53,64 @@ import java.util.stream.Collectors;
  * String docId = hit.getId();
  * Map&lt;String, Object&gt; content = hit.getSourceAsMap();
  * float relevanceScore = hit.getScore();
+ *
+ * // Site Search snippets — empty for every hit that was not highlighted
+ * List&lt;String&gt; fragments = hit.highlightsFor("content");
  * </pre>
  *
- * @param getId          the unique identifier of this search hit (the document ID)
- * @param getIndex       the index name where this search hit was found, or {@code null} if not available
- * @param getSourceAsMap the source document as a map of field names to values
- * @param getScore       the search relevance score for this hit
- * @param getFields      the document fields retrieved by the search query (additional fields beyond
- *                       the source document that were explicitly requested), empty if none were requested
- * @param getSortValues  the per-hit sort values the engine returns when the query sorts by a field
- *                       (e.g. the computed distance for a {@code _geo_distance} sort), in the order the
- *                       {@code sort} clause declared; empty for relevance-only (unsorted) queries
- * @param getHighlights  the per-field highlight fragments the engine returns when the query asks for
- *                       highlighting, keyed by field name (e.g. {@code content} for Site Search), each
- *                       value holding that field's fragments in engine order; empty when the query did
- *                       not request highlighting or the field produced no match fragment
  * @author Fabrizio Araya
+ * @see ContentSearchHit
+ * @see SiteSearchHit
  * @see SearchHits
  * @see com.dotcms.content.index.ContentFactoryIndexOperations
  */
-public record SearchHit(
-        @JsonProperty("id") String getId,
-        @JsonProperty("index") String getIndex,
-        @JsonProperty("sourceAsMap") Map<String, Object> getSourceAsMap,
-        @JsonProperty("score") float getScore,
-        @JsonProperty("fields") Map<String, Object> getFields,
-        @JsonProperty("sortValues") List<Object> getSortValues,
-        @JsonProperty("highlights") Map<String, List<String>> getHighlights) {
+@JsonDeserialize(as = ContentSearchHit.class)
+public sealed interface SearchHit permits ContentSearchHit, SiteSearchHit {
 
     /**
-     * Canonical constructor. Collection components default to an empty map/list when {@code null} so
-     * the accessors never return {@code null} (mirrors the previous Immutables collection defaults).
+     * @return the unique identifier of this search hit (the document ID)
      */
-    public SearchHit {
-        getSourceAsMap = getSourceAsMap == null ? Map.of() : getSourceAsMap;
-        getFields = getFields == null ? Map.of() : getFields;
-        getSortValues = getSortValues == null ? List.of() : getSortValues;
-        getHighlights = getHighlights == null ? Map.of() : getHighlights;
-    }
+    String getId();
 
     /**
-     * The highlight fragments for a single field, in engine order, or an empty list when the field
-     * carries none. Saves every caller the {@code getOrDefault} dance — Site Search only ever asks
-     * for one field ({@code content}), and Velocity can reach it as {@code $hit.highlights.content}.
+     * @return the index name where this search hit was found, or {@code null} if not available
+     */
+    String getIndex();
+
+    /**
+     * @return the source document as a map of field names to values, never {@code null}
+     */
+    Map<String, Object> getSourceAsMap();
+
+    /**
+     * @return the search relevance score for this hit, or {@code NaN} when the engine omitted it
+     *         (field-sorted, non-relevance-scored queries)
+     */
+    float getScore();
+
+    /**
+     * @return the document fields retrieved by the search query (additional fields beyond the source
+     *         document that were explicitly requested), empty if none were requested
+     */
+    Map<String, Object> getFields();
+
+    /**
+     * @return the per-hit sort values the engine returns when the query sorts by a field (e.g. the
+     *         computed distance for a {@code _geo_distance} sort), in the order the {@code sort}
+     *         clause declared; empty for relevance-only (unsorted) queries
+     */
+    List<Object> getSortValues();
+
+    /**
+     * The highlight fragments for a single field, in engine order. Only {@link SiteSearchHit} carries
+     * any: a hit from a query that did not request highlighting yields an empty list here, which is
+     * why callers can turn the result straight into an array without a null check.
      *
      * @param fieldName the field the highlight was requested for
      * @return that field's fragments, never {@code null}
      */
-    public List<String> highlightsFor(final String fieldName) {
-        return getHighlights.getOrDefault(fieldName, List.of());
+    default List<String> highlightsFor(final String fieldName) {
+        return List.of();
     }
 
     /**
@@ -87,7 +118,7 @@ public record SearchHit(
      *
      * @return a new builder instance
      */
-    public static Builder builder() {
+    static Builder builder() {
         return new Builder();
     }
 
@@ -97,7 +128,7 @@ public record SearchHit(
      * @param esSearchHit the Elasticsearch SearchHit to wrap
      * @return a new SearchHit instance
      */
-    public static SearchHit from(org.elasticsearch.search.SearchHit esSearchHit) {
+    static SearchHit from(final org.elasticsearch.search.SearchHit esSearchHit) {
         final Object[] esSortValues = esSearchHit.getSortValues();
         return builder()
                 .id(esSearchHit.getId())
@@ -142,7 +173,7 @@ public record SearchHit(
      * @return a new SearchHit instance
      */
     @SuppressWarnings("unchecked")
-    public static SearchHit from(org.opensearch.client.opensearch.core.search.Hit<?> osHit) {
+    static SearchHit from(final org.opensearch.client.opensearch.core.search.Hit<?> osHit) {
         // Extract source as Map - OpenSearch Hit.source() returns the typed source object
         Map<String, Object> sourceMap;
         Object source = osHit.source();
@@ -193,8 +224,15 @@ public record SearchHit(
      * Fluent builder for {@link SearchHit}. Unset collection attributes default to an empty map and
      * an unset score defaults to {@code 0.0f}, preserving the lenient behaviour of the former
      * Immutables builder.
+     *
+     * <p>{@link #build()} is where the two shapes are chosen: a hit whose engine response carried no
+     * highlight fragments becomes a {@link ContentSearchHit}, which has no highlight state to carry.
+     * That keeps the decision in one place instead of threading a "do I want highlights" flag down
+     * through {@code rawSearch} → {@code ContentSearchResponse.from} → {@code SearchHits.from}, which
+     * would be needed otherwise: Site Search and content search reach the neutral layer through the
+     * very same factory.</p>
      */
-    public static final class Builder {
+    final class Builder {
 
         private String id;
         private String index;
@@ -241,8 +279,15 @@ public record SearchHit(
             return this;
         }
 
+        /**
+         * @return a {@link SiteSearchHit} when highlight fragments are present, otherwise the lean
+         *         {@link ContentSearchHit}
+         */
         public SearchHit build() {
-            return new SearchHit(id, index, sourceAsMap, score, fields, sortValues, highlights);
+            if (highlights.isEmpty()) {
+                return new ContentSearchHit(id, index, sourceAsMap, score, fields, sortValues);
+            }
+            return new SiteSearchHit(id, index, sourceAsMap, score, fields, sortValues, highlights);
         }
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/SearchHit.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/SearchHit.java
@@ -1,6 +1,7 @@
 package com.dotcms.content.index.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -36,10 +37,11 @@ import java.util.stream.Collectors;
  * <p>Accessors are bean-style ({@code getId()}, {@code getSourceAsMap()}, …) so the type works
  * directly from Velocity templates (e.g. {@code $hit.id}) without any extra alias methods. The record
  * components are named accordingly and the {@code JsonProperty} annotations keep the JSON contract
- * clean ({@code id}, {@code index}, …) for the caches/REST paths backed by this type. Deserialization
- * of the interface targets {@link ContentSearchHit}: nothing serializes a Site Search hit today, and
- * the alternative (polymorphic {@code JsonTypeInfo}) would add a type discriminator to a JSON shape
- * those caches depend on.</p>
+ * clean ({@code id}, {@code index}, …) for the caches/REST paths backed by this type. Deserializing the
+ * interface goes through {@link #fromJson}, which reads the same {@code highlights} key the serialized
+ * form already carries and rebuilds the matching shape — so a round-trip preserves the fragments
+ * instead of silently dropping them, and no polymorphic type discriminator has to be added to a JSON
+ * shape those caches depend on.</p>
  *
  * <p><strong>Usage Examples:</strong></p>
  * <pre>
@@ -64,7 +66,6 @@ import java.util.stream.Collectors;
  * @see SearchHits
  * @see com.dotcms.content.index.ContentFactoryIndexOperations
  */
-@JsonDeserialize(as = ContentSearchHit.class)
 public sealed interface SearchHit permits ContentSearchHit, SiteSearchHit {
 
     /**
@@ -120,6 +121,38 @@ public sealed interface SearchHit permits ContentSearchHit, SiteSearchHit {
      */
     static Builder builder() {
         return new Builder();
+    }
+
+    /**
+     * Jackson entry point for the interface, which is not instantiable on its own.
+     *
+     * <p>It deliberately re-uses {@link Builder#build()} rather than pinning one implementation: the
+     * serialized form already carries the {@code highlights} key when there were fragments, so the same
+     * rule that picks the shape on the way in from the engine picks it on the way in from JSON. Pinning
+     * {@code ContentSearchHit} instead would make a serialized {@link SiteSearchHit} come back without
+     * its fragments and without an error — a silent loss, which is the failure mode this codebase has
+     * already paid for elsewhere.</p>
+     *
+     * @return the shape matching the deserialized data
+     */
+    @JsonCreator
+    static SearchHit fromJson(
+            @JsonProperty("id") final String id,
+            @JsonProperty("index") final String index,
+            @JsonProperty("sourceAsMap") final Map<String, Object> sourceAsMap,
+            @JsonProperty("score") final float score,
+            @JsonProperty("fields") final Map<String, Object> fields,
+            @JsonProperty("sortValues") final List<Object> sortValues,
+            @JsonProperty("highlights") final Map<String, List<String>> highlights) {
+        return builder()
+                .id(id)
+                .index(index)
+                .sourceAsMap(sourceAsMap)
+                .score(score)
+                .fields(fields)
+                .sortValues(sortValues)
+                .highlights(highlights)
+                .build();
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/SiteSearchHit.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/SiteSearchHit.java
@@ -53,11 +53,18 @@ public record SiteSearchHit(
     /**
      * {@inheritDoc}
      *
-     * <p>Answers from the fragments this hit carries. Saves every caller the {@code getOrDefault}
-     * dance — Site Search only ever asks for one field ({@code content}).</p>
+     * <p>Answers from the fragments this hit carries. Saves every caller the null dance — Site Search
+     * only ever asks for one field ({@code content}) and turns the result straight into an array.</p>
+     *
+     * <p>Deliberately not {@code getOrDefault}: that substitutes the default only when the key is
+     * <i>absent</i>, so a field explicitly mapped to {@code null} would come back as {@code null} and
+     * NPE at the {@code toArray} on the caller's side. Both unvalidated inputs can produce that — the
+     * OpenSearch adapter passes {@code Hit.highlight()} through as-is, and a {@code "highlights":
+     * {"content": null}} payload survives deserialization.</p>
      */
     @Override
     public List<String> highlightsFor(final String fieldName) {
-        return getHighlights.getOrDefault(fieldName, List.of());
+        final List<String> fragments = getHighlights.get(fieldName);
+        return fragments == null ? List.of() : fragments;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/SiteSearchHit.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/SiteSearchHit.java
@@ -1,0 +1,63 @@
+package com.dotcms.content.index.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The {@link SearchHit} shape that carries highlight fragments, produced for Site Search.
+ *
+ * <p>Site Search renders each result as a snippet with the matched terms emphasised, so its queries
+ * ask the engine to highlight the {@code content} field and its results need those fragments. No other
+ * search path requests highlighting, which is why this shape exists separately from
+ * {@link ContentSearchHit} instead of every hit carrying the field.</p>
+ *
+ * <p>Instances come from {@link SearchHit.Builder#build()}, which selects this shape whenever the
+ * engine response actually carried highlight fragments — no caller flag is involved.</p>
+ *
+ * @param getId          the unique identifier of this search hit (the document ID)
+ * @param getIndex       the index name where this search hit was found, or {@code null} if not available
+ * @param getSourceAsMap the source document as a map of field names to values
+ * @param getScore       the search relevance score for this hit
+ * @param getFields      the document fields retrieved by the search query (additional fields beyond
+ *                       the source document that were explicitly requested), empty if none were requested
+ * @param getSortValues  the per-hit sort values the engine returns when the query sorts by a field, in
+ *                       the order the {@code sort} clause declared; empty for unsorted queries
+ * @param getHighlights  the per-field highlight fragments the engine returned, keyed by field name
+ *                       (e.g. {@code content} for Site Search), each value holding that field's
+ *                       fragments in engine order
+ * @author Fabrizio Araya
+ * @see SearchHit
+ * @see ContentSearchHit
+ */
+public record SiteSearchHit(
+        @JsonProperty("id") String getId,
+        @JsonProperty("index") String getIndex,
+        @JsonProperty("sourceAsMap") Map<String, Object> getSourceAsMap,
+        @JsonProperty("score") float getScore,
+        @JsonProperty("fields") Map<String, Object> getFields,
+        @JsonProperty("sortValues") List<Object> getSortValues,
+        @JsonProperty("highlights") Map<String, List<String>> getHighlights) implements SearchHit {
+
+    /**
+     * Canonical constructor. Collection components default to an empty map/list when {@code null} so
+     * the accessors never return {@code null} (mirrors the previous Immutables collection defaults).
+     */
+    public SiteSearchHit {
+        getSourceAsMap = getSourceAsMap == null ? Map.of() : getSourceAsMap;
+        getFields = getFields == null ? Map.of() : getFields;
+        getSortValues = getSortValues == null ? List.of() : getSortValues;
+        getHighlights = getHighlights == null ? Map.of() : getHighlights;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Answers from the fragments this hit carries. Saves every caller the {@code getOrDefault}
+     * dance — Site Search only ever asks for one field ({@code content}).</p>
+     */
+    @Override
+    public List<String> highlightsFor(final String fieldName) {
+        return getHighlights.getOrDefault(fieldName, List.of());
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/content/index/domain/SearchHitTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/domain/SearchHitTest.java
@@ -3,6 +3,8 @@ package com.dotcms.content.index.domain;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -136,5 +138,50 @@ public class SearchHitTest {
                 hit.highlightsFor("content").isEmpty());
         assertTrue("the builder default must behave the same",
                 SearchHit.builder().id("1").build().highlightsFor("content").isEmpty());
+    }
+
+    /**
+     * Method to test: {@link SearchHit#fromJson}
+     * Given scenario: a Site Search hit carrying highlight fragments is serialized and read back
+     *          through the {@link SearchHit} interface.
+     * Expected result: it returns as the highlight-bearing shape with its fragments intact. Pinning
+     *          deserialization to one implementation would drop them silently instead — the whole
+     *          reason the creator rebuilds through the builder.
+     */
+    @Test
+    public void jacksonRoundTrip_highlightedHit_keepsFragments() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper().registerModule(new GuavaModule());
+        final SearchHit hit = SearchHit.builder()
+                .id("abc123")
+                .index("sitesearch_1")
+                .highlights(Map.of("content", List.of("an <em>argue</em>ment")))
+                .build();
+        assertTrue("precondition: the builder must pick the highlight-bearing shape",
+                hit instanceof SiteSearchHit);
+
+        final SearchHit back = mapper.readValue(mapper.writeValueAsString(hit), SearchHit.class);
+
+        assertTrue("a highlighted hit must come back as the highlight-bearing shape",
+                back instanceof SiteSearchHit);
+        assertEquals("the fragments must survive the round-trip",
+                List.of("an <em>argue</em>ment"), back.highlightsFor("content"));
+        assertEquals("abc123", back.getId());
+    }
+
+    /**
+     * Method to test: {@link SearchHit#fromJson}
+     * Given scenario: a content hit — no highlight key in the JSON — read back through the interface.
+     * Expected result: the lean shape, so the round-trip does not quietly widen every cached hit into
+     *          the Site Search one.
+     */
+    @Test
+    public void jacksonRoundTrip_contentHit_staysLean() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper().registerModule(new GuavaModule());
+        final SearchHit hit = SearchHit.builder().id("abc123").index("live_1").build();
+
+        final SearchHit back = mapper.readValue(mapper.writeValueAsString(hit), SearchHit.class);
+
+        assertTrue("an un-highlighted hit must come back lean", back instanceof ContentSearchHit);
+        assertEquals("abc123", back.getId());
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/content/index/domain/SearchHitTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/domain/SearchHitTest.java
@@ -93,10 +93,31 @@ public class SearchHitTest {
 
         final SearchHit hit = SearchHit.from(osHit);
 
+        assertTrue("a highlighted hit must take the highlight-bearing shape",
+                hit instanceof SiteSearchHit);
         final List<String> fragments = hit.highlightsFor("content");
         assertEquals("both fragments must survive the conversion", 2, fragments.size());
         assertTrue(fragments.get(0).contains("<em>argue</em>"));
         assertTrue(fragments.get(1).contains("<em>argues</em>"));
+    }
+
+    /**
+     * Method to test: {@link SearchHit#from(Hit)}
+     * Given scenario: a hit from a query that never asked for highlighting — i.e. every content search.
+     * Expected result: the lean {@link ContentSearchHit} shape, which carries no highlight state at
+     *          all. This is the invariant that keeps the content path from paying for a Site Search
+     *          concern, so it is asserted rather than assumed.
+     */
+    @Test
+    public void from_openSearchHit_noHighlight_yieldsLeanContentShape() {
+        final Hit<Object> osHit = Hit.of(builder -> builder.index("idx").id("1"));
+
+        final SearchHit hit = SearchHit.from(osHit);
+
+        assertTrue("an un-highlighted hit must take the lean shape",
+                hit instanceof ContentSearchHit);
+        assertTrue("the builder default must behave the same",
+                SearchHit.builder().id("1").build() instanceof ContentSearchHit);
     }
 
     /**
@@ -111,8 +132,6 @@ public class SearchHitTest {
 
         final SearchHit hit = SearchHit.from(osHit);
 
-        assertTrue("a hit without highlighting must expose an empty map",
-                hit.getHighlights().isEmpty());
         assertTrue("an un-highlighted field must yield an empty list, not null",
                 hit.highlightsFor("content").isEmpty());
         assertTrue("the builder default must behave the same",

--- a/dotCMS/src/test/java/com/dotcms/content/index/domain/SearchHitTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/domain/SearchHitTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
@@ -138,6 +139,32 @@ public class SearchHitTest {
                 hit.highlightsFor("content").isEmpty());
         assertTrue("the builder default must behave the same",
                 SearchHit.builder().id("1").build().highlightsFor("content").isEmpty());
+    }
+
+    /**
+     * Method to test: {@link SearchHit#highlightsFor(String)}
+     * Given scenario: the highlight map carries the field as an explicit {@code null} value rather than
+     *          omitting it. Both unvalidated inputs can produce this — the OpenSearch adapter passes
+     *          {@code Hit.highlight()} through as-is, and a {@code "highlights": {"content": null}}
+     *          payload survives deserialization.
+     * Expected result: an empty list, not {@code null}. {@code getOrDefault} would have returned the
+     *          {@code null} (it only substitutes when the key is absent) and NPE'd at the caller's
+     *          {@code toArray}.
+     */
+    @Test
+    public void highlightsFor_fieldMappedToNull_yieldsEmptyList() {
+        final Map<String, List<String>> withNullValue = new HashMap<>();
+        withNullValue.put("content", null);
+        withNullValue.put("title", List.of("a <em>fragment</em>"));
+
+        final SearchHit hit = SearchHit.builder().id("1").highlights(withNullValue).build();
+
+        assertTrue("precondition: a non-empty map must still pick the highlight-bearing shape",
+                hit instanceof SiteSearchHit);
+        assertTrue("a field explicitly mapped to null must yield an empty list, not null",
+                hit.highlightsFor("content").isEmpty());
+        assertEquals("a sibling field with real fragments must still resolve",
+                1, hit.highlightsFor("title").size());
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to @wezell's review on #36886: content search results should stay small and fast, and
highlight fragments are a Site Search concern no other caller reads. Instead of every hit carrying
a field only one caller uses, `SearchHit` becomes a **sealed interface over two records**.

**Stacked on #36886** (base is `issue-36360-phase-sweep-fixes`, not `main`) — the field this splits
only exists on that branch. Retarget to `main` once #36886 merges.

## The shape

```java
public sealed interface SearchHit permits ContentSearchHit, SiteSearchHit {
    // ... the six neutral accessors ...
    default List<String> highlightsFor(String field) { return List.of(); }
}
```

- **`ContentSearchHit`** — six components, no highlight state at all. What every content query produces.
- **`SiteSearchHit`** — the same six plus the fragments, overriding `highlightsFor`.

The `default` is what makes it work: the concern is declared once on the contract, costs zero bytes
per instance, and a caller holding a plain `SearchHit` never has to know or ask which shape it got.

## Callers never choose the shape

`Builder.build()` picks it from the data — the lean record unless the engine actually returned
fragments. That matters because Site Search and content search reach the neutral layer through the
*same* factory (`ContentSearchResponse.from`, since Site Search reads via `rawSearch` after #36398),
so a "do I want highlights" flag would have to be threaded through `rawSearch` →
`ContentSearchResponse.from` → `SearchHits.from` → the hit adapter. Deciding from the response keeps
it in one place. Since the only queries that request highlighting are the two Site Search ones, a
content hit is always the lean shape.

## Blast radius: none outside the domain package

`./mvnw compile -pl :dotcms-core` passes with **zero changes anywhere else** — the ten
`SearchHits.from` / `SearchHit::from` call sites, `ContentSearchResponse`, `Aggregation`,
`ESContentResourcePortlet` and `OSSiteSearchAPI` all compile untouched. Verified the enterprise
consumer really does resolve through the contract:

```
javap OSSiteSearchAPI.class
  429: invokeinterface  // SearchHit.highlightsFor:(Ljava/lang/String;)Ljava/util/List;
```

## Jackson

An interface is not instantiable, so deserialization goes through a `@JsonCreator` static factory that
rebuilds via `Builder.build()`. The serialized form already carries the `highlights` key when there were
fragments, so the same rule that picks the shape coming from the engine picks it coming from JSON — no
polymorphic `@JsonTypeInfo`, so the JSON shape the query caches depend on is unchanged.

The first cut of this PR instead pinned deserialization to `ContentSearchHit`, which made a serialized
`SiteSearchHit` come back without its fragments and without an error. Nothing serializes one today, but
that is a silent-loss landmine of the same class as #36026, so it is fixed rather than documented.

Side benefit: `ContentSearchHit` no longer serializes an empty `"highlights":{}`.

## Velocity

No template reads highlights (zero `.vtl` references in the repo), and Site Search results are not
exposed through a viewtool at all — those templates consume `SiteSearchResult`, which this does not
touch. The at-risk surface is the *content* hit accessors reachable as `$hit.id` / `$hit.sourceAsMap` /
`$hit.sortValues`, and those are guarded by `ContentSearchToolTest`, which evaluates real customer VTL
through the dotCMS Velocity engine.

## Testing

All green against this branch. **25 unit + 83 integration tests**, covering every family that consumes
the neutral hit:

| Test | Covers | Result |
|---|---|---|
| `SearchHitTest` | shape decision, OS `sort()` unwrap, highlights, JSON round-trip both ways, field mapped to `null` | 9/9 |
| `AggregationDomainTest` | Jackson round-trip of `SearchHit` / `SearchHits` | 16/16 |
| `ContentSearchToolTest` | real Velocity: `$hit.id` / `.index` / `.sourceAsMap` / `.sortValues` on `search()` and `raw()`, plus the nested `top_hits` walk | 11/11 |
| `ESContentResourcePortletTest` | the `/api/es/search` and `/api/es/raw` wire shape | 14/14 |
| `ContentletIndexAPIImplTest` | content indexing + search, and the Site Search highlight assertions | 16/16 |
| `ESContentFactoryImplTest` | `searchHits` on the Elasticsearch factory path | 42/42 (1 pre-existing skip) |

Verified the ITs ran against the refactor rather than a stale artifact — the integration module resolves
`dotcms-core` from `~/.m2`, so core was reinstalled first and the installed jar carries `SearchHit` as an
interface alongside the two records.

**Coverage gap, stated plainly:** the runs above are phase 0, where Site Search reads are served by
`ESSiteSearchAPI` — which uses Elasticsearch's own `SearchHit` and never touches the neutral type. So
`SiteSearchHit` end-to-end (`OSSiteSearchAPI` → neutral hit → fragments on the result) is currently
covered by unit tests only. Exercising it needs a phase 2/3 run, where OpenSearch serves reads.

## Breaking Changes

None at the source level. `SearchHit` changes from a record to a sealed interface, so anything
compiled against the concrete type would need recompiling — nothing in the repo does, and the type is
internal to the neutral search layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36360

This PR fixes: #36360