### PR TITLE
Revert "perf(cache): migrate H22 cache async commits to virtual threads" (#35992)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ When editing ANY code, improve incrementally:
 
 ### Backend Development (Java/Maven)
 - [Java Standards](docs/backend/JAVA_STANDARDS.md) — Coding patterns, immutables, exceptions, utilities
+- [When to Use Virtual Threads](docs/backend/VIRTUAL_THREADS.md) — Socket I/O yes, file I/O no; carrier pinning
 - [REST API Patterns](docs/backend/REST_API_PATTERNS.md) — JAX-RS, Swagger, @Schema rules
 - [Maven Build System](docs/backend/MAVEN_BUILD_SYSTEM.md) — Dependency management
 - [Configuration Patterns](docs/backend/CONFIGURATION_PATTERNS.md) — Config.getProperty() usage

--- a/docs/backend/VIRTUAL_THREADS.md
+++ b/docs/backend/VIRTUAL_THREADS.md
@@ -1,0 +1,94 @@
+# When to Use Virtual Threads
+
+Java 25 gives us virtual threads. They are not a drop-in upgrade for every thread pool — the win depends
+entirely on **what the thread blocks on**.
+
+## The one rule
+
+> Virtual threads unmount on **socket** I/O. They do **not** unmount on **file** I/O.
+
+A virtual thread blocked on a socket releases its carrier thread, and the carrier goes off and runs
+other work. A virtual thread blocked on the filesystem **holds its carrier for the whole call**. The
+carrier pool defaults to `Runtime.getRuntime().availableProcessors()` — often 2–4 in a container — so a
+handful of concurrent file writes can starve the scheduler for every virtual thread in the JVM.
+
+## ✅ Good candidates
+
+- HTTP / REST clients, webhooks, outbound API calls
+- Elasticsearch / OpenSearch queries
+- PostgreSQL and other **networked** JDBC (`jdbc:postgresql:…`)
+- Redis / pub-sub / message queues
+- Anything with a socket at the bottom of the stack, especially high fan-out with idle waits
+
+## ❌ Poor candidates — keep these on platform threads
+
+- **Embedded H2** (`jdbc:h2:/path/…`) — MVStore writes are file I/O
+- Local disk reads/writes, `FileChannel`, `Files.*`, `File.exists()`, fsync
+- Network-backed filesystems (NFS, EFS, FUSE/geesefs) — file I/O *and* slow
+- Asset/binary storage on a mounted volume
+- CPU-bound work — virtual threads give nothing here; use a sized pool
+
+## Worked example: why we reverted the H22 cache migration
+
+PR #35992 moved the H22 (embedded H2 on-disk cache) async commit executor from a fixed pool of 5
+platform threads to `Executors.newThreadPerTaskExecutor(Thread.ofVirtual()…)`. It was reverted in
+#36900 after causing a startup hang (#36892).
+
+The reasoning in that PR looked sound:
+
+> JEP 491 means `synchronized` blocks in Hikari/H2 no longer pin the carrier thread, so the classic
+> "virtual threads + JDBC pinning" concern does not apply.
+
+That statement is **correct about `synchronized`** and still the wrong conclusion. JEP 491 removed one
+pinning mechanism; it did not make file I/O unmount. Embedded H2 writes to a file, so every writer kept
+its carrier.
+
+Measured — 3000 upserts of a 4KB payload, 5 concurrent writers, H2 2.2.224:
+
+| carriers | platform pool | virtual threads | ratio |
+|---|---|---|---|
+| 2 (small container) | 7042 puts/sec | **20 puts/sec** | 350x |
+| 4 | 6977 puts/sec | 889 puts/sec | 7.8x |
+| 8 | 6000 puts/sec | 1304 puts/sec | 4.6x |
+| 24 (default) | 7059 puts/sec | 1293 puts/sec | 5.5x |
+
+Platform throughput is flat regardless of carrier count. Virtual threads were 5x slower even with 24
+carriers available, and collapsed on a 2-CPU container.
+
+The throughput loss then exposed a second-order failure: a pre-existing overflow path that ran cache
+writes on the calling thread, which was unreachable at 7000 puts/sec, started firing during startup and
+parked the `main` thread on H2's single-writer lock. **A latent fallback that was harmless at high
+throughput became a hang at low throughput.**
+
+## Before you migrate a pool
+
+1. **Identify what it blocks on.** Socket, file, or CPU? If file or CPU, stop.
+2. **Check for a submit-time cost change.** `newThreadPerTaskExecutor` starts a thread *immediately* on
+   submit. A `ThreadPoolExecutor` with a queue holds backlog as cheap queue nodes; the virtual version
+   holds it as live parked threads. Under a large backlog that is a big memory difference.
+3. **Measure with a realistic carrier count.** Benchmarking on a 24-core dev laptop hides carrier
+   starvation entirely — the H22 regression was 5x locally and 350x on 2 CPUs. Constrain it:
+   ```bash
+   java -Djdk.virtualThreadScheduler.parallelism=2 …
+   ```
+4. **Look for load-shedding or caller-runs fallbacks in the code you are speeding up or slowing down.**
+   Throughput changes move those thresholds. Check what happens when the new code is *slower* than the
+   old, not just faster.
+
+## Diagnosing a suspected pinning problem
+
+A thread dump showing a *platform* carrier thread inside file I/O, with many virtual threads parked
+behind it, is the signature. Also useful:
+
+```bash
+# warn when a virtual thread pins its carrier
+-Djdk.tracePinnedThreads=full
+```
+
+Note that a virtual thread parked on a `ReentrantLock` or `Semaphore` is **fine** — `java.util.concurrent`
+locks are virtual-thread aware and unmount correctly. The problem is the file syscall, not the lock.
+
+## Related
+
+- [Java Standards](JAVA_STANDARDS.md)
+- [Database Patterns](DATABASE_PATTERNS.md)

--- a/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/h22/H22Cache.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/cache/provider/h22/H22Cache.java
@@ -11,6 +11,7 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.zaxxer.hikari.pool.HikariPool.PoolInitializationException;
 import io.vavr.control.Try;
 import java.io.BufferedInputStream;
@@ -33,13 +34,12 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.comparator.LastModifiedFileComparator;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 
@@ -53,13 +53,8 @@ public class H22Cache extends CacheProvider {
     final boolean shouldAsync=Config.getBooleanProperty("cache_h22_async", true);
 
 
-    // Async cache commits run on virtual threads: they block cheaply on JDBC/disk I/O instead of
-    // pinning a small pool of platform threads. numberOfAsyncThreads now sizes a Semaphore that caps
-    // how many commits hit the H2/Hikari pool concurrently (embedded H2 writes don't scale linearly),
-    // while inFlightTasks tracks the total async backlog that isAllocationWithinTolerance() reads.
-    final ThreadFactory namedThreadFactory = Thread.ofVirtual().name("H22-ASYNC-COMMIT-", 0).factory();
-    private final Semaphore dbWorkPermits = new Semaphore(Math.max(1, numberOfAsyncThreads));
-    private final AtomicInteger inFlightTasks = new AtomicInteger(0);
+    final ThreadFactory namedThreadFactory =  new ThreadFactoryBuilder().setDaemon(true).setNameFormat("H22-ASYNC-COMMIT-%d").build();
+    final private LinkedBlockingQueue<Runnable> asyncTaskQueue = new LinkedBlockingQueue<>();
     private ExecutorService executorService;
 
 
@@ -120,10 +115,16 @@ public class H22Cache extends CacheProvider {
 
 
     private ExecutorService spawnNewThreadPool() {
-        // One virtual thread per submitted commit. Backpressure is handled up-front by shouldAsync()
-        // (which falls back to running the commit synchronously on the caller), and dbWorkPermits caps
-        // how many of these virtual threads touch the H2/Hikari pool at the same time.
-        return Executors.newThreadPerTaskExecutor(namedThreadFactory);
+
+        if (Config.getBooleanProperty("cache.h22.async.caller.runs.policy", true)) {
+            return new ThreadPoolExecutor(numberOfAsyncThreads, numberOfAsyncThreads, 10,
+                    TimeUnit.SECONDS, asyncTaskQueue, namedThreadFactory, new ThreadPoolExecutor.CallerRunsPolicy()
+            );
+        }
+
+        return new ThreadPoolExecutor(numberOfAsyncThreads, numberOfAsyncThreads, 10,
+                TimeUnit.SECONDS, asyncTaskQueue, namedThreadFactory
+        );
     }
 
 
@@ -182,43 +183,15 @@ public class H22Cache extends CacheProvider {
 
 
     void putAsync(final Fqn fqn, final Object content) {
-        submitAsync(() -> {
+
+        executorService.submit(()-> {
             try {
                 // Add the given content to the group and for a given key
                 doUpsert(fqn, (Serializable) content);
             } catch (Exception e) {
                 handleError(e, fqn);
             }
-        });
-    }
-
-    /**
-     * Submits a cache commit to run on a virtual thread. The {@link #inFlightTasks} counter is bumped
-     * before submission and cleared in a {@code finally} so {@link #isAllocationWithinTolerance()} sees
-     * the real backlog, and the task acquires a {@link #dbWorkPermits} permit so only a bounded number
-     * of commits hit the H2/Hikari pool at once.
-     */
-    private void submitAsync(final Runnable dbTask) {
-        inFlightTasks.incrementAndGet();
-        try {
-            executorService.submit(() -> {
-                try {
-                    dbWorkPermits.acquire();
-                    try {
-                        dbTask.run();
-                    } finally {
-                        dbWorkPermits.release();
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    inFlightTasks.decrementAndGet();
-                }
-            });
-        } catch (RejectedExecutionException e) {
-            // Executor is shutting down; keep the counter balanced.
-            inFlightTasks.decrementAndGet();
-        }
+         });
     }
 	
 	
@@ -318,7 +291,7 @@ public class H22Cache extends CacheProvider {
 	 * @return
 	 */
 	boolean isAllocationWithinTolerance() {
-		final int size = inFlightTasks.get();
+		final int size = asyncTaskQueue.size();
 		final float allocation = (float) size / (float) asyncTaskQueueSize;
 		Logger.debug(H22Cache.class,
 				() -> " size is " + size + ", allocation is " + allocation + ", tolerance is :"
@@ -336,7 +309,8 @@ public class H22Cache extends CacheProvider {
 	}
 
     void removeAsync(final Fqn fqn) {
-        submitAsync(() -> {
+
+        executorService.submit(()-> {
             try {
                 // Invalidates from Cache a key from a given group
                 doDelete(fqn);


### PR DESCRIPTION
Reverts #35992.

Original issue: #35991 (Java 25 Performance Improvements)
Startup failure this fixes: #36892

## The problem

A customer instance could not complete startup. `main` parked indefinitely in `MVStore.commit` under `H22Cache.put` → `doUpsert`, driven from `InitServlet.init()` → `populateAllVanityURLsCache` → `ESContentFactoryImpl.findContentlets`:

```
"main" ... waiting on condition
   - parking to wait for <0x00000007fe4a3718> (a java.util.concurrent.locks.ReentrantLock$FairSync)
	at org.h2.mvstore.MVStore.commit(MVStore.java:775)
	at org.h2.mvstore.MVStore.beforeWrite(MVStore.java:1273)
	...
	at com.dotmarketing.business.cache.provider.h22.H22Cache.doUpsert(H22Cache.java:650)
	at com.dotmarketing.business.cache.provider.h22.H22Cache.put(H22Cache.java:176)
```

`H22Cache.java:176` is the *synchronous* branch of `put()` — the caller was doing the H2 write itself.

## Why the migration caused it

#35992 rested on this premise:

> JEP 491 means `synchronized` blocks in Hikari/H2 no longer pin the carrier thread, so the classic "virtual threads + JDBC pinning" concern does not apply.

That is true for `synchronized`, but it is not the pinning that matters here. **Virtual threads do not unmount on file I/O, and embedded H2 is file I/O, not socket I/O.** Every commit holding a `dbWorkPermits` permit pins its carrier for the duration of the MVStore write, so the 5 concurrent writers contend for a carrier pool sized to `availableProcessors()`. The old model used 5 dedicated *platform* threads, which are unaffected by carrier availability.

The submission path also changed cost profile: `newThreadPerTaskExecutor` starts a virtual thread immediately on submit, so a backlogged put became a live thread parked on a semaphore rather than a `LinkedBlockingQueue` node.

## Measurements

3000 upserts of a 4KB payload through 5 concurrent writers, H2 2.2.224, using the same statement shape H22 uses (`MERGE INTO … key(cache_id)`):

| carriers | platform pool (old) | virtual+semaphore (new) | ratio |
|---|---|---|---|
| 2 (small container) | 7042 puts/sec | **20 puts/sec** | 350x |
| 4 | 6977 puts/sec | 889 puts/sec | 7.8x |
| 8 | 6000 puts/sec | 1304 puts/sec | 4.6x |
| 24 (default) | 7059 puts/sec | 1293 puts/sec | 5.5x |

Platform throughput is flat regardless of carrier count. The virtual-thread path is 5x slower even with 24 carriers, and collapses on a 2-CPU container.

## Why that throughput loss becomes a hang

The caller-runs fallback in `isAllocationWithinTolerance()` is **not** a regression from #35992 — it dates to `e3b58b3694` (2020-09-16) with the same `10000` / `0.98` defaults. It was simply unreachable at ~7000 puts/sec, because the backlog never approached 9800.

At 20–1300 puts/sec it is reached routinely during startup. Once crossed, every caller writes inline, and hundreds of threads queue on H2's single-writer fair `ReentrantLock`. Throughput drops further, the backlog never drains, and the threshold never clears — it latches rather than sheds.

## Scope

- Pure revert. `H22Cache.java` is byte-identical to `98f8d66fae^`, verified by diff.
- Nothing landed in the h22 package since the migration, so there was nothing to reconcile.
- No test changes — h22 unit tests unmodified and passing.

## Follow-up (deliberately not in this PR)

Tracked in #36892, kept out to keep the revert clean and reviewable:

- overflow should shed puts rather than run them on the caller — already safe, since `put` marks the key in `DONT_CACHE_ME` before writing and `doSelect` honors `exclude()`, so a dropped put reads as a miss
- deletes must never be shed — a dropped delete resurfaces as stale content once the 20s `DONT_CACHE_ME` entry expires
- `setQueryTimeout` on the fail-safe statements
- retire `cache_h22_async_task_queue` / `cache_h22_async_tolerance`, which no longer describe a real queue

## Note for #35991

Any future virtual-thread migration in this codebase should distinguish socket I/O from file I/O. JEP 491 removed `synchronized` pinning; it did not make file I/O unmount. Workloads that block on the filesystem — embedded H2, local disk, FUSE mounts — still hold their carrier and should stay on platform threads.

## Verification

- `./mvnw test-compile -pl :dotcms-core` — clean
- `H22CacheTest` — OK (4 tests)
- Benchmark reproducible standalone against H2 2.2.224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36892