### PR TITLE
perf(test): remove real-time waits and per-iteration content types in slow ITs (#36912)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/jobs/business/detector/AbandonedJobDetector.java
+++ b/dotCMS/src/main/java/com/dotcms/jobs/business/detector/AbandonedJobDetector.java
@@ -103,8 +103,10 @@ public class AbandonedJobDetector implements AutoCloseable {
      *   <li>Put back in queue for retry</li>
      *   <li>Generate a JobAbandonedEvent</li>
      * </ol>
+     * Public so callers (e.g. integration tests) can trigger an immediate scan instead of
+     * waiting for the next scheduled tick; the scheduled executor uses this same method.
      */
-    private void detectAbandonedJobs() {
+    public void detectAbandonedJobs() {
 
         try {
 

--- a/dotcms-integration/src/test/java/com/dotcms/jobs/business/api/JobQueueManagerAPIIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/jobs/business/api/JobQueueManagerAPIIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.dotcms.jobs.business.detector.AbandonedJobDetector;
 import com.dotcms.jobs.business.error.ExponentialBackoffRetryStrategy;
 import com.dotcms.jobs.business.error.RetryStrategy;
 import com.dotcms.jobs.business.job.Job;
@@ -58,6 +59,9 @@ public class JobQueueManagerAPIIntegrationTest extends com.dotcms.Junit5WeldBase
 
     @Inject
     JobQueueManagerAPI jobQueueManagerAPI;
+
+    @Inject
+    AbandonedJobDetector abandonedJobDetector;
 
     /**
      * Sets up the test environment before all tests are run.
@@ -542,7 +546,11 @@ public class JobQueueManagerAPIIntegrationTest extends com.dotcms.Junit5WeldBase
             }
         });
 
-        boolean abandoned = latch.await(3, TimeUnit.MINUTES);
+        // Trigger detection directly instead of waiting up to a minute for the
+        // detector's scheduled tick (the inserted job is already past the threshold)
+        abandonedJobDetector.detectAbandonedJobs();
+
+        boolean abandoned = latch.await(30, TimeUnit.SECONDS);
         assertTrue(abandoned, "Job should be marked as abandoned within timeout period");
 
         // Verify the abandoned job state and error details
@@ -655,7 +663,11 @@ public class JobQueueManagerAPIIntegrationTest extends com.dotcms.Junit5WeldBase
             }
         });
 
-        boolean abandoned = latch.await(3, TimeUnit.MINUTES);
+        // Trigger detection directly instead of waiting up to a minute for the
+        // detector's scheduled tick (the inserted job is already past the threshold)
+        abandonedJobDetector.detectAbandonedJobs();
+
+        boolean abandoned = latch.await(30, TimeUnit.SECONDS);
         assertTrue(abandoned, "Job should be marked as abandoned within timeout period");
 
         // Verify the abandoned job state and error details

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
@@ -17,6 +17,9 @@ import org.quartz.SchedulerException;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -72,19 +75,24 @@ public class StartEndScheduledExperimentsJobTest extends IntegrationTestBase {
             scheduledToStartExperiment = experimentsAPI.start(scheduledToStartExperiment.id().orElseThrow(),
                     APILocator.systemUser());
 
-            // wait for both the start date and the end date to be reached
-            Thread.sleep(25 * 1000);
-
             assertEquals(Status.SCHEDULED, scheduledToStartExperiment.status());
 
-            new StartEndScheduledExperimentsJob().run(null);
-
-            assertEquals(Status.RUNNING,
-                    experimentsAPI.find(scheduledToStartExperiment.id().orElseThrow()
-                            , APILocator.systemUser()).orElseThrow().status());
-            assertEquals(Status.ENDED,
-                    experimentsAPI.find(scheduledToEndExperiment.id().orElseThrow()
-                            , APILocator.systemUser()).orElseThrow().status());
+            // Re-run the job (as Quartz would) until both scheduling dates have passed and
+            // the transitions land: no fixed sleep, completes as soon as the dates are reached
+            final String startId = scheduledToStartExperiment.id().orElseThrow();
+            final String endId = scheduledToEndExperiment.id().orElseThrow();
+            Awaitility.await()
+                    .atMost(40, TimeUnit.SECONDS)
+                    .pollInterval(2, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        new StartEndScheduledExperimentsJob().run(null);
+                        assertEquals(Status.RUNNING,
+                                experimentsAPI.find(startId, APILocator.systemUser())
+                                        .orElseThrow().status());
+                        assertEquals(Status.ENDED,
+                                experimentsAPI.find(endId, APILocator.systemUser())
+                                        .orElseThrow().status());
+                    });
         } finally {
             final Experiment shouldBeRunning = experimentsAPI.find(scheduledToStartExperiment.id().orElseThrow()
                     , APILocator.systemUser()).orElseThrow();

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
@@ -46,11 +46,13 @@ public class StartEndScheduledExperimentsJobTest extends IntegrationTestBase {
     @Test
     public void testJob()
             throws SchedulerException, InterruptedException, DotDataException, DotSecurityException {
-        final Instant NOW_PLUS_TWO_MINUTES = Instant.now().plus(2, ChronoUnit.MINUTES);
+        // Short windows: validateScheduling only requires dates after now-1min, so seconds
+        // are enough — the old 1/2-minute windows forced a 2-minute Thread.sleep
+        final Instant NOW_PLUS_TWENTY_SECONDS = Instant.now().plus(20, ChronoUnit.SECONDS);
 
         // create experiment that will end soon
         Experiment scheduledToEndExperiment = new ExperimentDataGen()
-                .scheduling(Scheduling.builder().endDate(NOW_PLUS_TWO_MINUTES).build())
+                .scheduling(Scheduling.builder().endDate(NOW_PLUS_TWENTY_SECONDS).build())
                 .status(Status.RUNNING)
                 .nextPersisted();
 
@@ -61,17 +63,17 @@ public class StartEndScheduledExperimentsJobTest extends IntegrationTestBase {
             assertEquals(Status.RUNNING, scheduledToEndExperiment.status());
 
             // create experiment that should have started
-            final Instant NOW_PLUS_ONE_MINUTE = Instant.now().plus(1, ChronoUnit.MINUTES);
+            final Instant NOW_PLUS_TEN_SECONDS = Instant.now().plus(10, ChronoUnit.SECONDS);
 
             scheduledToStartExperiment = new ExperimentDataGen()
-                    .scheduling(Scheduling.builder().startDate(NOW_PLUS_ONE_MINUTE).build())
+                    .scheduling(Scheduling.builder().startDate(NOW_PLUS_TEN_SECONDS).build())
                     .nextPersisted();
 
             scheduledToStartExperiment = experimentsAPI.start(scheduledToStartExperiment.id().orElseThrow(),
                     APILocator.systemUser());
 
-            // wait some minutes for its end date to be reached
-            Thread.sleep(2 * 60 * 1000);
+            // wait for both the start date and the end date to be reached
+            Thread.sleep(25 * 1000);
 
             assertEquals(Status.SCHEDULED, scheduledToStartExperiment.status());
 

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
@@ -78,11 +78,12 @@ public class StartEndScheduledExperimentsJobTest extends IntegrationTestBase {
             assertEquals(Status.SCHEDULED, scheduledToStartExperiment.status());
 
             // Re-run the job (as Quartz would) until both scheduling dates have passed and
-            // the transitions land: no fixed sleep, completes as soon as the dates are reached
+            // the transitions land: no fixed sleep, completes as soon as the dates are
+            // reached (~20s); the 2-minute cap is failure-path only, sized for slow runners
             final String startId = scheduledToStartExperiment.id().orElseThrow();
             final String endId = scheduledToEndExperiment.id().orElseThrow();
             Awaitility.await()
-                    .atMost(40, TimeUnit.SECONDS)
+                    .atMost(2, TimeUnit.MINUTES)
                     .pollInterval(2, TimeUnit.SECONDS)
                     .untilAsserted(() -> {
                         new StartEndScheduledExperimentsJob().run(null);

--- a/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
@@ -1504,11 +1504,13 @@ public class TagAPITest extends IntegrationTestBase {
 		final String tagvalue1 = "mytesttag1";
 
 		final Tag tag1 = Try.of(()->APILocator.getTagAPI().saveTag(tagvalue1, testUser.getUserId(), defaultHostId)).getOrNull();
+		// One content type for all iterations: getWikiLikeContentType() creates a brand-new
+		// content type per call, and 100 of them means 100 ES mapping updates
+		final ContentType contentType = TestDataUtils.getWikiLikeContentType();
 		IntStream.range(0, 100).forEach(r -> {
 
 			try {
 				final Contentlet contentAsset = new Contentlet();
-				ContentType contentType = TestDataUtils.getWikiLikeContentType();
 				contentAsset.setContentTypeId(contentType.id());
 				contentAsset.setHost(defaultHostId);
 				contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());


### PR DESCRIPTION
### Proposed Changes

Fixes three of the slowest integration-test hotspots identified from per-class CI timing analysis (run 31054926456). ~4.5 min of aggregate IT time recovered, all behavior-preserving:

| Test | Before | Fix |
|---|---|---|
| StartEndScheduledExperimentsJobTest.testJob | 124s — `Thread.sleep(2 * 60 * 1000)` | Scheduling windows compressed to 10/20 seconds (validateScheduling allows any date after now-1min); sleep 25s |
| JobQueueManagerAPIIntegrationTest abandoned-job tests | ~100s — jobs inserted 5 min stale but tests wait for the detector's minute-granularity timer tick | `AbandonedJobDetector.detectAbandonedJobs()` made public; tests trigger the scan directly, latch 3min → 30s |
| TagAPITest.findTopTags… | 78s — `getWikiLikeContentType()` inside a 100-iteration loop creates ~100 content types → ~100 ES `update_mapping` calls | Content type hoisted out of the loop (one instead of ~100) |

The TagAPITest fix also stops that test permanently bloating the shared index mapping (ES mappings are append-only), which taxes every `update_mapping` from tests that run after it in MainSuite2b.

Only production change is a method visibility change (`private` → `public`) on `AbandonedJobDetector.detectAbandonedJobs()` — no logic touched; the scheduled executor calls the same method.

Investigated and deferred: ShortyIdApiTest.test404CacheWhenDBDown (76s) — not a simple timeout knob (pool is 60 conns / 3s checkout); needs profiling.

Related: #36910 / #36911 (suite reordering).

### Checklist
- [x] Tests (existing tests exercise all changed paths; timing-only changes)
- [ ] Translations
- [x] Security Implications Contemplated (no security impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36912

This PR fixes: #36912