### PR TITLE
fix(cache): add triggering user to cache flush log messages (#36830)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
@@ -17,6 +17,7 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.MaintenanceUtil;
 import com.dotmarketing.util.PortletID;
 import com.google.common.annotations.VisibleForTesting;
+import com.liferay.portal.model.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -295,15 +296,16 @@ public class CacheResource {
                                @PathParam("provider") final String provider,
                                @PathParam("group") final String group) {
 
-        new WebResource.InitBuilder(webResource)
+        final User user = new WebResource.InitBuilder(webResource)
                 .requestAndResponse(request, response)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
                 .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
-                .rejectWhenNoUser(true).init();
+                .rejectWhenNoUser(true).init().getUser();
 
-        Logger.debug(this, ()-> "Deletes objects on cache providers, group: " + group
-                + ", provider = " + provider);
+        Logger.info(this, String.format(
+                "User '%s' is flushing cache group '%s' on provider '%s'",
+                user.getUserId(), group, provider));
 
         this.getProvider(provider, group).remove(group);
         return Response.ok(new ResponseEntityView("flushed")).build();
@@ -327,15 +329,16 @@ public class CacheResource {
                                 @PathParam("group") final String group,
                                 @PathParam("id") final String id) {
 
-        new WebResource.InitBuilder(webResource)
+        final User user = new WebResource.InitBuilder(webResource)
                 .requestAndResponse(request, response)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
                 .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
-                .rejectWhenNoUser(true).init();
+                .rejectWhenNoUser(true).init().getUser();
 
-        Logger.debug(this, ()-> "Deletes object on  cache providers, group: " + group
-                + ", provider = " + provider);
+        Logger.info(this, String.format(
+                "User '%s' is flushing cache object '%s' from group '%s' on provider '%s'",
+                user.getUserId(), id, group, provider));
 
         this.getProvider(provider, group).remove(group, id);
         return Response.ok(new ResponseEntityView("flushed")).build();
@@ -369,14 +372,14 @@ public class CacheResource {
                                 @Context final HttpServletResponse response,
                                 @PathParam("provider") final String provider) {
 
-        new WebResource.InitBuilder(webResource)
+        final User user = new WebResource.InitBuilder(webResource)
                 .requestAndResponse(request, response)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
                 .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
-                .rejectWhenNoUser(true).init();
+                .rejectWhenNoUser(true).init().getUser();
 
-        Logger.debug(this, ()-> "Deletes all objects on  cache provider = " + provider);
+        Logger.info(this, String.format("User '%s' is flushing all caches", user.getUserId()));
 
         cacheMaintenanceHelper.flushAllCaches();
         return Response.ok(new ResponseEntityView("flushed all")).build();
@@ -505,21 +508,22 @@ public class CacheResource {
                     required = true, example = "Permission")
             @PathParam("regionName") final String regionName) {
 
-        new WebResource.InitBuilder(webResource)
+        final User user = new WebResource.InitBuilder(webResource)
                 .requestAndResponse(request, response)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
                 .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
-                .rejectWhenNoUser(true).init();
+                .rejectWhenNoUser(true).init().getUser();
 
         if ("all".equalsIgnoreCase(regionName)) {
-            Logger.info(this, "Flushing all caches");
+            Logger.info(this, String.format("User '%s' is flushing all caches", user.getUserId()));
             cacheMaintenanceHelper.flushAllCaches();
             return new ResponseEntityStringView("Flushed all caches");
         }
 
         final String canonical = cacheMaintenanceHelper.flushRegion(regionName);
-        Logger.info(this, "Flushed cache region: " + canonical);
+        Logger.info(this, String.format("User '%s' flushed cache region '%s'",
+                user.getUserId(), canonical));
         return new ResponseEntityStringView("Flushed " + canonical);
     }
 
@@ -605,14 +609,14 @@ public class CacheResource {
     public ResponseEntityStringView deleteMenuCache(@Context final HttpServletRequest request,
                                                     @Context final HttpServletResponse response) {
 
-        new WebResource.InitBuilder(webResource)
+        final User user = new WebResource.InitBuilder(webResource)
                 .requestAndResponse(request, response)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
                 .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
-                .rejectWhenNoUser(true).init();
+                .rejectWhenNoUser(true).init().getUser();
 
-        Logger.debug(this, ()-> "Deleting menu cache");
+        Logger.info(this, String.format("User '%s' is flushing the menu cache", user.getUserId()));
 
         MaintenanceUtil.deleteMenuCache();
         return new ResponseEntityStringView("flushed menucache");

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/action/ViewCMSMaintenanceAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/cmsmaintenance/action/ViewCMSMaintenanceAction.java
@@ -37,6 +37,7 @@ import com.dotmarketing.util.WebKeys;
 import com.dotmarketing.util.ZipUtil;
 import com.dotmarketing.util.starter.ExportStarterUtil;
 import com.google.common.collect.ImmutableList;
+import com.liferay.portal.model.User;
 import com.liferay.portlet.ActionResponseImpl;
 import com.liferay.util.FileUtil;
 import com.liferay.util.servlet.SessionMessages;
@@ -130,6 +131,8 @@ public class ViewCMSMaintenanceAction extends DotPortletAction {
 		//Manage all the cache Task
 		if(cmd.equals("cache")){
 
+			final User cacheUser = _getUser(req);
+			final String cacheUserId = null != cacheUser ? cacheUser.getUserId() : "unknown";
 			String cacheName = ccf.getCacheName();
 			if (cacheName.equals(com.dotmarketing.util.WebKeys.Cache.CACHE_CONTENTS_INDEX))
 			{
@@ -165,7 +168,7 @@ public class ViewCMSMaintenanceAction extends DotPortletAction {
 				}
 			} else if (cacheName.equals(com.dotmarketing.util.WebKeys.Cache.CACHE_MENU_FILES))
 			{
-				Logger.info(this, "Deleting Menu Files");
+				Logger.info(this, String.format("User '%s' is deleting Menu Files", cacheUserId));
 				_deleteMenusCache();
 				message = "message.cmsmaintenance.cache.flushmenucaches";
 			} else if (cacheName.equals("flushCache"))
@@ -177,7 +180,9 @@ public class ViewCMSMaintenanceAction extends DotPortletAction {
 				}catch (NullPointerException e) {
 					isAllCachesFlush = true;//is a NPE is returned means it's cleaning all the caches
 				}
-				final String msgLogger = isAllCachesFlush ? "Flushing All Caches" : "Flushing " + cacheToFlush +" Cache";
+				final String msgLogger = isAllCachesFlush
+						? String.format("User '%s' is flushing All Caches", cacheUserId)
+						: String.format("User '%s' is flushing %s Cache", cacheUserId, cacheToFlush);
 				Logger.info(this, msgLogger);
 				_flush(cacheToFlush);
 				//Reloads PushPublishing Filters if all cache or system cache is flushed
@@ -186,7 +191,8 @@ public class ViewCMSMaintenanceAction extends DotPortletAction {
 				}
 				message = isAllCachesFlush ? "message.cmsmaintenance.cache.flushallcache" : "message.cmsmaintenance.cache.flushcache";
 			} else {
-				Logger.info(this, "Flushing Live and Working File Cache");
+				Logger.info(this, String.format(
+						"User '%s' is flushing Live and Working File Cache", cacheUserId));
 				_deleteFiles(com.dotmarketing.util.WebKeys.Cache.CACHE_LIVE_FILES);
 				_deleteFiles(com.dotmarketing.util.WebKeys.Cache.CACHE_WORKING_FILES);
 

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -13,6 +13,7 @@ import com.dotcms.rest.api.v1.drive.ContentDriveHelperContentletAPIComparisonTes
 import com.dotcms.rest.api.v1.drive.ContentDriveKeywordSearchTest;
 import com.dotcms.rest.api.v1.drive.ContentDriveWorkflowArchiveStepTest;
 import com.dotcms.rest.api.v1.drive.ContentDriveWorkflowFilterTest;
+import com.dotcms.rest.api.v1.system.cache.CacheResourceIntegrationTest;
 import com.dotcms.security.apps.AppsAPIImplTest;
 import com.dotcms.telemetry.collectors.MetricTimeoutTest;
 import com.dotcms.telemetry.collectors.experiment.CountPagesWithAllEndedExperimentsMetricTypeTest;
@@ -98,6 +99,7 @@ import org.junit.runners.Suite;
         TreeFactoryTest.class,
         PublisherQueueJobTest.class,
         ContentToStringUtilTest.class,
+        CacheResourceIntegrationTest.class,
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
@@ -277,6 +277,21 @@ public class CacheResourceIntegrationTest {
         assertEquals(200, result.getStatus());
     }
 
+    /**
+     * Given: Authenticated admin user
+     * When: deleteMenuCache is called
+     * Then: Returns success — covers the newly added user dereference on this path
+     */
+    @Test
+    public void test_deleteMenuCache_returns_success() {
+
+        final ResponseEntityStringView result =
+                cacheResource.deleteMenuCache(mockAuthenticatedRequest(), mockResponse);
+
+        assertNotNull(result);
+        assertEquals("flushed menucache", result.getEntity());
+    }
+
     // =========================================================================
     // Helper
     // =========================================================================


### PR DESCRIPTION
Fixes #36830

### Proposed Changes
* **`CacheResource`** — the five flush endpoints (`flushAll`, `flushRegion`, `flushGroup`, `flushObject`, `deleteMenuCache`) built an `InitDataObject` via `WebResource.InitBuilder` purely for its auth side effect and discarded the return value, so the authenticated `User` never reached the log line. They now capture the user and include `user.getUserId()`, matching the pattern already used throughout `MaintenanceResource`.
* **Promoted four flush logs from `debug` to `info`** — `flushAll`, `flushGroup`, `flushObject` and `deleteMenuCache` were debug-only, so under default log levels those flushes left no trace at all. Also fixed a latent gap where `flushObject` logged the group but never the object `id`.
* **`ViewCMSMaintenanceAction`** — the legacy Struts cache branch now resolves the portlet user (null-guarded via `_getUser(req)`, falling back to `"unknown"`). This is the path the Maintenance tab's **Flush Cache** button actually posts to (`view_cms_maintenance.jsp` → `submitform('flushCache')` → `cmd=cache`); it is still wired in `struts-config.xml` and `portlet.xml`, and emitted the exact un-attributed `Flushing All Caches` line from the report.
* **Registered `CacheResourceIntegrationTest` in `MainSuite3a`** — the class was not referenced by any suite, so none of its tests ran in CI. Pre-existing gap from when the class was added in #35218; all 11 pre-existing tests pass.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (add notes if applicable)

Only the internal `userId` is logged (e.g. `dotcms.org.1`), not email or other PII. No auth logic changed: `rejectWhenNoUser(true)` + `requiredBackendUser(true)` + `requiredPortlet(...)` already guarantee a non-null user before the log line in `CacheResource`, so no extra guard is needed there. The legacy portlet path can return `null`, so it is explicitly null-guarded. Low-level flush primitives (`MaintenanceUtil.flushCache()`, `CacheMaintenanceHelper`, `CMSMaintenanceFactory`) were deliberately left user-agnostic — they are invoked from cluster events, startup and search-and-replace, which have no triggering user.

### Additional Info
`openapi.yaml` needs no regeneration — no Swagger annotations or method signatures changed.

**Verified in a running instance** (both legacy branches):
```
13:28:12.440  INFO  action.ViewCMSMaintenanceAction - User 'dotcms.org.1' is flushing All Caches
13:31:54.880  INFO  action.ViewCMSMaintenanceAction - User 'dotcms.org.1' is flushing Contentlet Cache
```

**Integration tests** — `Tests run: 12, Failures: 0, Errors: 0, Skipped: 0`, including REST-path attribution:
```
INFO  cache.CacheResource - User 'dotcms.org.1' flushed cache region 'Permission'
INFO  cache.CacheResource - User 'dotcms.org.1' is flushing all caches
INFO  cache.CacheResource - User 'dotcms.org.1' is flushing the menu cache
```

```
./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=CacheResourceIntegrationTest
```

Not addressed here: `CMSMaintenanceAjax.flushIndiciesCache()` (DWR path, ES index cache) has the identical gap, but fixing it requires changing `validateUser()` from `boolean` to `User`, touching ~15 unrelated call sites in that class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)