### PR TITLE
ci: throwaway probe for GitHub-hosted runner region (diagnostic for #36947)

### DIFF
--- a/.github/workflows/utility_probe-runner-location.yml
+++ b/.github/workflows/utility_probe-runner-location.yml
@@ -1,0 +1,68 @@
+name: 'Utility: Probe Runner Location'
+
+# Throwaway diagnostic. Answers "where do our GitHub-hosted runners actually run?"
+# so we can pick a region for a self-hosted remote build cache (see #36947)
+# instead of guessing from GitHub's global egress IP list, which covers all of
+# Actions worldwide and says nothing about where OUR jobs land.
+#
+# Two independent signals per runner:
+#   1. Azure IMDS  - authoritative (the VM's own region), but GitHub may block it
+#   2. egress geo  - always works, but reflects the NAT egress, not the VM
+#
+# Delete this workflow once the region question is settled.
+
+on:
+  workflow_dispatch:
+    inputs:
+      samples:
+        description: 'How many runners to sample (1-20)'
+        required: false
+        default: '12'
+  # Also runs on the PR that introduces it, so the numbers land without needing
+  # this file on the default branch first.
+  pull_request:
+    paths:
+      - '.github/workflows/utility_probe-runner-location.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: probe ${{ matrix.n }}
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        n: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    steps:
+      - name: Probe
+        run: |
+          set -uo pipefail
+
+          # 1. Azure IMDS - the VM's own view of where it is.
+          IMDS=$(curl -s -H 'Metadata:true' --max-time 5 \
+            "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01" 2>/dev/null || true)
+          if echo "$IMDS" | jq -e .location >/dev/null 2>&1; then
+            LOCATION=$(echo "$IMDS" | jq -r '.location // "?"')
+            ZONE=$(echo "$IMDS" | jq -r '.zone // "-"')
+            VMSIZE=$(echo "$IMDS" | jq -r '.vmSize // "?"')
+          else
+            LOCATION="imds-unavailable"; ZONE="-"; VMSIZE="?"
+          fi
+
+          # 2. Egress geolocation - always available, but this is the NAT exit,
+          #    which can differ from the VM's region.
+          GEO=$(curl -s --max-time 8 https://ipinfo.io/json 2>/dev/null || true)
+          IP=$(echo "$GEO"     | jq -r '.ip // "?"'      2>/dev/null || echo '?')
+          CITY=$(echo "$GEO"   | jq -r '.city // "?"'    2>/dev/null || echo '?')
+          REGION=$(echo "$GEO" | jq -r '.region // "?"'  2>/dev/null || echo '?')
+          CC=$(echo "$GEO"     | jq -r '.country // "?"' 2>/dev/null || echo '?')
+
+          echo "PROBE_RESULT azure_region=${LOCATION} zone=${ZONE} vm=${VMSIZE} egress=${CC}/${REGION}/${CITY} ip=${IP} cores=$(nproc) mem=$(free -g | awk '/^Mem:/{print $2}')G"
+
+          {
+            echo "| # | Azure region | zone | VM size | egress | cores |"
+            echo "|---|---|---|---|---|---|"
+            echo "| ${{ matrix.n }} | \`${LOCATION}\` | ${ZONE} | ${VMSIZE} | ${CC}/${REGION}/${CITY} | $(nproc) |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
**Draft / diagnostic — not for merge.** Delete the branch once we have the numbers.

For #36947 we need to pick a region for a self-hosted remote build cache. GitHub publishes Actions egress IP ranges, but that list covers all of Actions worldwide (5,658 IPv4 prefixes, ~27.9M addresses) and says nothing about where *our* `ubuntu-24.04` jobs actually land. Geolocating a sample of it clustered in US East but scattered enough to be unreliable.

This samples 12 runners and records two independent signals per runner:

1. **Azure IMDS** — the VM's own region. Authoritative, but GitHub may block it.
2. **Egress geolocation** — always available, but reflects the NAT exit, which can differ from the VM's region.

Plus cores/memory, which is separately useful given every test job runs Postgres + Elasticsearch + dotCMS on one runner.

Named `utility_*` on purpose: the `build`/`backend` filters only match `cicd_comp_*`, `cicd_1-pr` and `core-cicd/**/action.yml`, so this should not trigger the heavy pipeline.