### PR TITLE
perf(ci): cancel superseded Claude review runs (#36962)

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Reviewing a commit that has already been superseded helps nobody, and the run
+# holds a runner slot the rest of the pipeline is queueing for.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ─────────────────────────────────────────────────────────────────
   # Gate 1 — Pilot author allowlist

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -15,6 +15,16 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Only push-triggered runs supersede each other. The fallback chain matters:
+#   comment.id        -> unique per comment, so two @claude comments in a row never
+#                        cancel each other; an in-flight interactive reply survives
+#   pull_request.number -> shared across pushes to one PR, so a new push cancels the
+#                        review of the commit it just replaced
+#   run_id            -> unique, so manual workflow_dispatch runs are never cancelled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.comment.id || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Security gate: Check if user is dotCMS organization member
   #

--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Reviewing a commit that has already been superseded helps nobody, and the run
+# holds a runner slot the rest of the pipeline is queueing for.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Security gate: Check if user is dotCMS organization member
   #

--- a/.github/workflows/ai_claude-sdk-breaking-change.yml
+++ b/.github/workflows/ai_claude-sdk-breaking-change.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Reviewing a commit that has already been superseded helps nobody, and the run
+# holds a runner slot the rest of the pipeline is queueing for.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Security gate: Check if user is dotCMS organization member
   #


### PR DESCRIPTION
Closes #36962.

## What

Adds a `concurrency` group with `cancel-in-progress: true` to the four Claude AI workflows, matching the pattern `cicd_1-pr.yml:36` already uses.

## Why

All four fire on `pull_request: [opened, synchronize]` and none declared a concurrency group. Every push to a PR launches four more jobs while the previous four keep reviewing a commit nobody will merge.

Observed directly while working on #36961 — a force-push at 18:48 started a new set while the 18:46 set was **still in progress** on the same branch:

```
ai_claude-orchestrator        (running)  18:46  issue-36947-maven-s3-build-cache
ai_claude-orchestrator        (running)  18:48  issue-36947-maven-s3-build-cache
ai_claude-rollback-safety     (running)  18:46  issue-36947-maven-s3-build-cache
ai_claude-rollback-safety     success    18:48  issue-36947-maven-s3-build-cache
```

## This is contention, not latency

Worth being precise, because it changes what the fix is worth. These workflows are **not** on the critical path:

- they are standalone workflows, not called from `cicd_1-pr.yml`
- the only required status checks on `main` are `Finalize / Final Status` and `Initialize / Initialize` — no Claude workflow is required, none can block a merge
- none has a `merge_group` trigger, so they never run in the merge queue

So this does not shorten the pipeline directly. It stops superseded jobs from holding runner slots the rest of the pipeline is queueing for. Measured aggregate queue on a PR run reaches **271 job-minutes**, with individual jobs waiting 20m, so that contention inflates wall clock indirectly.

## The orchestrator is deliberately different

`ai_claude-orchestrator` also fires on `issue_comment` and `pull_request_review_comment`. A naive `cancel-in-progress` there would kill an in-flight interactive `@claude` reply the moment a second comment arrived.

The fallback chain avoids that:

| Fallback | Event | Effect |
|---|---|---|
| `github.event.comment.id` | comment | unique per comment — interactive replies never cancel each other |
| `github.event.pull_request.number` | push | shared per PR — a new push cancels the superseded review |
| `github.run_id` | `workflow_dispatch` | unique — manual runs are never cancelled |

Only push-triggered runs supersede each other.

## Risk

Low. Worst case a review is cancelled and the push that cancelled it triggers a fresh one, which is the intent. No behaviour change for comment-driven or manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014a2iJy9JXRBSVdKBbmoZ2S

This PR fixes: #36962