### PR TITLE
DO NOT MERGE: fix(folders): enforce FolderSearchParams required fields in the canonical constructor (#34154)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderSearchParams.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderSearchParams.java
@@ -40,8 +40,10 @@ import java.util.Objects;
  * reshaping it is a public API change. Recorded so that keeping the flat shape stays a deliberate
  * choice rather than an oversight — and note that the component count has already grown once.</p>
  *
- * <p>Related, and independent of the shape: the {@code siteId} and {@code user} null checks currently
- * live in {@link Builder#build()}, which a direct call to the canonical constructor bypasses.</p>
+ * <p>For the same reason, the required-field checks live in the canonical constructor and not in
+ * {@link Builder#build()}: a check in the builder only guards callers who happen to use the builder,
+ * while a check in the canonical constructor guards every construction path, including the builder's
+ * own.</p>
  */
 public record FolderSearchParams(
         String name,
@@ -55,6 +57,16 @@ public record FolderSearchParams(
         String orderBy,
         String orderDirection,
         boolean includePermissions) {
+
+    /**
+     * Canonical constructor. The required-field checks live here rather than in
+     * {@link Builder#build()} because this is the only construction path that cannot be bypassed: the
+     * builder delegates to it, and so does any direct {@code new FolderSearchParams(...)} call.
+     */
+    public FolderSearchParams {
+        Objects.requireNonNull(siteId, "siteId is required");
+        Objects.requireNonNull(user, "user is required");
+    }
 
     public static Builder builder() {
         return new Builder();
@@ -87,9 +99,10 @@ public record FolderSearchParams(
         public Builder orderDirection(final String orderDirection) { this.orderDirection = orderDirection; return this; }
         public Builder includePermissions(final boolean includePermissions) { this.includePermissions = includePermissions; return this; }
 
+        /**
+         * Delegates to the canonical constructor, which enforces the required fields.
+         */
         public FolderSearchParams build() {
-            Objects.requireNonNull(siteId, "siteId is required");
-            Objects.requireNonNull(user,   "user is required");
             return new FolderSearchParams(name, path, recursive, siteId, user,
                     respectFrontendRoles, limit, offset, orderBy, orderDirection, includePermissions);
         }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderSearchParams.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderSearchParams.java
@@ -10,6 +10,38 @@ import java.util.Objects;
  * <p>{@code includePermissions} opts into per-folder permission computation: when {@code false}
  * (the default) the resulting views carry a {@code null} permission list and no extra permission
  * query is issued.
+ *
+ * <h2>Design note: this record carries eleven flat components</h2>
+ *
+ * <p>A record's canonical constructor is positional, and because this record is {@code public} the
+ * canonical constructor cannot be declared less accessible than the record itself. So there is always
+ * a callable eleven-argument entry point, and {@link #builder()} is a convenience rather than a
+ * gate.</p>
+ *
+ * <p>Three pairs of adjacent components share a type — {@code name} / {@code path},
+ * {@code limit} / {@code offset}, {@code orderBy} / {@code orderDirection} — and three more components
+ * are {@code boolean} ({@code recursive}, {@code respectFrontendRoles}, {@code includePermissions}). A
+ * transposed argument list therefore compiles and silently searches for the wrong thing, or quietly
+ * flips a permission behaviour. Validating inside the canonical constructor does not help with this:
+ * each transposed value is individually valid, so there is nothing for a check to reject.</p>
+ *
+ * <p>The components do fall into natural groups, which would remove the hazard by typing instead of by
+ * discipline — a {@code PageRequest} cannot be passed where a {@code FolderCriteria} is expected:</p>
+ *
+ * <pre>{@code
+ * public record FolderSearchParams(
+ *         FolderCriteria criteria,   // name, path, recursive
+ *         Requester requester,       // user, respectFrontendRoles, includePermissions
+ *         PageRequest page) {        // limit, offset, sortColumn, sortDirection
+ * }
+ * }</pre>
+ *
+ * <p>Not applied here: this type appears in the {@link FolderAPI#searchFolders} signature, so
+ * reshaping it is a public API change. Recorded so that keeping the flat shape stays a deliberate
+ * choice rather than an oversight — and note that the component count has already grown once.</p>
+ *
+ * <p>Related, and independent of the shape: the {@code siteId} and {@code user} null checks currently
+ * live in {@link Builder#build()}, which a direct call to the canonical constructor bypasses.</p>
  */
 public record FolderSearchParams(
         String name,

--- a/dotCMS/src/test/java/com/dotmarketing/portlets/folders/business/FolderSearchParamsTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/portlets/folders/business/FolderSearchParamsTest.java
@@ -1,0 +1,117 @@
+package com.dotmarketing.portlets.folders.business;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+import com.liferay.portal.model.User;
+import org.junit.Test;
+
+/**
+ * Unit tests for the required-field invariants of {@link FolderSearchParams}.
+ *
+ * <p>The point of these tests is <em>where</em> the checks are enforced, not merely that they exist. A
+ * record's canonical constructor cannot be declared less accessible than the record itself, so for a
+ * {@code public record} there is always a public positional entry point and
+ * {@link FolderSearchParams#builder()} can only ever be a convenience. A check placed in
+ * {@code Builder.build()} guards the callers who happen to use the builder; a check in the canonical
+ * constructor guards every construction path, the builder's own included.</p>
+ *
+ * <p>{@link #test_directConstruction_enforcesRequiredFields()} is therefore the test that matters: it
+ * would have passed silently before the checks moved.</p>
+ *
+ * @author Fabrizio Araya
+ */
+public class FolderSearchParamsTest {
+
+    private static final String SITE_ID = "48190c8c-42c4-46af-8d1a-0cd5db894797";
+
+    /**
+     * Method to test: {@link FolderSearchParams#FolderSearchParams(String, String, boolean, String, User, boolean, int, int, String, String, boolean)}
+     * Given scenario: the canonical constructor is called directly, bypassing the builder, with a
+     * missing {@code siteId} and then with a missing {@code user}.
+     * Expected result: it rejects both. This is the case a check in {@code Builder.build()} cannot
+     * cover, and the reason the invariant belongs on the constructor.
+     */
+    @Test
+    public void test_directConstruction_enforcesRequiredFields() {
+        final NullPointerException noSite = assertThrows(NullPointerException.class,
+                () -> new FolderSearchParams("name", "/", false, null, new User(), false,
+                        40, 0, "folder.name", "ASC", false));
+        assertEquals("siteId is required", noSite.getMessage());
+
+        final NullPointerException noUser = assertThrows(NullPointerException.class,
+                () -> new FolderSearchParams("name", "/", false, SITE_ID, null, false,
+                        40, 0, "folder.name", "ASC", false));
+        assertEquals("user is required", noUser.getMessage());
+    }
+
+    /**
+     * Method to test: {@link FolderSearchParams.Builder#build()}
+     * Given scenario: the builder is used without setting {@code siteId}.
+     * Expected result: it still rejects, now because it delegates to the canonical constructor rather
+     * than because it carries its own copy of the check. Same exception type and message as before, so
+     * the behaviour callers see is unchanged.
+     */
+    @Test
+    public void test_builderWithoutSiteId_stillRejects() {
+        final NullPointerException thrown = assertThrows(NullPointerException.class,
+                () -> FolderSearchParams.builder().user(new User()).build());
+
+        assertEquals("siteId is required", thrown.getMessage());
+    }
+
+    /**
+     * Method to test: {@link FolderSearchParams.Builder#build()}
+     * Given scenario: the builder is used without setting {@code user}.
+     * Expected result: rejected, with the message unchanged.
+     */
+    @Test
+    public void test_builderWithoutUser_stillRejects() {
+        final NullPointerException thrown = assertThrows(NullPointerException.class,
+                () -> FolderSearchParams.builder().siteId(SITE_ID).build());
+
+        assertEquals("user is required", thrown.getMessage());
+    }
+
+    /**
+     * Method to test: {@link FolderSearchParams.Builder#build()}
+     * Given scenario: only the two required fields are set.
+     * Expected result: the builder's documented defaults survive the move — nothing about them was
+     * folded into the constructor.
+     */
+    @Test
+    public void test_builderDefaults_areUnchanged() {
+        final User user = new User();
+        final FolderSearchParams params = FolderSearchParams.builder()
+                .siteId(SITE_ID)
+                .user(user)
+                .build();
+
+        assertEquals(SITE_ID, params.siteId());
+        // assertSame, not assertEquals: User.equals() dereferences a primary key a bare User lacks.
+        assertSame(user, params.user());
+        assertEquals("/", params.path());
+        assertEquals(false, params.recursive());
+        assertEquals(false, params.respectFrontendRoles());
+        assertEquals(40, params.limit());
+        assertEquals(0, params.offset());
+        assertEquals("folder.name", params.orderBy());
+        assertEquals("ASC", params.orderDirection());
+        assertEquals(false, params.includePermissions());
+    }
+
+    /**
+     * Method to test: {@link FolderSearchParams#FolderSearchParams(String, String, boolean, String, User, boolean, int, int, String, String, boolean)}
+     * Given scenario: an optional component is left null.
+     * Expected result: accepted. Only {@code siteId} and {@code user} are required, so the move must
+     * not have tightened anything else — {@code name} being null is how "no name filter" is expressed.
+     */
+    @Test
+    public void test_optionalComponentsMayBeNull() {
+        final FolderSearchParams params = new FolderSearchParams(null, "/", false, SITE_ID,
+                new User(), false, 40, 0, "folder.name", "ASC", false);
+
+        assertEquals(null, params.name());
+    }
+}


### PR DESCRIPTION
## Summary

`FolderSearchParams` kept its `siteId` and `user` null checks in `Builder.build()`. This moves them into
the canonical constructor, and documents the shape trade-off that made the misplacement easy to miss.

## Why the builder could never enforce it

A record's canonical constructor **cannot be declared less accessible than the record itself** — the
language forbids it. So for a `public record` there is always a public positional entry point, and
`builder()` can only ever be a convenience, never a gate:

```java
FolderSearchParams.builder().user(user).build();   // rejected: no siteId
new FolderSearchParams(name, path, false, null, user, ...);   // before: accepted
```

This is a real difference from the Immutables-based models used elsewhere in this codebase, where the
generated constructor *is* private (`ImportResult` → `private ImportResult(...)`) and the builder
therefore genuinely *is* the only door. With a record, the invariant has exactly one enforceable home.

## What changed

Both checks moved to the canonical constructor. `build()` now delegates instead of carrying its own copy.

**Behaviour is unchanged for existing callers**: same exception type (`NullPointerException`, via
`Objects.requireNonNull`), same messages (`"siteId is required"` / `"user is required"`), and `build()`
still rejects the same inputs. Nothing in the repository constructs the record directly other than
`build()` itself, so no call site changes.

## The javadoc note

The same commit range documents what validation *cannot* fix here, because it is the more interesting
half. The record carries **eleven flat components**, and the count has already grown once
(`includePermissions` arrived with #36889). Three pairs of adjacent components share a type —
`name`/`path`, `limit`/`offset`, `orderBy`/`orderDirection` — and three more are `boolean`
(`recursive`, `respectFrontendRoles`, `includePermissions`).

A transposed argument list therefore compiles and silently searches for the wrong thing, or quietly
flips a permission behaviour. **Constructor validation does nothing for that**: each transposed value is
individually valid, so there is nothing for a check to reject. The grouping that would fix it by typing
instead of by discipline is recorded in the javadoc:

```java
public record FolderSearchParams(
        FolderCriteria criteria,   // name, path, recursive
        Requester requester,       // user, respectFrontendRoles, includePermissions
        PageRequest page) {        // limit, offset, sortColumn, sortDirection
}
```

Deliberately **not applied**: this type is in the `FolderAPI.searchFolders` signature, so reshaping it is
a public API change and belongs in its own PR. Written down so that keeping the flat shape stays a
decision rather than an oversight.

## Testing

**44 green** — 15 unit, 29 integration.

| Test | Covers | Result |
|---|---|---|
| `FolderSearchParamsTest` | the invariants, new | 5/5 |
| `FolderSearchPaginatorTest` | the only caller, unchanged | 10/10 |
| `FolderAPIImplFilterTest` | folder search through the API | 16/16 |
| `FolderFactoryImplFilterTest` | the SQL the params drive | 7/7 |
| `FolderCollectionDataFetcherTest` | the GraphQL consumer | 6/6 |

The test that carries the weight is `test_directConstruction_enforcesRequiredFields` — it exercises the
path a check in `build()` cannot cover, and **would have passed silently before this change**. The others
pin what must *not* have shifted: the same exception and message coming out of the builder, the builder's
defaults, and that the optional components may still be null (`name == null` is how "no name filter" is
expressed).

`doclint` is disabled project-wide (`parent/pom.xml` → `<doclint>none</doclint>`), so the javadoc carries
no build risk.

## Breaking Changes

None for any caller in this repository. Strictly speaking, external code that constructed the record
directly with a null `siteId` or `user` would now fail at construction rather than later and elsewhere —
which is the intent, and the type is on a public API, so it is worth stating rather than glossing over.

## Context

Groundwork for the Devoxx Belgium 2025 Lunch and Learn (#34154). Its dotCMS half argues about when
records fit this codebase and when they do not, and this type carries both halves of that argument at
once: the invariant belongs on the canonical constructor *because* it cannot be hidden, and eleven flat
components is the point where a record stops being the right carrier.

This PR fixes: #34154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
