### PR TITLE
fix(ci): force flatten on build-cache hits so installed POMs resolve (#36947)

### DIFF
--- a/.github/actions/core-cicd/build-cache-remote/action.yml
+++ b/.github/actions/core-cicd/build-cache-remote/action.yml
@@ -169,8 +169,18 @@ runs:
         # jobs consume. Same reasoning for docker-maven-plugin: a hit on
         # dotcms-core would otherwise skip the execution that writes
         # dotCMS/target/docker-build.tar, which the next step uploads.
+        # flatten-maven-plugin is the one that makes install CORRECT rather than
+        # merely present. parent/pom.xml uses Maven CI-friendly versions
+        # (<revision>) with flatten's updatePomFile=true, so flatten rewrites the
+        # project POM to the resolved version and install publishes that. On a
+        # cache hit flatten:flatten is skipped, install then publishes the RAW
+        # pom, and every consumer fails with:
+        #   Could not find artifact ...:pom:${revision}${sha1}${changelist}
+        # Measured: 19 restored modules, 19 skipped flatten executions, whole
+        # integration suite unable to resolve dotcms-core's dependencies.
+        #
         # (Named goals, not globs — FINAL_ARGS is expanded unquoted in maven-job.)
-        ALWAYS_RUN="maven-install-plugin:install,docker-maven-plugin:build"
+        ALWAYS_RUN="flatten-maven-plugin:flatten,maven-install-plugin:install,docker-maven-plugin:build"
 
         # remote.save.final: never let a later build overwrite an existing entry.
         ARGS="-Dmaven.build.cache.remote.enabled=true"


### PR DESCRIPTION
🔴 **Fixes an active CI outage on main.** Every PR and merge-queue build is currently publishing broken POMs into its own Maven repo.

## Symptom

```
Could not resolve dependencies for project com.dotcms:dotcms-integration:
  Failed to collect dependencies at com.dotcms:dotcms-core -> com.dotcms.core.plugins:com.dotcms.tika-api
  Could not find artifact com.dotcms.core.plugins:dotcms-core-plugins-parent
    :pom:${revision}${sha1}${changelist}
```

## Cause

`parent/pom.xml` uses [Maven CI-friendly versions](https://maven.apache.org/maven-ci-friendly.html) (`<revision>1.0.0</revision>`) with `flatten-maven-plugin`'s `updatePomFile=true`. Flatten rewrites the project POM to the resolved version at `process-resources`, and `install` publishes *that*.

The build cache treats `flatten:flatten` as a cached execution and **skips it on a hit** — while `alwaysRunPlugins` forces `install` to run anyway. So `install` faithfully published the raw `pom.xml`, placeholders and all.

On run [31235284253](https://github.com/dotCMS/core/actions/runs/31235284253): **19 modules restored, 19 `Skipping plugin execution (cached): flatten:flatten`**, and the whole integration suite unable to resolve `dotcms-core`'s dependencies.

## Why it passed every previous run

The bucket was empty until the first `merge_group` write on #36960's own merge. A 100% cache miss never exercises this path — so every run before that was legitimately green, including the one that merged the cache. **The first run to get real hits was the first to break.**

## Verified locally against `:com.dotcms.tika-api`

| Scenario | Installed POM version | flatten skipped |
|---|---|---|
| Cold build, no cache | `1.0.0-SNAPSHOT` ✅ | 0 |
| Cache hit, previous flags | `${revision}${sha1}${changelist}` ❌ | 4 |
| Cache hit, **flatten forced** | `1.0.0-SNAPSHOT` ✅ | 0 |

## Immediate mitigation, independent of this PR

```
gh variable set BUILD_CACHE_DISABLED --body true --repo dotCMS/core
```

That kill switch (shipped in #36960) turns the cache off repo-wide with no revert and no deploy. Unset it once this lands.

## The shape of this bug is worth naming

`alwaysRunPlugins` is a hand-curated allowlist of "executions that must not be skipped" — precisely the kind of hand-maintained predicate that [the caching proposal](https://github.com/dotCMS/core/blob/main/docs/core/CI_REMOTE_CACHE_PROPOSAL.md) argued content hashing should replace. `install` was identified up front; `flatten` was not, because nothing fails until a hit actually happens. **Any other plugin that mutates state `install` depends on carries the same exposure**, and a miss-only run will never reveal it.

Two follow-ups worth considering, not done here:
- Keep `BUILD_CACHE_DISABLED=true` until a merge-queue build demonstrates a *green* run with hits, rather than trusting this fix on a miss-only PR run.
- Consider whether `<flatten.skip>` or narrowing what the cache is allowed to skip is a more durable answer than growing the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014a2iJy9JXRBSVdKBbmoZ2S

This PR fixes: #36947
