### PR TITLE
fix(opensearch): keep the Lucene query on random-sorted OS searches (#36501)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentFactoryIndexOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentFactoryIndexOperationsOS.java
@@ -32,7 +32,6 @@ import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.FunctionScoreQuery;
-import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryStringQuery;
 import org.opensearch.client.opensearch._types.query_dsl.RandomScoreFunction;
@@ -288,25 +287,44 @@ public class ContentFactoryIndexOperationsOS implements ContentFactoryIndexOpera
     }
 
     /**
-     * Creates a Query object from the query string and sort parameters
+     * Creates a Query object from the query string and sort parameters.
+     *
+     * <p><strong>The Lucene query must survive every branch.</strong> The Elasticsearch
+     * counterpart ({@code ContentFactoryIndexOperationsES.createSearchSourceBuilder}) keeps it
+     * as a {@code post_filter} whenever it swaps the main query for {@code match_all}; the
+     * OpenSearch port dropped it on the {@code random} branch and never applied a post-filter at
+     * all, so a random-sorted search returned an unfiltered sample of the whole index. Callers
+     * then resolved arbitrary documents against the database: {@code IdentifierDateJob} NPE'd on
+     * inodes that do not exist and tried to INSERT phantom identifier rows, and any VTL
+     * {@code $dotcontent.pull(query, limit, "random")} returned content the query never asked
+     * for (issue #36501, D12).</p>
+     *
+     * <p>Rather than mirroring {@code post_filter}, the random branch wraps the real query inside
+     * the {@code function_score}. The hit set and its ordering are identical — {@code post_filter}
+     * is only distinguishable when aggregations are in play, and this request carries none — and
+     * filtering in query context is cheaper, since scoring only runs on matching documents.</p>
      */
-    private Query createQuery(final String query, final String sortBy) {
+    @VisibleForTesting
+    Query createQuery(final String query, final String sortBy) {
+
+        final Query queryString = Query.of(q -> q.queryString(QueryStringQuery.of(qs -> qs.query(query))));
 
         if(IndexConfigHelper.getBoolean(OSIndexProperty.USE_FILTERS_FOR_SEARCHING, false)
                 && sortBy != null && !sortBy.toLowerCase().startsWith("score")) {
 
             if("random".equals(sortBy)){
                 return Query.of(q -> q.functionScore(FunctionScoreQuery.of(fsq -> fsq
-                        .query(Query.of(maq -> maq.matchAll(MatchAllQuery.of(ma -> ma))))
+                        .query(queryString)
                         .functions(fsf -> fsf.randomScore(RandomScoreFunction.of(rs -> rs)))
                 )));
             } else {
-                // Use match_all with post_filter (this would need to be implemented differently in OpenSearch Java client)
-                return Query.of(q -> q.queryString(QueryStringQuery.of(qs -> qs.query(query))));
+                // ES builds match_all + post_filter(query) here; querying directly yields the same
+                // hits without the extra clause, so there is nothing to port.
+                return queryString;
             }
 
         } else {
-            return Query.of(q -> q.queryString(QueryStringQuery.of(qs -> qs.query(query))));
+            return queryString;
         }
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/IdentifierDateJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/IdentifierDateJob.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.quartz.job;
 
+import com.dotcms.content.index.IndexContentletScroll;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.notifications.bean.NotificationLevel;
 import com.dotcms.notifications.bean.NotificationType;
@@ -42,6 +43,9 @@ import org.quartz.SimpleTrigger;
  */
 public class IdentifierDateJob implements Job {
 
+	/** Identifiers are updated this many at a time, one transaction per batch. */
+	private static final int BATCH_SIZE = 500;
+
 	/* (non-Javadoc)
 	 * @see org.quartz.Job#execute(org.quartz.JobExecutionContext)
 	 */
@@ -59,83 +63,37 @@ public class IdentifierDateJob implements Job {
 								" +working:true" +
 								" +languageId:" + APILocator.getLanguageAPI().getDefaultLanguage().getId();
 
-			//Identifiers will be updated 500 at a time
-			Integer limit = 500;
-			Integer offset = 0;
+			// Identifiers are updated in batches, one transaction each, over a scroll cursor.
+			//
+			// The previous offset pagination was doubling the page size and then adding the NEW
+			// size to the offset (limit += limit; offset += limit), so it walked
+			// [0,500) [1000,2000) [3000,5000) [7000,11000)… — skipping an ever-widening gap
+			// between pages. Worse, once the doubled limit passed ContentletAPI's MAX_LIMIT
+			// (10000), searchIndex switches to the scroll branch and ignores the offset entirely:
+			// it returned the FULL result set, which is never empty, so on a content type with
+			// more than ~15000 working contentlets the loop never terminated at all and
+			// reprocessed everything on every pass. Randomly sorting the result made it worse
+			// still — pages of an offset-paginated random sort have no relation to one another.
+			//
+			// A scroll cursor holds one consistent snapshot for the whole walk, which is exactly
+			// the guarantee this job needs: every matching contentlet visited once.
+			try (final IndexContentletScroll contentletScroll =
+					contentletAPI.createScrollQuery(luceneQuery, user, false, BATCH_SIZE, null)) {
 
-			//Get all the ContentletSearch
-			List<ContentletSearch> contenletSearchList = contentletAPI.searchIndex(luceneQuery, limit, offset, "random", user, false);
+				List<ContentletSearch> contentletSearchList;
 
-			//If the query result is not empty
-			while(!contenletSearchList.isEmpty()){
-				//Start 500 (limit) transaction
-				HibernateUtil.startTransaction();
+				while((contentletSearchList = contentletScroll.nextBatch()) != null
+						&& !contentletSearchList.isEmpty()){
+					//Start batch transaction
+					HibernateUtil.startTransaction();
 
-				//Iterates all the ContentletSearch of the query
-				for(ContentletSearch contentletSearch : contenletSearchList){
-					//Get the identifier of each contentlet
-					final Identifier identifier= APILocator.getIdentifierAPI().find(contentletSearch.getIdentifier());
-
-					//Gets contentlet info
-                    final Contentlet contentlet = contentletAPI.find(contentletSearch.getInode(), user, false);
-
-					// A hit the database cannot resolve is skipped, not fatal. The index and the
-					// database drift for ordinary reasons (an interrupted delete, a stale shadow
-					// index during the ES→OS migration), and neither unresolved value is safe to
-					// carry into the body below: a null contentlet throws on getMap() and takes
-					// down the whole job, so every remaining contentlet of this type silently keeps
-					// a stale date; and an unresolved identifier comes back from find() as an
-					// EMPTY Identifier (IdentifierFactoryImpl.check404), which save() would
-					// persist as a brand-new row under a generated id, with null parent_path /
-					// asset_name / host_inode — rejected by identifier_parent_path_check, or
-					// corrupt data on any engine that lets it through. See issue #36501.
-					if (contentlet == null || !UtilMethods.isSet(identifier.getId())) {
-						Logger.warn(this, "Skipping index hit that does not resolve in the database"
-								+ " — identifier: " + contentletSearch.getIdentifier()
-								+ ", inode: " + contentletSearch.getInode()
-								+ ", content type: " + type.variable());
-						continue;
+					for(final ContentletSearch contentletSearch : contentletSearchList){
+						updateIdentifierDates(contentletSearch, type, user, contentletAPI);
 					}
 
-					//Check if the new Publish Date Var is not null
-					if(UtilMethods.isSet(type.publishDateVar())){
-						//Sets the identifier SysPublishDate to the new Structure/Content Publish Date Var
-						identifier.setSysPublishDate((Date)contentlet.getMap().get(type.publishDateVar()));
-					}else{
-						identifier.setSysPublishDate(null);
-					}
-
-					//Check if the new Expire Date Var is not null
-					if(UtilMethods.isSet(type.expireDateVar())){
-						//Sets the identifier SysExpireDate to the new Structure/Content Expire Date Var
-						identifier.setSysExpireDate((Date)contentlet.getMap().get(type.expireDateVar()));
-					}else{
-						identifier.setSysExpireDate(null);
-					}
-
-					//Saves the update
-					APILocator.getIdentifierAPI().save(identifier);
-					//Clears Identifier Cache
-					CacheLocator.getIdentifierCache().removeFromCacheByIdentifier(contentletSearch.getIdentifier());
-					//Clears Contentlet Cache for each language and version
-					for(Language lan : APILocator.getLanguageAPI().getLanguages()) {
-						Optional<ContentletVersionInfo> versionInfo = APILocator.getVersionableAPI().getContentletVersionInfo(identifier.getId(), lan.getId()) ;
-						if(versionInfo.isPresent() && UtilMethods.isSet(versionInfo.get().getIdentifier())) {
-							CacheLocator.getContentletCache().remove(versionInfo.get().getWorkingInode());
-							if(UtilMethods.isSet(versionInfo.get().getLiveInode())) {
-								CacheLocator.getContentletCache().remove(versionInfo.get().getLiveInode());
-
-							}
-						}
-					}
+					//Commit batch transaction
+					HibernateUtil.closeAndCommitTransaction();
 				}
-				//Commit 500 (limit) transaction
-				HibernateUtil.closeAndCommitTransaction();
-
-				//Next 500
-				limit += limit;
-				offset += limit;
-				contenletSearchList = contentletAPI.searchIndex(luceneQuery, limit, offset, "random", user, false);
 			}
 
 			//Send Notification
@@ -165,7 +123,76 @@ public class IdentifierDateJob implements Job {
             }
 		}
 	}
-	
+
+	/**
+	 * Copies the content type's publish/expire date values from one contentlet onto its identifier,
+	 * then evicts the identifier and contentlet cache entries the change invalidates.
+	 *
+	 * @param contentletSearch the index hit to process
+	 * @param type             the content type whose date vars are being applied
+	 * @param user             the user the job runs as
+	 * @param contentletAPI    resolved once by the caller
+	 */
+	private void updateIdentifierDates(final ContentletSearch contentletSearch, final ContentType type,
+			final User user, final ContentletAPI contentletAPI)
+			throws DotDataException, DotSecurityException {
+
+		//Get the identifier of each contentlet
+		final Identifier identifier = APILocator.getIdentifierAPI().find(contentletSearch.getIdentifier());
+
+		//Gets contentlet info
+		final Contentlet contentlet = contentletAPI.find(contentletSearch.getInode(), user, false);
+
+		// A hit the database cannot resolve is skipped, not fatal. The index and the database drift
+		// for ordinary reasons (an interrupted delete, a stale shadow index during the ES→OS
+		// migration), and neither unresolved value is safe to carry into the body below: a null
+		// contentlet throws on getMap() and takes down the whole job, so every remaining contentlet
+		// of this type silently keeps a stale date; and an unresolved identifier comes back from
+		// find() as an EMPTY Identifier (IdentifierFactoryImpl.check404), which save() would persist
+		// as a brand-new row under a generated id, with null parent_path / asset_name / host_inode —
+		// rejected by identifier_parent_path_check, or corrupt data on any engine that lets it
+		// through. See issue #36501.
+		if (contentlet == null || !UtilMethods.isSet(identifier.getId())) {
+			Logger.warn(this, "Skipping index hit that does not resolve in the database"
+					+ " — identifier: " + contentletSearch.getIdentifier()
+					+ ", inode: " + contentletSearch.getInode()
+					+ ", content type: " + type.variable());
+			return;
+		}
+
+		//Check if the new Publish Date Var is not null
+		if (UtilMethods.isSet(type.publishDateVar())) {
+			//Sets the identifier SysPublishDate to the new Structure/Content Publish Date Var
+			identifier.setSysPublishDate((Date) contentlet.getMap().get(type.publishDateVar()));
+		} else {
+			identifier.setSysPublishDate(null);
+		}
+
+		//Check if the new Expire Date Var is not null
+		if (UtilMethods.isSet(type.expireDateVar())) {
+			//Sets the identifier SysExpireDate to the new Structure/Content Expire Date Var
+			identifier.setSysExpireDate((Date) contentlet.getMap().get(type.expireDateVar()));
+		} else {
+			identifier.setSysExpireDate(null);
+		}
+
+		//Saves the update
+		APILocator.getIdentifierAPI().save(identifier);
+		//Clears Identifier Cache
+		CacheLocator.getIdentifierCache().removeFromCacheByIdentifier(contentletSearch.getIdentifier());
+		//Clears Contentlet Cache for each language and version
+		for (final Language lan : APILocator.getLanguageAPI().getLanguages()) {
+			final Optional<ContentletVersionInfo> versionInfo =
+					APILocator.getVersionableAPI().getContentletVersionInfo(identifier.getId(), lan.getId());
+			if (versionInfo.isPresent() && UtilMethods.isSet(versionInfo.get().getIdentifier())) {
+				CacheLocator.getContentletCache().remove(versionInfo.get().getWorkingInode());
+				if (UtilMethods.isSet(versionInfo.get().getLiveInode())) {
+					CacheLocator.getContentletCache().remove(versionInfo.get().getLiveInode());
+				}
+			}
+		}
+	}
+
 	/**
 	 * Setup the job and trigger it immediately
 	 * 

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/IdentifierDateJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/IdentifierDateJob.java
@@ -79,6 +79,24 @@ public class IdentifierDateJob implements Job {
 					//Gets contentlet info
                     final Contentlet contentlet = contentletAPI.find(contentletSearch.getInode(), user, false);
 
+					// A hit the database cannot resolve is skipped, not fatal. The index and the
+					// database drift for ordinary reasons (an interrupted delete, a stale shadow
+					// index during the ES→OS migration), and neither unresolved value is safe to
+					// carry into the body below: a null contentlet throws on getMap() and takes
+					// down the whole job, so every remaining contentlet of this type silently keeps
+					// a stale date; and an unresolved identifier comes back from find() as an
+					// EMPTY Identifier (IdentifierFactoryImpl.check404), which save() would
+					// persist as a brand-new row under a generated id, with null parent_path /
+					// asset_name / host_inode — rejected by identifier_parent_path_check, or
+					// corrupt data on any engine that lets it through. See issue #36501.
+					if (contentlet == null || !UtilMethods.isSet(identifier.getId())) {
+						Logger.warn(this, "Skipping index hit that does not resolve in the database"
+								+ " — identifier: " + contentletSearch.getIdentifier()
+								+ ", inode: " + contentletSearch.getInode()
+								+ ", content type: " + type.variable());
+						continue;
+					}
+
 					//Check if the new Publish Date Var is not null
 					if(UtilMethods.isSet(type.publishDateVar())){
 						//Sets the identifier SysPublishDate to the new Structure/Content Publish Date Var

--- a/dotCMS/src/test/java/com/dotcms/content/index/opensearch/ContentFactoryIndexOperationsOSQueryTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/opensearch/ContentFactoryIndexOperationsOSQueryTest.java
@@ -1,0 +1,148 @@
+package com.dotcms.content.index.opensearch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.dotmarketing.util.Config;
+import java.io.StringWriter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+/**
+ * Unit tests for {@link ContentFactoryIndexOperationsOS#createQuery(String, String)} — the query
+ * the OpenSearch read path actually sends to the cluster.
+ *
+ * <p>Regression cover for issue #36501 (D12). With
+ * {@code ELASTICSEARCH_USE_FILTERS_FOR_SEARCHING=true} — the shipped default in
+ * {@code dotcms-config-cluster.properties} — and {@code sortBy="random"}, the OpenSearch port
+ * returned a bare {@code function_score} over {@code match_all} and dropped the Lucene query
+ * entirely, while its Elasticsearch counterpart kept the query as a {@code post_filter}. A
+ * random-sorted search therefore returned an unfiltered sample of the whole index: callers
+ * resolved arbitrary documents against the database, and {@code IdentifierDateJob} NPE'd on
+ * inodes that do not exist and attempted to INSERT phantom identifier rows.</p>
+ *
+ * <p>The invariant these tests pin is engine-independent and holds on every branch: <strong>the
+ * Lucene query must reach the cluster.</strong> Assertions run against the serialized JSON — the
+ * same wire form {@link OSQueryCache} keys on — so they survive refactors of the builder chain
+ * and would catch the query being dropped anywhere in it.</p>
+ *
+ * @author Fabrizzio Araya
+ */
+public class ContentFactoryIndexOperationsOSQueryTest {
+
+    /** Same key the production code resolves first; shadows the ES fallback. */
+    private static final String OS_FILTERS_KEY = "OS_USE_FILTERS_FOR_SEARCHING";
+
+    /** A query with a field that only the real caller's content type would match. */
+    private static final String LUCENE_QUERY =
+            "+structureName:myTestType +working:true +languageId:1";
+
+    private static final JacksonJsonpMapper MAPPER = new JacksonJsonpMapper();
+
+    private ContentFactoryIndexOperationsOS operations;
+    private String previousFlag;
+
+    @BeforeClass
+    public static void prepare() {
+        Config.initializeConfig();
+    }
+
+    @Before
+    public void setUp() {
+        previousFlag = Config.getStringProperty(OS_FILTERS_KEY, null);
+        // Neither collaborator is reachable from createQuery — it is a pure builder.
+        operations = new ContentFactoryIndexOperationsOS(null, null);
+    }
+
+    @After
+    public void tearDown() {
+        Config.setProperty(OS_FILTERS_KEY, previousFlag);
+    }
+
+    private static void useFiltersForSearching(final boolean enabled) {
+        Config.setProperty(OS_FILTERS_KEY, String.valueOf(enabled));
+    }
+
+    /** Serializes the query to the JSON the OpenSearch client would put on the wire. */
+    private static String json(final Query query) {
+        final StringWriter writer = new StringWriter();
+        try (final jakarta.json.stream.JsonGenerator generator =
+                MAPPER.jsonProvider().createGenerator(writer)) {
+            query.serialize(generator, MAPPER);
+        }
+        return writer.toString();
+    }
+
+    private String queryJson(final String sortBy) {
+        return json(operations.createQuery(LUCENE_QUERY, sortBy));
+    }
+
+    // ---- the regression: random sort must not discard the query ---------------------------------
+
+    @Test
+    public void randomSort_withFiltersEnabled_keepsTheLuceneQuery() {
+        useFiltersForSearching(true);
+
+        final String json = queryJson("random");
+
+        assertTrue("random sort must still carry the Lucene query, got: " + json,
+                json.contains(LUCENE_QUERY));
+    }
+
+    @Test
+    public void randomSort_withFiltersEnabled_doesNotDegenerateToMatchAll() {
+        useFiltersForSearching(true);
+
+        final String json = queryJson("random");
+
+        // The exact shape of the #36501 defect: function_score wrapping an unfiltered match_all.
+        assertFalse("random sort must not search the whole index, got: " + json,
+                json.contains("match_all"));
+    }
+
+    @Test
+    public void randomSort_withFiltersEnabled_stillScoresRandomly() {
+        useFiltersForSearching(true);
+
+        final String json = queryJson("random");
+
+        // Keeping the query must not cost the randomness the caller asked for.
+        assertTrue("random sort must keep its random_score function, got: " + json,
+                json.contains("random_score"));
+    }
+
+    // ---- every other branch already kept the query; lock that in --------------------------------
+
+    @Test
+    public void nonScoreSort_withFiltersEnabled_keepsTheLuceneQuery() {
+        useFiltersForSearching(true);
+
+        assertTrue(queryJson("moddate desc").contains(LUCENE_QUERY));
+    }
+
+    @Test
+    public void scoreSort_withFiltersEnabled_keepsTheLuceneQuery() {
+        useFiltersForSearching(true);
+
+        // "score" short-circuits the filter branch entirely.
+        assertTrue(queryJson("score").contains(LUCENE_QUERY));
+    }
+
+    @Test
+    public void randomSort_withFiltersDisabled_keepsTheLuceneQuery() {
+        useFiltersForSearching(false);
+
+        assertTrue(queryJson("random").contains(LUCENE_QUERY));
+    }
+
+    @Test
+    public void noSort_keepsTheLuceneQuery() {
+        useFiltersForSearching(true);
+
+        assertTrue(queryJson(null).contains(LUCENE_QUERY));
+    }
+}


### PR DESCRIPTION
Relates to #36501 (finding **D12**).

Not a `Closes` reference: #36501 is the umbrella for product findings from the phased ES→OS integration runs and stays open. This PR resolves D12 only.

## What

The OpenSearch read path **discarded the Lucene query** whenever the caller asked for random sorting, and searched the whole index instead.

`ContentFactoryIndexOperationsOS.createQuery` mirrors `ContentFactoryIndexOperationsES.createSearchSourceBuilder`, which swaps the main query for `match_all` and keeps the query as a `post_filter`:

```java
// ES — the query survives
if ("random".equals(sortBy)) {
    queryBuilder = QueryBuilders.functionScoreQuery(
            QueryBuilders.matchAllQuery(), new RandomScoreFunctionBuilder());
}
postFilter = QueryBuilders.queryStringQuery(query);
...
searchSourceBuilder.postFilter(postFilter);
```

The port kept the `match_all` but never applied a post-filter. The only mention of it in the whole OS class was a comment conceding the gap — *"this would need to be implemented differently in OpenSearch Java client"*. The request that actually went on the wire:

```json
{"function_score":{"functions":[{"random_score":{}}],"query":{"match_all":{}}}}
```

The branch is gated on `ELASTICSEARCH_USE_FILTERS_FOR_SEARCHING`, which is **`true` in the shipped config** (`dotCMS/src/main/resources/dotcms-config-cluster.properties:46`, and the integration-test config), and `OSIndexProperty.USE_FILTERS_FOR_SEARCHING` falls back to that same key — so the branch is always taken.

### Impact

Any random-sorted search returned arbitrary content in phases 2 and 3:

| Caller | Consequence |
|---|---|
| `ContentUtils.pull` → **VTL `$dotcontent.pull(query, limit, "random")`** | returns content the query never asked for |
| `ContentsWebAPI:724`, `LuceneHits:95` | same |
| `IdentifierDateJob:67,120` | job dies on unresolvable hits (see the caveat in *Test plan* — this is **not** the whole story for auto-unpublish) |

`IdentifierDateJob` is how the sweep surfaced it. It resolved the arbitrary documents against the database and hit two failure modes, both visible in CI:

```
java.lang.NullPointerException: Cannot invoke "…Contentlet.getMap()" because "contentlet" is null
    at com.dotmarketing.quartz.job.IdentifierDateJob.execute(IdentifierDateJob.java:93)

DotDataException: ERROR: Cannot INSERT folder <NULL> [6c79b602-…] in path <NULL> … in Site <NULL>
  Where: PL/pgSQL function identifier_parent_path_check() line 13 at RAISE
    at com.dotmarketing.quartz.job.IdentifierDateJob.execute(IdentifierDateJob.java:99)
```

This also explains the observation that stalled D12 in July — *"`structurename` appears nowhere in the OS run log"*. It never does: the query string is not sent to OpenSearch at all.

## Changes

**1. `ContentFactoryIndexOperationsOS.createQuery`** — the query is built once and survives every branch. The random branch wraps it inside the `function_score` instead of replacing it with `match_all`:

```java
final Query queryString = Query.of(q -> q.queryString(QueryStringQuery.of(qs -> qs.query(query))));
...
if ("random".equals(sortBy)) {
    return Query.of(q -> q.functionScore(FunctionScoreQuery.of(fsq -> fsq
            .query(queryString)
            .functions(fsf -> fsf.randomScore(RandomScoreFunction.of(rs -> rs))))));
}
```

Wrapping rather than porting `post_filter`: the hit set and its ordering are identical — `post_filter` is only distinguishable when aggregations are in play, and this request carries none — and filtering in query context is cheaper, since scoring only runs on matching documents. The rationale is in the javadoc so the next reader does not "restore" the match_all.

**2. `IdentifierDateJob` — skip index hits the database cannot resolve.** Defense in depth, independent of the engine: index/DB drift happens for ordinary reasons (an interrupted delete, a stale shadow index mid-migration), and neither unresolved value was safe to carry forward.

* A null contentlet threw on `getMap()` and **took down the whole job** — so every remaining contentlet of that content type silently kept a stale date.
* An unresolved identifier comes back from `find()` as an **empty** `Identifier` (`IdentifierFactoryImpl.check404`), which `save()` then persisted as a *brand-new row under a generated id* with null `parent_path`/`asset_name`/`host_inode` — rejected here by `identifier_parent_path_check`, and corrupt data on anything that lets it through.

Both are now skipped with a warning naming the identifier, inode and content type.

## Test plan

New unit test `ContentFactoryIndexOperationsOSQueryTest` (7 cases). It asserts against the **serialized JSON** — the same wire form `OSQueryCache` keys on — so it survives refactors of the builder chain and catches the query being dropped anywhere in it.

| Test | Pins |
|---|---|
| `randomSort_withFiltersEnabled_keepsTheLuceneQuery` | the defect: the query must reach the cluster |
| `randomSort_withFiltersEnabled_doesNotDegenerateToMatchAll` | its exact shape |
| `randomSort_withFiltersEnabled_stillScoresRandomly` | the fix does not cost the requested randomness |
| `nonScoreSort` / `scoreSort` / `filtersDisabled` / `noSort` | the four branches that were already correct |

Red/green verified by reverting the fix in place:

* **Red** — `Tests run: 7, Failures: 2`, the message printing the defective request verbatim.
* **Green** — `Tests run: 7, Failures: 0, Errors: 0`.

```
./mvnw test -pl :dotcms-core -Dtest=ContentFactoryIndexOperationsOSQueryTest -Dmaven.build.cache.enabled=false
```

(`-Dmaven.build.cache.enabled=false` matters: with the cache on, the build skips surefire and still reports BUILD SUCCESS.)

**Not covered by a new automated test:** the `IdentifierDateJob` changes. Exercising them at unit level means static-mocking `APILocator`, `CacheLocator` and `HibernateUtil` across a Quartz `execute()`, which buys little for a two-condition skip and a loop rewrite.

### Verified under real phases 2 and 3 — `PublisherTest` passes

`PublisherTest.autoUnpublishContent` now passes under both migration phases, verified locally with the job instrumented to log its query and hit count:

| Phase | Job's query | Hits | Result |
|---|---|---|---|
| 2 | `+structureName:testVarname… +working:true +languageId:1` | first attempt **0**, rerun **1** | `Tests run: 10, Failures: 0, Errors: 0, Flakes: 1` |
| 3 | same | first attempt **0**, rerun **1** | `Tests run: 10, Failures: 0, Errors: 0, Flakes: 1` |

The query reaches OpenSearch correctly formed and matches the content — which is the whole point of the `createQuery` fix.

**Getting a valid reproduction took two false starts, worth recording so nobody repeats them.** Earlier revisions of this description claimed first that the test would pass, then that a local run proved it does not. Both were wrong: in those runs `IdentifierDateJob.execute()` never executed at all. The integration-test environment does not start the Quartz scheduler — tests that need it call `QuartzUtils.startSchedulers()` in `@BeforeClass` (`QuartzUtilsTest`, `DotStatefulJobTest`, and others), and `PublisherTest` does not; it relies on another class in the same suite having started it earlier in the same JVM. **Running `-Dit.test=PublisherTest` on its own fails under every phase, including phase 0, for that reason alone.** A valid run pairs it with a scheduler-starting class:

```
./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false \
    -Dopensearch.phase=2 -Dit.test=QuartzUtilsTest,PublisherTest \
    -Dmaven.build.cache.enabled=false -Dit.test.forkcount=1
```

### Residual: a read-after-write visibility race, not addressed here

In both phases the **first** attempt returned 0 hits and the rerun returned 1 — consistent across 2/2 runs. The job is one-shot: if it runs before the freshly published contentlet is visible to search, it iterates nothing and never retries, and the test's 30-second `await` cannot help because the event it needed has already passed. Surefire counts this as a flake and the suite passes, but it is a real residual.

Both engines use the same default refresh policy in `setRefreshPolicy` (`NONE` / `False`), so this race is symmetric in the code; it simply lands more often on the OpenSearch path. It belongs to the OS write-visibility flake family already noted on #36501 and is **not** fixed by this PR.

### Recorded while investigating

Measured directly against live ES and OS indices: documents are indexed with **lowercase** keys, so `+structureName:x` returns 0 on *both* engines while `+structurename:x` returns 1 on both. Field-name casing is not an ES/OS divergence — `TranslatedQuery` lowercases the query unconditionally on both paths (`TranslatedQuery:210`).

---

## 3. `IdentifierDateJob` pagination — separate bug, engine-independent

Found while reading the job for the guard above. **This one is not migration-related and never worked**, on Elasticsearch either.

The job doubled the page size and then added the **new** size to the offset:

```java
limit  += limit;   // 500 -> 1000 -> 2000 -> 4000 ...
offset += limit;   // 0 -> 1000 -> 3000 -> 7000 ...
```

so it walked `[0,500) [1000,2000) [3000,5000) [7000,11000)…`, **skipping an ever-widening gap** between pages — roughly half the content of the type never got its dates updated.

It gets worse at scale. On the fifth pass the doubled limit reaches 16000, above `ContentletAPI.MAX_LIMIT` (10000), and `searchIndex` switches to its scroll branch — which **ignores the offset and returns the full result set**. That list is never empty, so:

> on a content type with more than ~15000 working contentlets in the default language, the loop never terminates. It reprocesses every contentlet on every pass, writing identifier rows and flushing caches until the Quartz worker is killed.

Sorting the pages randomly compounded it: successive pages of an offset-paginated random sort have no relation to one another, so documents were skipped and revisited arbitrarily even where the offset arithmetic happened to line up.

**Fix:** replaced the hand-rolled pagination with `ContentletAPI.createScrollQuery` — which is exactly what `IndexContentletScroll` exists for. One consistent snapshot for the whole walk, every matching contentlet visited exactly once, no result-window ceiling. Batch size (500) and the per-batch transaction are unchanged. The per-contentlet body moved to `updateIdentifierDates` so `execute()` stays readable.

### Reviewer note on scope

Changes 2 and 3 touch `IdentifierDateJob` and are **engine-independent** — they are bugs on Elasticsearch too, and are worth having regardless of the migration. Change 1 is the OpenSearch read path. They ship together because they were found together and 2/3 sit in the same method; say the word if you would rather review them apart.

This PR fixes: #36501

This PR fixes: #36501