### PR TITLE
fix(startup): replace count(*) inode probes with existence checks (#36865)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/db/DotCMSInitDb.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DotCMSInitDb.java
@@ -36,12 +36,32 @@ public class DotCMSInitDb {
     static final String ADMIN_DEFAULT_MAIL = "admin@dotcms.com";
     static final String DEFAULT_STARTER_PATH = "/WEB-INF/classes/starter.zip";
 
+    /**
+     * Existence probe for the {@code inode} table, shared by the run-always startup tasks that gate
+     * schema load and starter import.
+     * <p>
+     * These call sites only ever need to know <i>whether</i> a row exists, never how many, so this
+     * deliberately avoids {@code count(*)} -- which forces a full scan of {@code inode}.
+     * PostgreSQL plans the {@code EXISTS} sub-query as an {@code InitPlan} over a {@code Limit},
+     * so it stops at the first row.
+     * <p>
+     * The {@code CASE} wrapper is load-bearing: it guarantees exactly one row with a single integer
+     * column named {@code test}, so {@link DotConnect#getInt(String)} still resolves against an
+     * empty table.
+     * <p>
+     * {@link com.dotmarketing.startup.runalways.Task00001LoadSchema#forceRun()} further relies on
+     * this statement failing with a {@code SQLException} when {@code inode} does not exist at all;
+     * any replacement must preserve that signal.
+     */
+    public static final String INODE_EXISTS_SQL =
+            "select case when exists (select 1 from inode) then 1 else 0 end as test";
+
 
     @CloseDBIfOpened
 	private static boolean isConfigured () {
 
 		return new DotConnect()
-                .setSQL("select count(*) as test from inode")
+                .setSQL(INODE_EXISTS_SQL)
                 .getInt("test")>0;
 
 	}

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00001LoadSchema.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00001LoadSchema.java
@@ -5,17 +5,16 @@ import com.dotcms.enterprise.license.LicenseManager;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.common.util.SQLUtil;
 import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.db.DotCMSInitDb;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.startup.StartupTask;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.MaintenanceUtil;
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -101,8 +100,10 @@ public class Task00001LoadSchema implements StartupTask {
 		// independently closed and returned to the pool without affecting the outer scope.
 		try (Connection conn = DbConnectionFactory.getDataSource().getConnection();
 			 Statement stmt = conn.createStatement();
-			 ResultSet rs = stmt.executeQuery("select count(*) as test from inode")) {
-			rs.next();
+			 var _ = stmt.executeQuery(DotCMSInitDb.INODE_EXISTS_SQL)) {
+			// The row's value is irrelevant here -- reaching this point means `inode` resolved,
+			// so the schema is already loaded. Only a SQLException, raised when the table does
+			// not exist, signals an empty database.
 			return false;
 		} catch (SQLException e1) {
 			Logger.info(this.getClass(),"-------------------------------------------------------------------------------------");

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00004LoadStarter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00004LoadStarter.java
@@ -16,13 +16,13 @@ public class Task00004LoadStarter implements StartupTask {
 		DotCMSInitDb.InitializeDb();
 	}
 
+	@Override
 	public boolean forceRun() {
 
-		DotConnect db = new DotConnect();
-		db.setSQL("select count(*) as test from inode");
+		final DotConnect db = new DotConnect();
+		db.setSQL(DotCMSInitDb.INODE_EXISTS_SQL);
 
-		int test = db.getInt("test");
-		return (test < 1);
+		return db.getInt("test") < 1;
 	}
 
 }

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -30,6 +30,7 @@ import com.dotcms.telemetry.collectors.theme.TotalSizeOfFilesPerThemeMetricTypeT
 import com.dotcms.util.TimeMachineUtilTest;
 import com.dotmarketing.business.DeterministicIdentifierAPITest;
 import com.dotmarketing.business.SecondaryCategoryPermissionTest;
+import com.dotmarketing.db.InodeExistenceCheckIntegrationTest;
 import com.dotmarketing.factories.TreeFactoryTest;
 import com.dotmarketing.fixtask.tasks.FixTask00090RecreateMissingFoldersInParentPathTest;
 import com.dotmarketing.portlets.contentlet.action.ImportContentletsActionSmokeTest;
@@ -100,6 +101,7 @@ import org.junit.runners.Suite;
         PublisherQueueJobTest.class,
         ContentToStringUtilTest.class,
         CacheResourceIntegrationTest.class,
+        InodeExistenceCheckIntegrationTest.class,
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotmarketing/db/InodeExistenceCheckIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/db/InodeExistenceCheckIntegrationTest.java
@@ -1,0 +1,175 @@
+package com.dotmarketing.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.startup.runalways.Task00001LoadSchema;
+import com.dotmarketing.startup.runalways.Task00004LoadStarter;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Guards the contract of {@link DotCMSInitDb#INODE_EXISTS_SQL}, the existence probe that replaced
+ * {@code select count(*) as test from inode} in the three run-always startup checks.
+ * <p>
+ * The probe is only a safe substitute for {@code count(*)} if it holds three properties at once,
+ * and the two that guard first-boot cannot be exercised against the real {@code inode} table
+ * because the integration database is always populated. They are covered here with a scratch table
+ * and a deliberately absent one:
+ * <ul>
+ *     <li>populated table -&gt; exactly one row, value {@code 1};</li>
+ *     <li>empty table -&gt; exactly one row, value {@code 0}, resolvable through
+ *     {@link DotConnect#getInt(String)} <b>without throwing</b> (a bare
+ *     {@code select 1 ... limit 1} would return zero rows here and blow up
+ *     {@code Task00004LoadStarter.forceRun()} / {@code DotCMSInitDb.isConfigured()} on a fresh
+ *     database);</li>
+ *     <li>missing table -&gt; {@link SQLException}, which is the signal
+ *     {@link Task00001LoadSchema#forceRun()} uses to decide the schema must be loaded.</li>
+ * </ul>
+ *
+ * @author dotCMS
+ */
+public class InodeExistenceCheckIntegrationTest {
+
+
+    private static final String INODE_TABLE = "inode";
+    private static final String EMPTY_TABLE = "dotcms_36865_empty_probe";
+    private static final String MISSING_TABLE = "dotcms_36865_absent_probe";
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Builds the production probe for an arbitrary table. The table names fed to this method are
+     * all {@code private static final} constants declared above -- no external input reaches it.
+     *
+     * @param table The table to probe.
+     *
+     * @return The existence-probe SQL statement for the given table.
+     */
+    private static String existsSqlFor(final String table) {
+        return "select case when exists (select 1 from " + table + ") then 1 else 0 end as test";
+    }
+
+    /**
+     * Runs a statement on a connection borrowed straight from the pool, so DDL never rides on the
+     * ThreadLocal connection the surrounding test may already have a transaction open on.
+     *
+     * @param sql The statement to execute.
+     */
+    private static void executeOnPooledConnection(final String sql) throws SQLException {
+        try (Connection conn = DbConnectionFactory.getDataSource().getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
+        }
+    }
+
+    /**
+     * Method to test: {@link DotCMSInitDb#INODE_EXISTS_SQL}
+     * Given Scenario: The constant is compared against the shape this test parameterises for its
+     * scratch tables.
+     * Expected Result: They are identical, so every other assertion here is genuinely exercising
+     * the statement that ships.
+     */
+    @Test
+    public void test_probeSqlShape_matchesProductionConstant() {
+        assertEquals("The test builds a different query shape than the one used in production; "
+                        + "update existsSqlFor() to match DotCMSInitDb.INODE_EXISTS_SQL.",
+                DotCMSInitDb.INODE_EXISTS_SQL, existsSqlFor(INODE_TABLE));
+    }
+
+    /**
+     * Method to test: {@link DotCMSInitDb#INODE_EXISTS_SQL}
+     * Given Scenario: The probe runs against the populated {@code inode} table of a started-up
+     * dotCMS.
+     * Expected Result: {@link DotConnect#getInt(String)} returns 1, keeping the {@code > 0} and
+     * {@code < 1} comparisons at the call sites behaving exactly as they did with {@code count(*)}.
+     */
+    @Test
+    public void test_probe_returnsOne_whenTableHasRows() {
+        final DotConnect db = new DotConnect();
+        db.setSQL(DotCMSInitDb.INODE_EXISTS_SQL);
+
+        assertEquals(1, db.getInt("test"));
+    }
+
+    /**
+     * Method to test: {@link DotCMSInitDb#INODE_EXISTS_SQL}
+     * Given Scenario: The probe runs against an existing but completely empty table -- the shape of
+     * a database whose schema has been loaded but whose starter has not been imported yet.
+     * Expected Result: Exactly one row is returned and {@link DotConnect#getInt(String)} yields 0
+     * without throwing. This is the regression guard for first-boot: a zero-row query would make
+     * {@code getInt} throw {@code DotRuntimeException} instead.
+     */
+    @Test
+    public void test_probe_returnsZeroAndDoesNotThrow_whenTableIsEmpty() throws Exception {
+        executeOnPooledConnection("create table if not exists " + EMPTY_TABLE + " (id int)");
+        try {
+            final DotConnect db = new DotConnect();
+            db.setSQL(existsSqlFor(EMPTY_TABLE));
+
+            assertEquals("The probe must always return exactly one row, even against an empty "
+                    + "table, or DotConnect.getInt() throws on a fresh database.",
+                    1, db.loadObjectResults().size());
+            assertEquals(0, db.getInt("test"));
+        } finally {
+            executeOnPooledConnection("drop table if exists " + EMPTY_TABLE);
+        }
+    }
+
+    /**
+     * Method to test: {@link DotCMSInitDb#INODE_EXISTS_SQL}
+     * Given Scenario: The probe runs against a table that does not exist at all -- the shape of a
+     * brand new, unschema'd database.
+     * Expected Result: A {@link SQLException} is raised. {@link Task00001LoadSchema#forceRun()}
+     * treats that exception, not a row value, as the signal to load the schema, so the probe must
+     * keep failing this way.
+     */
+    @Test
+    public void test_probe_throwsSqlException_whenTableIsMissing() throws Exception {
+        try (Connection conn = DbConnectionFactory.getDataSource().getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(existsSqlFor(MISSING_TABLE))) {
+            fail("Expected a SQLException probing the missing table '" + MISSING_TABLE
+                    + "' -- Task00001LoadSchema.forceRun() depends on that exception.");
+        } catch (final SQLException expected) {
+            // Expected: this is the "empty dotCMS database" signal.
+        }
+    }
+
+    /**
+     * Method to test: {@link Task00001LoadSchema#forceRun()}
+     * Given Scenario: A populated database whose schema is already loaded.
+     * Expected Result: false -- the schema must not be re-created.
+     */
+    @Test
+    public void test_task00001ForceRun_isFalse_onPopulatedDatabase() {
+        assertFalse("Task00001LoadSchema would re-run the schema load against a populated database.",
+                new Task00001LoadSchema().forceRun());
+    }
+
+    /**
+     * Method to test: {@link Task00004LoadStarter#forceRun()}
+     * Given Scenario: A populated database that already has inodes.
+     * Expected Result: false -- the starter import must not run again.
+     */
+    @Test
+    public void test_task00004ForceRun_isFalse_onPopulatedDatabase() {
+        assertFalse("Task00004LoadStarter would re-import the starter against a populated database.",
+                new Task00004LoadStarter().forceRun());
+    }
+
+}


### PR DESCRIPTION
### Proposed Changes

* **`DotCMSInitDb`** — adds `INODE_EXISTS_SQL`, a single shared existence probe (`select case when exists (select 1 from inode) then 1 else 0 end as test`), and uses it in `isConfigured()`.
* **`Task00001LoadSchema.forceRun()`** — probes with `INODE_EXISTS_SQL` instead of `count(*)`. Keeps the dedicated pool borrow and the "exception is the signal" contract exactly; drops the now-redundant `rs.next()` whose return was already discarded.
* **`Task00004LoadStarter.forceRun()`** — same probe; `< 1` semantics unchanged, so an empty-but-existing `inode` still triggers the starter import. Also adds the missing `@Override`.
* **`InodeExistenceCheckIntegrationTest`** (new) — covers the populated, empty and missing-table paths; registered in `MainSuite3a` alongside the other startup-task tests.

### Why

All three call sites needed only **existence**, never cardinality, then discarded the count. On PostgreSQL `count(*)` on `inode` is a full scan — measured at **~148ms** on the production table during the #36544 incident. `StartupTasksExecutor.executeStartUpTasks()` re-invokes `forceRun()` on every run-always task with no already-ran guard, and `MainServlet.init()` throws `DotRuntimeException` on failure so Tomcat re-inits on the next request — so each retry re-paid the cost twice. In that incident: **3,571 executions in one 600s window, 528s total ≈ 88% of the startup window.**

This removes the *cost* of the retry storm, not the storm itself — #36801 / #36802 / #36803 still own the crash-loop and the missing already-ran guard.

### Why `case when exists` and not `select 1 … limit 1`

The AC suggested `select 1 from inode limit 1`. Two of the three sites read the result via `DotConnect.getInt("test")`, which indexes into the result list — a query returning **zero rows** on an empty `inode` table makes it throw `DotRuntimeException` instead of returning `0`, breaking the exact first-boot path the AC flags as the risk surface. `select exists (…)` alone fails differently: PostgreSQL returns a boolean, `DotConnect.fromResultSet` stores it via `rs.getString()` as `"t"`/`"f"`, and `Integer.parseInt("t")` throws.

The `CASE` form always yields exactly one row with one integer column, so **no Java changes were needed at any call site** and failure semantics are byte-for-byte unchanged. Same plan cost — PostgreSQL plans `EXISTS` in a scalar context as an `InitPlan` over a `Limit`, stopping at the first row.

### Checklist
- [x] Tests — new `InodeExistenceCheckIntegrationTest` (6 cases). Full `MainSuite3a` green locally: **670 run, 0 failures, 0 errors, 8 skipped**.
- [ ] Translations — n/a
- [x] Security Implications Contemplated — no auth/authz/crypto surface. The new constant is a fixed literal with no interpolation; the test builds scratch-table SQL by concatenation from `private static final` constants only, no external input.

### Additional Info

**Still needs verification in a real environment** (AC 5–7) — the new test covers query semantics, not a full bootstrap:
- Timing on a large `inode` table via `pg_stat_statements` / `EXPLAIN ANALYZE`.
- A **fresh empty database** boots end to end — both "no `inode` table at all" and "`inode` present but empty".
- An existing **populated** database starts normally and does not re-run the starter import.

⚠️ **Measurement note:** the issue's baseline filter `WHERE query ILIKE '%as test from inode%'` no longer matches after this change (the new statement ends `… end as test`). Use `ILIKE '%exists (select 1 from inode)%'` for the after-reading, or zero rows will read as "the calls disappeared" rather than "they got faster".

**Deliberately out of scope:** `InodeFactory.countChildrenOfClass` also uses `count(*) as test from inode` but genuinely returns the count. `LocalTransactionAndCloseDBIfOpenedFactoryTest` / `DbConnectionFactoryTest` keep their `SQL_COUNT` — they exercise transaction semantics, not startup.

Refs: #36865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36865

This PR fixes: #36865