### PR TITLE
fix(cost): charge NAV_BUILD past the nav-cache short-circuit

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/business/interceptor/RequestCostHandler.java
+++ b/dotCMS/src/main/java/com/dotcms/business/interceptor/RequestCostHandler.java
@@ -10,6 +10,12 @@ import java.lang.reflect.Method;
 /**
  * Shared handler for {@code @RequestCost} logic. Used by both the ByteBuddy advice and the
  * CDI interceptor to keep the implementation DRY.
+ * <p>
+ * Charge sites placed past a cache short-circuit (so a cache hit stays free) follow a shared
+ * idiom by convention, not by a common helper: call {@link #incrementCost(Price, Class, String,
+ * Object[])} right after the short-circuit check, with a comment naming the sibling sites. See
+ * {@code NavTool.getNav}, {@code DotDirective.render}, and {@code VelocityLiveMode.writePage}.
+ * If a fourth site shows up, promote this to a real helper instead of copy-pasting the comment.
  */
 public final class RequestCostHandler {
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/navigation/NavTool.java
@@ -1,7 +1,7 @@
 package com.dotcms.rendering.velocity.viewtools.navigation;
 
 
-import com.dotcms.cost.RequestCost;
+import com.dotcms.business.interceptor.RequestCostHandler;
 import com.dotcms.cost.RequestPrices.Price;
 import com.dotcms.rest.api.v1.browsertree.BrowserTreeHelper;
 import com.dotmarketing.beans.Host;
@@ -88,7 +88,6 @@ public class NavTool implements ViewTool {
         children.add(nav);
     }
 
-    @RequestCost(Price.NAV_BUILD)
     protected NavResultHydrated getNav(final Host host, String path, final long languageId, final User systemUserParam)
             throws DotDataException, DotSecurityException {
 
@@ -118,6 +117,15 @@ public class NavTool implements ViewTool {
                 return new NavResultHydrated(result, this.context);
             }
         }
+
+        // Charged here, past the nav-cache short-circuit above, so a cached nav stays cheap -
+        // same placement as DotDirective.render and VelocityLiveMode.writePage. Only the actual
+        // build pays: the folder/menu-item walk below (findMenuItems, findSubFolders,
+        // IdentifierAPI.find) is not metered anywhere else, which is what this flat fee covers.
+        // Content-backed menu items still stack their own CONTENT_FROM_CACHE/CONTENT_FROM_DB
+        // charges through the content factory - that stacking is intended.
+        RequestCostHandler.incrementCost(Price.NAV_BUILD, NavTool.class, "getNav",
+                new Object[]{path, languageId});
 
         String parentId;
         if (!folder.getInode()


### PR DESCRIPTION
### Proposed Changes

Follow-up to #36978, addressing a review finding that landed after merge: `@RequestCost(Price.NAV_BUILD)` on `NavTool.getNav` fired on method entry, so a live-mode navigation served entirely from `NavToolCache` still paid the full NAV_BUILD(10) — the common case on live traffic.

This moves the charge to a direct `RequestCostHandler.incrementCost` call on the cache-miss/build path, matching the cache-aware placement deliberately used in `DotDirective.render` and `VelocityLiveMode.writePage`:

* **Warm nav (live-mode cache hit): costs 0** — caching visibly pays off, consistent with cached containers/pages.
* **Cache miss / edit / preview: flat NAV_BUILD(10)** — covers the folder/menu-item walk (`findMenuItems`, `findSubFolders`, `IdentifierAPI.find`), which is not metered anywhere else.
* Content-backed menu items still stack their own `CONTENT_FROM_CACHE`/`CONTENT_FROM_DB` charges through the content factory — that stacking is intended and documented in the code comment.

Related to #36977.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTt9ymEwfmHV9DSKe1vPuJ

This PR fixes: #36977

This PR fixes: #36977