### PR TITLE
fix(sdk-angular): stop padding block editor text runs with whitespace (#37001)

### DIFF
--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.html
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.html
@@ -348,7 +348,7 @@
                 <ng-container
                     *ngTemplateOutlet="textRun; context: { marks: restMarks(marks), text: text }" />
             } @else {
-                {{ text }}
+                <ng-container>{{ text }}</ng-container>
             }
         }
     }

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
@@ -281,6 +281,137 @@ describe('DotCMSBlockEditorRendererNativeComponent — semantic dispatch', () =>
         });
     });
 
+    describe('Text — whitespace fidelity', () => {
+        // A text run must render byte-for-byte what the stored block says. Padding a
+        // run with stray whitespace stretches the mark's box past its text — an <a>
+        // underline and hit area bleeding into the neighbouring characters — and adds
+        // a visible gap wherever the neighbour is punctuation rather than a space.
+        it('should not pad a plain text run with whitespace', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.PARAGRAPH,
+                    content: [{ type: BlockEditorDefaultBlocks.TEXT, text: 'Hello', marks: [] }]
+                }
+            ]);
+
+            expect(spectator.query('p')?.textContent).toBe('Hello');
+        });
+
+        it('should not pad the text inside a link mark', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.PARAGRAPH,
+                    content: [
+                        {
+                            type: BlockEditorDefaultBlocks.TEXT,
+                            text: 'mylink',
+                            marks: [{ type: 'link', attrs: { href: '/foo' } }]
+                        }
+                    ]
+                }
+            ]);
+
+            expect(spectator.query('a')?.textContent).toBe('mylink');
+        });
+
+        it('should not pad the text inside a bold mark', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.PARAGRAPH,
+                    content: [
+                        {
+                            type: BlockEditorDefaultBlocks.TEXT,
+                            text: 'Bold',
+                            marks: [{ type: 'bold', attrs: {} }]
+                        }
+                    ]
+                }
+            ]);
+
+            expect(spectator.query('strong')?.textContent).toBe('Bold');
+        });
+
+        it('should not pad the text inside stacked marks', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.PARAGRAPH,
+                    content: [
+                        {
+                            type: BlockEditorDefaultBlocks.TEXT,
+                            text: 'Few',
+                            marks: [
+                                { type: 'underline', attrs: {} },
+                                { type: 'bold', attrs: {} }
+                            ]
+                        }
+                    ]
+                }
+            ]);
+
+            expect(spectator.query('u strong')?.textContent).toBe('Few');
+        });
+
+        it('should keep a link flush against the punctuation around it', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.PARAGRAPH,
+                    content: [
+                        { type: BlockEditorDefaultBlocks.TEXT, text: 'See (', marks: [] },
+                        {
+                            type: BlockEditorDefaultBlocks.TEXT,
+                            text: 'mylink',
+                            marks: [{ type: 'link', attrs: { href: '/foo' } }]
+                        },
+                        { type: BlockEditorDefaultBlocks.TEXT, text: ').', marks: [] }
+                    ]
+                }
+            ]);
+
+            expect(spectator.query('p')?.textContent).toBe('See (mylink).');
+        });
+
+        it('should keep adjacent marked runs flush against each other', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.PARAGRAPH,
+                    content: [
+                        {
+                            type: BlockEditorDefaultBlocks.TEXT,
+                            text: 'bold',
+                            marks: [{ type: 'bold', attrs: {} }]
+                        },
+                        {
+                            type: BlockEditorDefaultBlocks.TEXT,
+                            text: 'italic',
+                            marks: [{ type: 'italic', attrs: {} }]
+                        }
+                    ]
+                }
+            ]);
+
+            expect(spectator.query('p')?.textContent).toBe('bolditalic');
+        });
+
+        it('should preserve the author’s own spacing around a link exactly once', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.PARAGRAPH,
+                    content: [
+                        { type: BlockEditorDefaultBlocks.TEXT, text: 'Go to ', marks: [] },
+                        {
+                            type: BlockEditorDefaultBlocks.TEXT,
+                            text: 'mylink',
+                            marks: [{ type: 'link', attrs: { href: '/foo' } }]
+                        },
+                        { type: BlockEditorDefaultBlocks.TEXT, text: ' now.', marks: [] }
+                    ]
+                }
+            ]);
+
+            expect(spectator.query('p')?.textContent).toBe('Go to mylink now.');
+        });
+    });
+
     describe('Headings', () => {
         it('should render a real <h2> for level "2"', () => {
             render([


### PR DESCRIPTION
### Parent Issue

Fixes #37001

### Problem

The native Block Editor renderer in `@dotcms/angular` rendered **every** text run padded with one leading and one trailing space. Because the padding lands *inside* the mark element, a link came out as `<a href="/foo"> mylink </a>`, so the underline, hover highlight and click target all overshot the link text by a space on each side.

Where the neighbouring run starts with punctuation, the extra space is also visible text corruption, since HTML whitespace collapsing only merges *consecutive* spaces:

| Stored content | Before | After |
|---|---|---|
| `See (` + link `mylink` + `).` | `See ( mylink ).` | `See (mylink).` |
| bold `bold` + italic `italic` | `bold italic` | `bolditalic` |
| plain text `Hello` | `" Hello "` | `"Hello"` |

Verified React and Vue for the same block: both already render byte-exact clean output, so this is Angular-only. The deprecated `DotCMSBlockEditorRendererComponent` is deliberately untouched.

### Root cause

In the recursive `#textRun` template, the terminal branch emitted the interpolation on its own indented line:

```html
} @else {
    {{ text }}
}
```

Angular's default whitespace handling only *deletes* whitespace-only text nodes. This node is not whitespace-only (it holds an interpolation), so its surrounding newline and indentation are instead collapsed into a single space at the front and back. Every text run therefore rendered as `" text "`, across all inline marks (`a`, `strong`, `em`, `u`, `s`, `sup`, `sub`) and plain text.

Not a data problem: the editor configures the link extension with `autolink: false` and only uses `extendMarkRange('link')`, so the stored block JSON carries no stray whitespace.

### Fix

Wrap the interpolation in a single-line `ng-container`, which keeps the template's whitespace outside the text node:

```html
<ng-container>{{ text }}</ng-container>
```

**Why not `@else {{{ text }}}` plus `prettier-ignore`?** Tested it: prettier reformats the flush form straight back into the multi-line padded version, i.e. back into the bug. That variant only holds behind a `prettier-ignore` comment that is load-bearing for correctness, which any routine `nx format:write` or pre-commit hook would otherwise defeat. The `ng-container` form survives `nx format:write` untouched, verified.

**DOM cost:** none in element terms. `querySelector('ng-container')` returns `null`; the only addition is one HTML comment marker per text run, alongside the many `<!--container-->` markers Angular already emits for this template's outlets. Comment nodes are invisible to rendering, to CSS selectors (`:first-child`, `+`, `~` count element children only), to `textContent`, and to assistive technology, so the renderer's "no wrapper element" guarantee is preserved.

**No code comment guards this.** The invariant is "keep the interpolation flush and on one line", and the tests enforce it: reintroducing the whitespace fails all seven with an explicit expected-vs-received diff that names the symptom. The commit message is the blame record for the reasoning, so the template stays a one-line change with nothing to drift out of date.

### Tests

Added `describe('Text — whitespace fidelity')` to `dotcms-block-editor-renderer-native.dispatch.spec.ts`, 7 tests written **before** the fix and confirmed failing against the real defect:

```
✕ should not pad the text inside a link mark
    Expected: "mylink"        Received: " mylink "
✕ should keep a link flush against the punctuation around it
    Expected: "See (mylink)." Received: " See ( mylink ). "
✕ should keep adjacent marked runs flush against each other
    Expected: "bolditalic"    Received: " bold italic "
```

The existing text assertions used `toContain(...)` and `.textContent?.trim()`, which is precisely what hid this defect, so the new tests assert **exact** `textContent` equality.

### Verification

- `pnpm nx test sdk-angular` : 21 suites, 234 tests passing
- `pnpm nx lint sdk-angular` : clean
- `pnpm nx format:write` : fix intact, no reformat

https://github.com/user-attachments/assets/247785ba-06cd-4dc7-b473-4df04ecd6e8b

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37001