### PR TITLE
docs(clustering): correct the stale server-heartbeat interval comment

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/init/DotInitScheduler.java
+++ b/dotCMS/src/main/java/com/dotmarketing/init/DotInitScheduler.java
@@ -581,8 +581,11 @@ private static void addDeleteOldSiteSearchIndicesJob (final Scheduler scheduler)
    private static void addServerHeartbeatJob () {
 
        final int initialDelay = Config.getIntProperty("SERVER_HEARTBEAT_INITIAL_DELAY_SECONDS", 60);
-       final int delaySeconds = Config.getIntProperty("SERVER_HEARTBEAT_RUN_EVERY_SECONDS", 60); // runs every 5 seconds.
-       
+       // Both default to one minute, matching the HEARTBEAT_CRON_EXPRESSION (0 0/1 * * * ?) this
+       // replaced when the schedulers were unified. The cadence bounds how quickly a node notices
+       // a cluster membership change or retries a failed cache-transport rewire.
+       final int delaySeconds = Config.getIntProperty("SERVER_HEARTBEAT_RUN_EVERY_SECONDS", 60);
+
        DotConcurrentFactory.getScheduledThreadPoolExecutor().scheduleAtFixedRate(() -> {
            Try.run(() -> new ServerHeartbeatJob().execute(null)).onFailure(e->Logger.warnAndDebug(DotInitScheduler.class, e));
        }, initialDelay, delaySeconds, TimeUnit.SECONDS);


### PR DESCRIPTION
### Proposed Changes

Fixes #37015.

`SERVER_HEARTBEAT_RUN_EVERY_SECONDS` defaults to **60**, but the trailing comment read `// runs every 5 seconds.`

```diff
-       final int delaySeconds = Config.getIntProperty("SERVER_HEARTBEAT_RUN_EVERY_SECONDS", 60); // runs every 5 seconds.
+       // Both default to one minute, matching the HEARTBEAT_CRON_EXPRESSION (0 0/1 * * * ?) this
+       // replaced when the schedulers were unified. The cadence bounds how quickly a node notices
+       // a cluster membership change or retries a failed cache-transport rewire.
+       final int delaySeconds = Config.getIntProperty("SERVER_HEARTBEAT_RUN_EVERY_SECONDS", 60);
```

### Why it was wrong

Not a default that changed and left the comment behind — the comment was **wrong when it was written**.

`999036092e` (#19291, *unifying the 3 quartz schedulers*, Oct 2020) created this block by adapting the `SystemEventsJob` block ~150 lines above:

```java
final int delaySeconds = Config.getIntProperty("SYSTEM_EVENTS_DELAY_SECONDS", 5); // runs every 5 seconds.
```

That one is correct — it really does default to 5. The heartbeat copy changed the property name and the default to 60 and kept the comment verbatim.

The cadence never changed either. Before that commit the heartbeat was a Quartz `CronTrigger` on `HEARTBEAT_CRON_EXPRESSION`, defaulted to `0 0/1 * * * ?` in `dotcms-config-cluster.properties` — once a minute. The 60-second fixed delay preserved it; only the mechanism changed.

### Testing

Comment only, no behaviour change — nothing to test. Found while tracing the heartbeat cadence for #36803, where this interval bounds how quickly a failed cache-transport rewire is retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
