### PR TITLE
fix(autodoc): trailing newline + random delimiter in eval context output

### DIFF
--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -287,12 +287,3 @@ jobs:
               --data @/tmp/payload.json
           fi
 
-          # Commit the report back to dotcms-aios.
-          # Push only runs if commit succeeds (i.e. there were actual changes to commit).
-          cd dotcms-aios
-          git config user.name "autodoc[bot]"
-          git config user.email "autodoc-bot@users.noreply.github.com"
-          git add "autodoc/reports/Epic-${EPIC_NUMBER}_burlap.md"
-          if git commit -m "eval: Epic-${EPIC_NUMBER} (burlap)"; then
-            git push origin HEAD
-          fi

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -71,6 +71,7 @@ jobs:
       REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Used by the Claude subprocess when it executes the curl in burlap.txt — not called directly here.
       AUTODOC_DOTCMS_API_TOKEN_AISEARCH: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_AISEARCH }}
       AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
       AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
@@ -200,23 +201,27 @@ jobs:
             exit 0
           fi
 
-          # Post report as issue comment (edit existing autodoc comment if one exists)
-          EXISTING=$(gh api "repos/$REPO/issues/$EPIC_NUMBER/comments" \
-            --jq '.[] | select(.body | contains("<!-- autodoc-report -->")) | .id' \
-            | head -1)
+          # Prepend idempotency marker so subsequent runs can find and edit this comment.
+          { echo '<!-- autodoc-report -->'; cat "$REPORT"; } > /tmp/comment_body.md
+
+          # Edit the existing autodoc comment if one exists, otherwise create a new one.
+          # --paginate ensures we search all comments, not just the first page.
+          EXISTING=$(gh api "repos/$REPO/issues/$EPIC_NUMBER/comments" --paginate \
+            --jq '[.[] | select(.body | contains("<!-- autodoc-report -->")) | .id] | first // empty')
           if [ -n "$EXISTING" ]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING" \
-              -f "body=@$REPORT"
+              -F "body=@/tmp/comment_body.md"
           else
-            gh issue comment "$EPIC_NUMBER" --repo "$REPO" --body-file "$REPORT"
+            gh issue comment "$EPIC_NUMBER" --repo "$REPO" --body-file /tmp/comment_body.md
           fi
 
-          # Parse action and urlTitle from the machine-readable meta block
+          # Parse action and urlTitle from the machine-readable meta block.
+          # All fields use sub() to preserve the full value after the key prefix.
           ACTION=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^action:/{print $2; exit}' "$REPORT")
-          URL_TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^urlTitle:/{print $2; exit}' "$REPORT")
+          URL_TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^urlTitle:/{sub(/^urlTitle:[[:space:]]*/,"");print;exit}' "$REPORT")
 
           if [ "$ACTION" = "update" ] && [ -n "$URL_TITLE" ]; then
-            IDENTIFIER=$(curl -sk -X POST "$AUTODOC_DOTCMS_BASE_URL/api/es/search" \
+            IDENTIFIER=$(curl -s --fail-with-body -X POST "$AUTODOC_DOTCMS_BASE_URL/api/es/search" \
               -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
               -H "Content-Type: application/json" \
               -d "{\"query\":{\"query_string\":{\"query\":\"+contentType:DotcmsDocumentation +DotcmsDocumentation.urlTitle:\\\"$URL_TITLE\\\"\"}},\"size\":1}" \
@@ -235,7 +240,7 @@ jobs:
               'disabledWYSIWYG': ['documentation']}}
           json.dump(payload, open('/tmp/payload.json', 'w'))
           PYEOF
-              curl -sk -X PUT \
+              curl -s --fail-with-body -X PUT \
                 "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/EDIT?identifier=$IDENTIFIER" \
                 -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
                 -H "Content-Type: application/json" \
@@ -265,7 +270,7 @@ jobs:
               payload['contentlet']['navFolder'] = sf
           json.dump(payload, open('/tmp/payload.json', 'w'))
           PYEOF
-            curl -sk -X PUT \
+            curl -s --fail-with-body -X PUT \
               "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/NEW" \
               -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
               -H "Content-Type: application/json" \

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -8,7 +8,7 @@ jobs:
   preflight:
     name: Determine whether to run
     if: |
-      contains(github.event.issue.labels.*.name, 'Epic') ||
+      github.event.issue.type.name == 'Epic' ||
       contains(github.event.issue.labels.*.name, 'Doc : Needs Doc') ||
       contains(github.event.issue.labels.*.name, 'Changelog: Needs Doc')
     runs-on: ubuntu-latest
@@ -24,21 +24,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          HAS_EPIC: ${{ contains(github.event.issue.labels.*.name, 'Epic') }}
+          HAS_EPIC: ${{ github.event.issue.type.name == 'Epic' }}
         run: |
           if [ "$HAS_EPIC" = "true" ]; then
-            echo "Issue #$ISSUE_NUMBER has Epic label — proceeding unconditionally."
+            echo "Issue #$ISSUE_NUMBER has Epic type — proceeding unconditionally."
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          PARENT_LABELS=$(gh api graphql \
+          PARENT_TYPE=$(gh api graphql \
             -f query='
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   issue(number: $number) {
                     parent {
-                      labels(first: 20) { nodes { name } }
+                      issueType { name }
                     }
                   }
                 }
@@ -47,9 +47,9 @@ jobs:
             -f owner="${REPO%/*}" \
             -f repo="${REPO#*/}" \
             -F number="$ISSUE_NUMBER" \
-            --jq '(.data.repository.issue.parent.labels.nodes // []) | .[].name')
+            --jq '.data.repository.issue.parent.issueType.name // ""')
 
-          if echo "$PARENT_LABELS" | grep -qx "Epic"; then
+          if [ "$PARENT_TYPE" = "Epic" ]; then
             echo "Issue #$ISSUE_NUMBER is a sub-task of an Epic — skipping; Epic closure will handle docs."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           else
@@ -65,6 +65,7 @@ jobs:
     permissions:
       issues: write
       contents: read
+      id-token: write
 
     env:
       EPIC_NUMBER: ${{ github.event.issue.number }}
@@ -88,10 +89,12 @@ jobs:
           token: ${{ secrets.AUTODOC_AIOS_CI }}
           path: dotcms-aios
 
-      - name: Install Claude Code CLI
-        # Version is unpinned intentionally — claude-code updates frequently and
-        # the package is published by Anthropic. Pin if supply-chain policy requires it.
-        run: npm install -g @anthropic-ai/claude-code
+      - name: Configure AWS credentials (Bedrock)
+        if: vars.BEDROCK_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.BEDROCK_ROLE_ARN }}
+          aws-region: ${{ vars.BEDROCK_AWS_REGION || 'us-east-1' }}
 
       - name: Write prompt
         run: |
@@ -294,15 +297,43 @@ jobs:
           PYEOF
           python3 /tmp/ctx.py
 
-      - name: Run Claude
-        run: claude --print --allowedTools Bash,Write < /tmp/eval_context.md
+      - name: Load eval context
+        id: eval_context
+        run: |
+          {
+            echo 'content<<__AUTODOC_EOF__'
+            cat /tmp/eval_context.md
+            echo '__AUTODOC_EOF__'
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Post comment, apply to dotCMS, commit report
+      - name: Compose Claude args
+        id: claude_args
+        env:
+          BEDROCK_MODEL_ID: ${{ vars.BEDROCK_MODEL_ID }}
+        run: |
+          ARGS="--allowedTools Bash,Write"
+          if [ -n "$BEDROCK_MODEL_ID" ]; then
+            ARGS="--model $BEDROCK_MODEL_ID $ARGS"
+          fi
+          echo "value=$ARGS" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_bedrock: ${{ vars.BEDROCK_ROLE_ARN != '' && 'true' || 'false' }}
+          prompt: ${{ steps.eval_context.outputs.content }}
+          claude_args: ${{ steps.claude_args.outputs.value }}
+          use_sticky_comment: 'false'
+          track_progress: 'false'
+
+      - name: Post report comment
         run: |
           REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
 
           if [ ! -f "$REPORT" ]; then
             echo "No report at $REPORT — skipping finalize."
+            echo "ACTION=none" >> "$GITHUB_ENV"
             exit 0
           fi
 
@@ -336,29 +367,39 @@ jobs:
             gh issue comment "$EPIC_NUMBER" --repo "$REPO" --body-file /tmp/comment_body.md
           fi
 
-          # Parse action and urlTitle from the machine-readable meta block.
-          # All fields use sub() to preserve the full value after the key prefix.
+          # Parse action and urlTitle from the machine-readable meta block and export
+          # for the downstream apply steps.
           ACTION=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^action:/{print $2; exit}' "$REPORT")
           URL_TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^urlTitle:/{sub(/^urlTitle:[[:space:]]*/,"");print;exit}' "$REPORT")
+          echo "ACTION=${ACTION:-none}" >> "$GITHUB_ENV"
+          echo "URL_TITLE=$URL_TITLE"   >> "$GITHUB_ENV"
+
+      - name: Apply doc update to dotCMS
+        if: env.ACTION == 'update'
+        run: |
+          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
 
           # Validate urlTitle is a URL slug before interpolating into the JSON query.
           # Non-slug chars (quotes, backslashes) would break the shell-built JSON payload.
-          if [ -n "$URL_TITLE" ] && ! echo "$URL_TITLE" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
-            echo "urlTitle '${URL_TITLE}' is not a valid slug — skipping dotCMS apply."
-            ACTION=none
+          if ! echo "$URL_TITLE" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
+            echo "urlTitle '${URL_TITLE}' is not a valid slug — skipping."
+            exit 0
           fi
 
-          if [ "$ACTION" = "update" ] && [ -n "$URL_TITLE" ]; then
-            IDENTIFIER=$(curl -s --fail-with-body -X POST "$AUTODOC_DOTCMS_BASE_URL/api/es/search" \
-              -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
-              -H "Content-Type: application/json" \
-              -d "{\"query\":{\"query_string\":{\"query\":\"+contentType:DotcmsDocumentation +DotcmsDocumentation.urlTitle:\\\"$URL_TITLE\\\"\"}},\"size\":1}" \
-              | jq -r '(.esresponse[0].hits.hits[0]._source.identifier) // empty')
+          IDENTIFIER=$(curl -s --fail-with-body -X POST "$AUTODOC_DOTCMS_BASE_URL/api/es/search" \
+            -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\":{\"query_string\":{\"query\":\"+contentType:DotcmsDocumentation +DotcmsDocumentation.urlTitle:\\\"$URL_TITLE\\\"\"}},\"size\":1}" \
+            | jq -r '(.esresponse[0].hits.hits[0]._source.identifier) // empty')
 
-            # Verify the identifier is UUID-shaped before placing it in a URL.
-            if echo "$IDENTIFIER" | grep -qE '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$' && [ -n "$IDENTIFIER" ]; then
-              export REPORT IDENTIFIER
-              python3 << 'PYEOF'
+          # Verify the identifier is UUID-shaped before placing it in a URL.
+          if ! echo "$IDENTIFIER" | grep -qE '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'; then
+            echo "No valid contentlet found for urlTitle '${URL_TITLE}' — skipping."
+            exit 0
+          fi
+
+          export REPORT IDENTIFIER
+          python3 << 'PYEOF'
           import json, os
           report = open(os.environ['REPORT']).read()
           marker = '<!-- BEGIN_DOC_DRAFT -->'
@@ -369,19 +410,29 @@ jobs:
               'disabledWYSIWYG': ['documentation']}}
           json.dump(payload, open('/tmp/payload.json', 'w'))
           PYEOF
-              curl -s --fail-with-body -X PUT \
-                "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/EDIT?identifier=$IDENTIFIER" \
-                -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
-                -H "Content-Type: application/json" \
-                --data @/tmp/payload.json
-            fi
 
-          elif [ "$ACTION" = "create" ]; then
-            TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^title:/{sub(/^title:[[:space:]]*/,"");print;exit}' "$REPORT")
-            TAGS=$(awk  '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^tags:/{sub(/^tags:[[:space:]]*/,"");print;exit}'  "$REPORT")
-            SEO=$(awk   '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^seoDescription:/{sub(/^seoDescription:[[:space:]]*/,"");print;exit}' "$REPORT")
-            export REPORT URL_TITLE TITLE TAGS SEO
-            python3 << 'PYEOF'
+          curl -s --fail-with-body -X PUT \
+            "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/EDIT?identifier=$IDENTIFIER" \
+            -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
+            -H "Content-Type: application/json" \
+            --data @/tmp/payload.json
+
+      - name: Apply doc create to dotCMS
+        if: env.ACTION == 'create'
+        run: |
+          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
+
+          # Validate urlTitle is a URL slug before interpolating into the JSON query.
+          if ! echo "$URL_TITLE" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
+            echo "urlTitle '${URL_TITLE}' is not a valid slug — skipping."
+            exit 0
+          fi
+
+          TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^title:/{sub(/^title:[[:space:]]*/,"");print;exit}' "$REPORT")
+          TAGS=$(awk  '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^tags:/{sub(/^tags:[[:space:]]*/,"");print;exit}'  "$REPORT")
+          SEO=$(awk   '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^seoDescription:/{sub(/^seoDescription:[[:space:]]*/,"");print;exit}' "$REPORT")
+          export REPORT URL_TITLE TITLE TAGS SEO
+          python3 << 'PYEOF'
           import json, os
           report = open(os.environ['REPORT']).read()
           marker = '<!-- BEGIN_DOC_DRAFT -->'
@@ -399,10 +450,10 @@ jobs:
               payload['contentlet']['navFolder'] = sf
           json.dump(payload, open('/tmp/payload.json', 'w'))
           PYEOF
-            curl -s --fail-with-body -X PUT \
-              "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/NEW" \
-              -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
-              -H "Content-Type: application/json" \
-              --data @/tmp/payload.json
-          fi
+
+          curl -s --fail-with-body -X PUT \
+            "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/NEW" \
+            -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
+            -H "Content-Type: application/json" \
+            --data @/tmp/payload.json
 

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   preflight:
     name: Determine whether to run
-    # Run if the issue carries any of the three trigger labels.
     if: |
       contains(github.event.issue.labels.*.name, 'Epic') ||
       contains(github.event.issue.labels.*.name, 'Doc : Needs Doc') ||
@@ -25,7 +24,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          # Epic label present means unconditional run — no further checks needed.
           HAS_EPIC: ${{ contains(github.event.issue.labels.*.name, 'Epic') }}
         run: |
           if [ "$HAS_EPIC" = "true" ]; then
@@ -34,8 +32,6 @@ jobs:
             exit 0
           fi
 
-          # Non-Epic issue: check whether it is a sub-task of an Epic.
-          # If so, skip — the parent Epic closure will handle documentation.
           PARENT_LABELS=$(gh api graphql \
             -f query='
               query($owner: String!, $repo: String!, $number: Int!) {
@@ -51,7 +47,7 @@ jobs:
             -f owner="${REPO%/*}" \
             -f repo="${REPO#*/}" \
             -F number="$ISSUE_NUMBER" \
-            --jq '.data.repository.issue.parent.labels.nodes[].name // empty')
+            --jq '(.data.repository.issue.parent.labels.nodes // []) | .[].name')
 
           if echo "$PARENT_LABELS" | grep -qx "Epic"; then
             echo "Issue #$ISSUE_NUMBER is a sub-task of an Epic — skipping; Epic closure will handle docs."
@@ -67,7 +63,7 @@ jobs:
     if: needs.preflight.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      issues: write   # post/edit the report comment
+      issues: write
       contents: read
 
     env:
@@ -81,47 +77,205 @@ jobs:
       AUTODOC_DOTCMS_SITE_FOLDER: ${{ secrets.AUTODOC_DOTCMS_SITE_FOLDER }}
 
     steps:
-      - name: Checkout triggering repo (for gh context)
+      - name: Checkout triggering repo
         uses: actions/checkout@v4
 
-      - name: Checkout dotcms-aios (includes autodoc scripts)
+      - name: Checkout dotcms-aios
         uses: actions/checkout@v4
         with:
           repository: dotCMS/dotcms-aios
           token: ${{ secrets.CI_MACHINE_TOKEN }}
           path: dotcms-aios
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          working-directory: dotcms-aios/autodoc
-
-      - name: Install autodoc dependencies
-        working-directory: dotcms-aios/autodoc
-        run: uv sync
-
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Run eval → Claude
-        working-directory: dotcms-aios/autodoc
+      - name: Build eval context
         run: |
-          uv run python scripts/run_eval.py \
-            --epic "$EPIC_NUMBER" \
-            --repo "$REPO" \
-            --prompt burlap \
-            --aios-dir ../ \
-            > /tmp/eval_context.md
+          cat > /tmp/ctx.py << 'PYEOF'
+          import json, os, subprocess, sys
 
-          claude --print --allowedTools Bash,Write < /tmp/eval_context.md
+          epic_num = os.environ['EPIC_NUMBER']
+          repo     = os.environ['REPO']
+          MAX_COMMENT_CHARS = 4000
 
-      - name: Run finalize (apply + post comment + commit)
-        working-directory: dotcms-aios/autodoc
+          result = subprocess.run(
+              ['gh', 'issue', 'view', epic_num, '--repo', repo,
+               '--json', 'number,title,body,labels,state,url,'
+                         'closedByPullRequestsReferences,comments'],
+              capture_output=True, text=True, check=True)
+          epic = json.loads(result.stdout)
+
+          labels  = ', '.join(l['name'] for l in epic.get('labels', []))
+          pr_nums = [r['number'] for r in epic.get('closedByPullRequestsReferences', [])]
+
+          def render_comments(comments):
+              parts, skipped = [], 0
+              for c in (comments or []):
+                  body = (c.get('body') or '').strip()
+                  if not body:
+                      continue
+                  if len(body) > MAX_COMMENT_CHARS:
+                      skipped += 1
+                      continue
+                  login = (c.get('author') or {}).get('login', '?')
+                  parts.append(f'**{login}:** {body}')
+              out = '\n\n'.join(parts)
+              if skipped:
+                  out += (f'\n\n*({skipped} comment{"s" if skipped > 1 else ""}'
+                          f' omitted — exceeded {MAX_COMMENT_CHARS}-character limit)*')
+              return out
+
+          lines = [
+              '# Evaluation Context', '',
+              f'## Epic: #{epic["number"]} — {repo}',
+              f'**Title:** {epic["title"]}',
+              f'**URL:** {epic.get("url", "")}',
+              f'**State:** {epic.get("state", "?")}',
+              f'**Labels:** {labels or "(none)"}',
+              f'**Related PRs:** {", ".join(f"#{n}" for n in pr_nums) or "(none)"}',
+              '', '### Epic Body', '',
+              (epic.get('body') or '').strip(),
+          ]
+          ct = render_comments(epic.get('comments'))
+          if ct:
+              lines += ['', '### Comments', '', ct]
+
+          for pr_num in pr_nums:
+              r = subprocess.run(
+                  ['gh', 'pr', 'view', str(pr_num), '--repo', repo,
+                   '--json', 'number,title,body,state,mergedAt,author,comments'],
+                  capture_output=True, text=True)
+              if r.returncode != 0:
+                  continue
+              pr = json.loads(r.stdout)
+              author = (pr.get('author') or {}).get('login', '?')
+              lines += [
+                  '', '---', '',
+                  f'## Related PR: #{pr["number"]} — {pr["title"]}',
+                  f'**State:** {pr.get("state","?")}  |  '
+                  f'**Author:** {author}  |  '
+                  f'**Merged:** {pr.get("mergedAt") or "N/A"}',
+                  '',
+                  (pr.get('body') or '').strip(),
+              ]
+              pct = render_comments(pr.get('comments'))
+              if pct:
+                  lines += ['', '### Comments', '', pct]
+
+          g = subprocess.run(
+              ['grep', '-rl', f'/issues/{epic_num}', 'dotcms-aios/work/epics/'],
+              capture_output=True, text=True)
+          vault_file = g.stdout.strip().split('\n')[0] if g.stdout.strip() else ''
+          if vault_file:
+              lines += ['', '---', '', '## Vault Context', '',
+                        open(vault_file).read().strip()]
+          else:
+              print(f'warning: no vault file for Epic #{epic_num}', file=sys.stderr)
+
+          prompt = open('dotcms-aios/autodoc/prompts/burlap.txt').read().strip()
+          report_path = f'dotcms-aios/autodoc/reports/Epic-{epic_num}_burlap.md'
+          lines += [
+              '', '---', '', '## Prompt: burlap', '', prompt,
+              '', '---', '',
+              f'**Report path:** `{report_path}`',
+              '',
+              'Use the Write tool to write the report to exactly that path.',
+          ]
+
+          with open('/tmp/eval_context.md', 'w') as f:
+              f.write('\n'.join(lines))
+          PYEOF
+          python3 /tmp/ctx.py
+
+      - name: Run Claude
+        run: claude --print --allowedTools Bash,Write < /tmp/eval_context.md
+
+      - name: Post comment, apply to dotCMS, commit report
         run: |
+          REPORT="dotcms-aios/autodoc/reports/Epic-${EPIC_NUMBER}_burlap.md"
+
+          if [ ! -f "$REPORT" ]; then
+            echo "No report at $REPORT — skipping finalize."
+            exit 0
+          fi
+
+          # Post report as issue comment (edit existing autodoc comment if one exists)
+          EXISTING=$(gh api "repos/$REPO/issues/$EPIC_NUMBER/comments" \
+            --jq '.[] | select(.body | contains("<!-- autodoc-report -->")) | .id' \
+            | head -1)
+          if [ -n "$EXISTING" ]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING" \
+              -f "body=@$REPORT"
+          else
+            gh issue comment "$EPIC_NUMBER" --repo "$REPO" --body-file "$REPORT"
+          fi
+
+          # Parse action and urlTitle from the machine-readable meta block
+          ACTION=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^action:/{print $2; exit}' "$REPORT")
+          URL_TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^urlTitle:/{print $2; exit}' "$REPORT")
+
+          if [ "$ACTION" = "update" ] && [ -n "$URL_TITLE" ]; then
+            IDENTIFIER=$(curl -sk -X POST "$AUTODOC_DOTCMS_BASE_URL/api/es/search" \
+              -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\":{\"query_string\":{\"query\":\"+contentType:DotcmsDocumentation +DotcmsDocumentation.urlTitle:\\\"$URL_TITLE\\\"\"}},\"size\":1}" \
+              | jq -r '(.esresponse[0].hits.hits[0]._source.identifier) // empty')
+
+            if [ -n "$IDENTIFIER" ]; then
+              export REPORT IDENTIFIER
+              python3 << 'PYEOF'
+          import json, os
+          report = open(os.environ['REPORT']).read()
+          marker = '<!-- BEGIN_DOC_DRAFT -->'
+          draft = report.split(marker, 1)[1].lstrip('\n') if marker in report else ''
+          payload = {'contentlet': {
+              'identifier': os.environ['IDENTIFIER'],
+              'languageId': 1, 'documentation': draft,
+              'disabledWYSIWYG': ['documentation']}}
+          json.dump(payload, open('/tmp/payload.json', 'w'))
+          PYEOF
+              curl -sk -X PUT \
+                "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/EDIT?identifier=$IDENTIFIER" \
+                -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
+                -H "Content-Type: application/json" \
+                --data @/tmp/payload.json
+            fi
+
+          elif [ "$ACTION" = "create" ]; then
+            TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^title:/{sub(/^title:[[:space:]]*/,"");print;exit}' "$REPORT")
+            TAGS=$(awk  '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^tags:/{sub(/^tags:[[:space:]]*/,"");print;exit}'  "$REPORT")
+            SEO=$(awk   '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^seoDescription:/{sub(/^seoDescription:[[:space:]]*/,"");print;exit}' "$REPORT")
+            export REPORT URL_TITLE TITLE TAGS SEO
+            python3 << 'PYEOF'
+          import json, os
+          report = open(os.environ['REPORT']).read()
+          marker = '<!-- BEGIN_DOC_DRAFT -->'
+          draft = report.split(marker, 1)[1].lstrip('\n') if marker in report else ''
+          sf = os.environ.get('AUTODOC_DOTCMS_SITE_FOLDER', '').strip()
+          payload = {'contentlet': {
+              'contentType': 'DotcmsDocumentation',
+              'urlTitle': os.environ['URL_TITLE'],
+              'title': os.environ['TITLE'],
+              'tag': os.environ['TAGS'],
+              'seoDescription': os.environ['SEO'],
+              'languageId': 1, 'documentation': draft,
+              'disabledWYSIWYG': ['documentation']}}
+          if sf:
+              payload['contentlet']['navFolder'] = sf
+          json.dump(payload, open('/tmp/payload.json', 'w'))
+          PYEOF
+            curl -sk -X PUT \
+              "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/NEW" \
+              -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
+              -H "Content-Type: application/json" \
+              --data @/tmp/payload.json
+          fi
+
+          # Commit the report back to dotcms-aios
+          cd dotcms-aios
           git config user.name "autodoc[bot]"
           git config user.email "autodoc-bot@users.noreply.github.com"
-
-          uv run python scripts/finalize.py \
-            --epic "$EPIC_NUMBER" \
-            --prompt burlap \
-            --repo "$REPO"
+          git add "autodoc/reports/Epic-${EPIC_NUMBER}_burlap.md"
+          git commit -m "eval: Epic-${EPIC_NUMBER} (burlap)" || true
+          git push

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -89,6 +89,8 @@ jobs:
           path: dotcms-aios
 
       - name: Install Claude Code CLI
+        # Version is unpinned intentionally — claude-code updates frequently and
+        # the package is published by Anthropic. Pin if supply-chain policy requires it.
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Build eval context
@@ -220,6 +222,13 @@ jobs:
           ACTION=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^action:/{print $2; exit}' "$REPORT")
           URL_TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^urlTitle:/{sub(/^urlTitle:[[:space:]]*/,"");print;exit}' "$REPORT")
 
+          # Validate urlTitle is a URL slug before interpolating into the JSON query.
+          # Non-slug chars (quotes, backslashes) would break the shell-built JSON payload.
+          if [ -n "$URL_TITLE" ] && ! echo "$URL_TITLE" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
+            echo "urlTitle '${URL_TITLE}' is not a valid slug — skipping dotCMS apply."
+            ACTION=none
+          fi
+
           if [ "$ACTION" = "update" ] && [ -n "$URL_TITLE" ]; then
             IDENTIFIER=$(curl -s --fail-with-body -X POST "$AUTODOC_DOTCMS_BASE_URL/api/es/search" \
               -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
@@ -227,7 +236,8 @@ jobs:
               -d "{\"query\":{\"query_string\":{\"query\":\"+contentType:DotcmsDocumentation +DotcmsDocumentation.urlTitle:\\\"$URL_TITLE\\\"\"}},\"size\":1}" \
               | jq -r '(.esresponse[0].hits.hits[0]._source.identifier) // empty')
 
-            if [ -n "$IDENTIFIER" ]; then
+            # Verify the identifier is UUID-shaped before placing it in a URL.
+            if echo "$IDENTIFIER" | grep -qE '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$' && [ -n "$IDENTIFIER" ]; then
               export REPORT IDENTIFIER
               python3 << 'PYEOF'
           import json, os
@@ -277,10 +287,12 @@ jobs:
               --data @/tmp/payload.json
           fi
 
-          # Commit the report back to dotcms-aios
+          # Commit the report back to dotcms-aios.
+          # Push only runs if commit succeeds (i.e. there were actual changes to commit).
           cd dotcms-aios
           git config user.name "autodoc[bot]"
           git config user.email "autodoc-bot@users.noreply.github.com"
           git add "autodoc/reports/Epic-${EPIC_NUMBER}_burlap.md"
-          git commit -m "eval: Epic-${EPIC_NUMBER} (burlap)" || true
-          git push
+          if git commit -m "eval: Epic-${EPIC_NUMBER} (burlap)"; then
+            git push origin HEAD
+          fi

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -118,6 +118,14 @@ jobs:
           Run multiple searches with varied queries to thoroughly assess coverage. Use the
           results to determine whether documentation exists, is sufficient, or needs updating.
 
+          **Source material quality check:** before drafting anything, assess whether the
+          Epic and its PRs contain enough real technical detail to write accurate
+          documentation. If the Epic is a placeholder, has no associated PRs, or describes
+          a feature without specifying its behaviour, configuration, or user-facing surface —
+          set `action: none` and explain that the source material is insufficient. Do not
+          infer, invent, or pad from general knowledge. A short honest `none` report is
+          always preferable to a hallucinated draft.
+
           Then write the report to the path shown at the bottom of this context block,
           using the Write tool.
 
@@ -298,8 +306,24 @@ jobs:
             exit 0
           fi
 
-          # Prepend idempotency marker so subsequent runs can find and edit this comment.
-          { echo '<!-- autodoc-report -->'; cat "$REPORT"; } > /tmp/comment_body.md
+          # Build comment body: prepend idempotency marker and collapse the doc draft
+          # under a <details> block so the comment isn't a wall of text.
+          export REPORT
+          python3 << 'PYEOF'
+          import os
+          report = open(os.environ['REPORT']).read()
+          marker = '<!-- BEGIN_DOC_DRAFT -->'
+          if marker in report:
+              before, draft = report.split(marker, 1)
+              body = (before.rstrip()
+                      + '\n\n<details>\n<summary>Documentation Draft</summary>\n\n'
+                      + draft.lstrip('\n')
+                      + '\n</details>')
+          else:
+              body = report
+          with open('/tmp/comment_body.md', 'w') as f:
+              f.write('<!-- autodoc-report -->\n' + body.rstrip())
+          PYEOF
 
           # Edit the existing autodoc comment if one exists, otherwise create a new one.
           # --paginate ensures we search all comments, not just the first page.

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotCMS/dotcms-aios
-          token: ${{ secrets.AUTODOC_AIOS_CI }}
+          token: ${{ secrets.CI_MACHINE_TOKEN }}
           path: dotcms-aios
 
       - name: Configure AWS credentials (Bedrock)

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dotCMS/dotcms-aios
-          token: ${{ secrets.CI_MACHINE_TOKEN }}
+          token: ${{ secrets.AUTODOC_AIOS_CI }}
           path: dotcms-aios
 
       - name: Install Claude Code CLI

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -93,6 +93,101 @@ jobs:
         # the package is published by Anthropic. Pin if supply-chain policy requires it.
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Write prompt
+        run: |
+          cat > /tmp/burlap.txt << 'PROMPTEOF'
+          The context block above contains an Epic with its related PRs already assembled.
+          Your task is to assess whether this Epic's delivery requires new or updated
+          documentation in the dotCMS docs.
+
+          If a `## Vault Context` section is present in this block, use it to inform the
+          grouping and audience sections of the report — target personas, product pillar,
+          GTM status, and strategic framing. If no Vault Context is present, infer from
+          the Epic and PR content.
+
+          Run one or more dotCMS AI semantic searches to assess current documentation
+          coverage. Use the Bash tool to execute each search:
+
+            curl -s -X POST "https://cdn.dotcms.dev/api/v1/ai/search" \
+              -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_AISEARCH" \
+              -H "Content-Type: application/json" \
+              -H "Origin: https://dev.dotcms.com" \
+              -H "Referer: https://dev.dotcms.com/" \
+              -d '{"model":"gpt-5.2","indexName":"default","prompt":"<your query here>","operator":"cosine","threshold":".25","searchLimit":20}'
+
+          Run multiple searches with varied queries to thoroughly assess coverage. Use the
+          results to determine whether documentation exists, is sufficient, or needs updating.
+
+          Then write the report to the path shown at the bottom of this context block,
+          using the Write tool.
+
+          **Every report, regardless of outcome, must contain a machine-readable metadata
+          block placed immediately after the report header and before the `## Determination`
+          section.** Use exactly this structure and no other:
+
+          ```
+          <!-- BEGIN_DOC_META -->
+          action: none
+          <!-- END_DOC_META -->
+          ```
+
+          For `update` reports, add `urlTitle` (the urlTitle of the page being updated):
+
+          ```
+          <!-- BEGIN_DOC_META -->
+          action: update
+          urlTitle: saml-authentication
+          <!-- END_DOC_META -->
+          ```
+
+          For `create` reports, add `urlTitle` (proposed), `title`, `tags`
+          (comma-separated), and `seoDescription`:
+
+          ```
+          <!-- BEGIN_DOC_META -->
+          action: create
+          urlTitle: vanity-urls-s3-static-publishing
+          title: Vanity URLs in S3 Static Publishing
+          tags: static publishing, push publishing, vanity urls, AWS S3
+          seoDescription: Learn how to enable and configure opt-in Vanity URL materialization for AWS S3 static publishing in dotCMS.
+          <!-- END_DOC_META -->
+          ```
+
+          The style of report depends upon a determination that must be made here:
+
+          - There is a chance that no documentation change is warranted. This is common when
+            the Epic delivers internal architecture work, bug fixes, or a feature that is
+            already fully documented. Some cases will be clear and some uncertain — evaluate
+            whether the Epic's delivery is both end-user relevant and documentable. If no
+            documentation is needed, the report must explain why. No `<!-- BEGIN_DOC_DRAFT -->`
+            token appears anywhere in no-documentation reports.
+
+          - There is a chance that relevant documentation exists but needs an update. If the
+            docs are not fully current with what the Epic delivered, the report should first
+            present a differential explaining what changes are necessary and where. After all
+            analysis, the report must end with the token `<!-- BEGIN_DOC_DRAFT -->` on its
+            own line, immediately followed by the **complete, final content of the page's
+            `documentation` field** — the full existing document with all proposed changes
+            already incorporated. This is not a diff and not an insertion fragment: it is the
+            entire field value as it should exist after the update, ready to be submitted to
+            the API as-is. The draft runs to the end of the file with no trailing content
+            after it.
+
+          - There is a chance that the Epic introduces something documentable with no
+            existing coverage. In this case, the report should include a differential on the
+            documentation gap, a list of appropriate tags, a short SEO description, a
+            description of what feature this documentation should be grouped with, and what
+            user personas it is most relevant to. After all analysis, the report must end
+            with the token `<!-- BEGIN_DOC_DRAFT -->` on its own line, immediately followed
+            by the complete draft of the new documentation page. The draft runs to the end
+            of the file with no trailing content after it.
+
+            When drafting the documentation page, use horizontal rules (`---`) sparingly.
+            Headings already provide clear visual and structural separation; `---` should
+            be reserved only for the most stark structural breaks and must not appear
+            between ordinary subsections.
+          PROMPTEOF
+
       - name: Build eval context
         run: |
           cat > /tmp/ctx.py << 'PYEOF'
@@ -176,8 +271,8 @@ jobs:
           else:
               print(f'warning: no vault file for Epic #{epic_num}', file=sys.stderr)
 
-          prompt = open('dotcms-aios/autodoc/prompts/burlap.txt').read().strip()
-          report_path = f'dotcms-aios/autodoc/reports/Epic-{epic_num}_burlap.md'
+          prompt = open('/tmp/burlap.txt').read().strip()
+          report_path = f'/tmp/Epic-{epic_num}_burlap.md'
           lines += [
               '', '---', '', '## Prompt: burlap', '', prompt,
               '', '---', '',
@@ -196,7 +291,7 @@ jobs:
 
       - name: Post comment, apply to dotCMS, commit report
         run: |
-          REPORT="dotcms-aios/autodoc/reports/Epic-${EPIC_NUMBER}_burlap.md"
+          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
 
           if [ ! -f "$REPORT" ]; then
             echo "No report at $REPORT — skipping finalize."

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -97,10 +97,10 @@ jobs:
 
     steps:
       - name: Checkout triggering repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.2.2
 
       - name: Checkout dotcms-aios
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.2.2
         with:
           repository: dotCMS/dotcms-aios
           token: ${{ secrets.CI_MACHINE_TOKEN }}
@@ -318,7 +318,10 @@ jobs:
     name: Run Claude (Bedrock)
     needs: prep
     uses: dotCMS/ai-workflows/.github/workflows/autodoc-executor.yml@v3.5.0
-    secrets: inherit
+    secrets:
+      AUTODOC_DOTCMS_API_TOKEN_AISEARCH: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_AISEARCH }}
+      AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
+      AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
     with:
       prompt: ${{ needs.prep.outputs.eval_context }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
@@ -344,7 +347,7 @@ jobs:
 
     steps:
       - name: Download report artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: autodoc-report
           path: /tmp/

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -304,14 +304,15 @@ jobs:
           ]
 
           with open('/tmp/eval_context.md', 'w') as f:
-              f.write('\n'.join(lines))
+              f.write('\n'.join(lines) + '\n')
           PYEOF
           python3 /tmp/ctx.py
 
+          DELIM="$(openssl rand -hex 16)"
           {
-            echo 'content<<__AUTODOC_EOF__'
+            echo "content<<${DELIM}"
             cat /tmp/eval_context.md
-            echo '__AUTODOC_EOF__'
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
   claude:

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -323,6 +323,7 @@ jobs:
       prompt: ${{ needs.prep.outputs.eval_context }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
+      autodoc_dotcms_site_folder: ${{ vars.AUTODOC_DOTCMS_SITE_FOLDER }}
 
   finalize:
     name: Post report and apply to dotCMS
@@ -339,7 +340,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
       AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
-      AUTODOC_DOTCMS_SITE_FOLDER: ${{ secrets.AUTODOC_DOTCMS_SITE_FOLDER }}
+      AUTODOC_DOTCMS_SITE_FOLDER: ${{ vars.AUTODOC_DOTCMS_SITE_FOLDER }}
 
     steps:
       - name: Download report artifact
@@ -417,6 +418,26 @@ jobs:
           # Verify the identifier is UUID-shaped before placing it in a URL.
           if ! echo "$IDENTIFIER" | grep -qE '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'; then
             echo "No valid contentlet found for urlTitle '${URL_TITLE}' — skipping."
+            exit 0
+          fi
+
+          # modUser guardrail: fetch the working inode and check whether it is safe
+          # to overwrite. GET /api/v1/content/{id} always returns the working inode.
+          #
+          # live==true  → working IS the live version; no pending draft → safe.
+          # live==false → a draft exists on top of the published version.
+          #   modUser == service account → automation owns the draft → safe.
+          #   modUser == anyone else     → human has an outstanding draft → skip.
+          CONTENT_CHECK=$(curl -s \
+            "$AUTODOC_DOTCMS_BASE_URL/api/v1/content/$IDENTIFIER" \
+            -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING")
+          IS_LIVE=$(echo "$CONTENT_CHECK" | jq -r '.entity.live // true')
+          MOD_USER=$(echo "$CONTENT_CHECK" | jq -r '.entity.modUser // ""')
+          SERVICE_ACCOUNT='user-3244a6be-d28b-4d80-a3fc-9f66a1d832ae'
+
+          if [ "$IS_LIVE" = "false" ] && [ "$MOD_USER" != "$SERVICE_ACCOUNT" ]; then
+            echo "SKIP: outstanding draft last saved by '${MOD_USER}' (not the CI Autodoc service account)."
+            echo "The automation will not overwrite a human edit. Please review the draft in dotCMS and apply the proposed changes manually if appropriate."
             exit 0
           fi
 

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -1,17 +1,3 @@
-# Automated documentation audit for closed issues.
-#
-# When an issue closes, this workflow decides whether its delivery warrants a
-# documentation change: it runs for Epics and for issues labeled
-# "Doc : Needs Doc" or "Changelog: Needs Doc", and skips sub-tasks of an Epic
-# (the Epic's own closure covers them).
-#
-# For qualifying issues it assembles the issue, its related PRs, and any
-# dotcms-aios vault context into an evaluation prompt, then runs Claude to
-# audit current documentation coverage via dotCMS AI semantic search. Claude
-# produces a report that determines one of three actions: none (no doc change
-# needed), update (revise an existing page), or create (draft a new page).
-# The report is posted as a comment on the issue, and update/create drafts
-# are applied to the dotCMS documentation site through its content API.
 name: Autodoc — Epic Documentation Audit
 
 on:
@@ -21,8 +7,9 @@ on:
 jobs:
   preflight:
     name: Determine whether to run
+    # Run if the issue carries any of the three trigger labels.
     if: |
-      github.event.issue.type.name == 'Epic' ||
+      contains(github.event.issue.labels.*.name, 'Epic') ||
       contains(github.event.issue.labels.*.name, 'Doc : Needs Doc') ||
       contains(github.event.issue.labels.*.name, 'Changelog: Needs Doc')
     runs-on: ubuntu-latest
@@ -38,21 +25,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          HAS_EPIC: ${{ github.event.issue.type.name == 'Epic' }}
+          # Epic label present means unconditional run — no further checks needed.
+          HAS_EPIC: ${{ contains(github.event.issue.labels.*.name, 'Epic') }}
         run: |
           if [ "$HAS_EPIC" = "true" ]; then
-            echo "Issue #$ISSUE_NUMBER has Epic type — proceeding unconditionally."
+            echo "Issue #$ISSUE_NUMBER has Epic label — proceeding unconditionally."
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          PARENT_TYPE=$(gh api graphql \
+          # Non-Epic issue: check whether it is a sub-task of an Epic.
+          # If so, skip — the parent Epic closure will handle documentation.
+          PARENT_LABELS=$(gh api graphql \
             -f query='
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   issue(number: $number) {
                     parent {
-                      issueType { name }
+                      labels(first: 20) { nodes { name } }
                     }
                   }
                 }
@@ -61,9 +51,9 @@ jobs:
             -f owner="${REPO%/*}" \
             -f repo="${REPO#*/}" \
             -F number="$ISSUE_NUMBER" \
-            --jq '.data.repository.issue.parent.issueType.name // ""')
+            --jq '.data.repository.issue.parent.labels.nodes[].name // empty')
 
-          if [ "$PARENT_TYPE" = "Epic" ]; then
+          if echo "$PARENT_LABELS" | grep -qx "Epic"; then
             echo "Issue #$ISSUE_NUMBER is a sub-task of an Epic — skipping; Epic closure will handle docs."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           else
@@ -77,397 +67,61 @@ jobs:
     if: needs.preflight.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write   # post/edit the report comment
       contents: read
-      id-token: write
 
     env:
       EPIC_NUMBER: ${{ github.event.issue.number }}
       REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      # Used by the Claude subprocess when it executes the curl in burlap.txt — not called directly here.
       AUTODOC_DOTCMS_API_TOKEN_AISEARCH: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_AISEARCH }}
       AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
       AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
       AUTODOC_DOTCMS_SITE_FOLDER: ${{ secrets.AUTODOC_DOTCMS_SITE_FOLDER }}
 
     steps:
-      - name: Checkout triggering repo
+      - name: Checkout triggering repo (for gh context)
         uses: actions/checkout@v4
 
-      - name: Checkout dotcms-aios
+      - name: Checkout dotcms-aios (includes autodoc scripts)
         uses: actions/checkout@v4
         with:
           repository: dotCMS/dotcms-aios
           token: ${{ secrets.CI_MACHINE_TOKEN }}
           path: dotcms-aios
 
-      - name: Configure AWS credentials (Bedrock)
-        if: vars.BEDROCK_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
-          role-to-assume: ${{ vars.BEDROCK_ROLE_ARN }}
-          aws-region: ${{ vars.BEDROCK_AWS_REGION || 'us-east-1' }}
+          working-directory: dotcms-aios/autodoc
 
-      - name: Write prompt
+      - name: Install autodoc dependencies
+        working-directory: dotcms-aios/autodoc
+        run: uv sync
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run eval → Claude
+        working-directory: dotcms-aios/autodoc
         run: |
-          cat > /tmp/burlap.txt << 'PROMPTEOF'
-          The context block above contains an Epic with its related PRs already assembled.
-          Your task is to assess whether this Epic's delivery requires new or updated
-          documentation in the dotCMS docs.
+          uv run python scripts/run_eval.py \
+            --epic "$EPIC_NUMBER" \
+            --repo "$REPO" \
+            --prompt burlap \
+            --aios-dir ../ \
+            > /tmp/eval_context.md
 
-          If a `## Vault Context` section is present in this block, use it to inform the
-          grouping and audience sections of the report — target personas, product pillar,
-          GTM status, and strategic framing. If no Vault Context is present, infer from
-          the Epic and PR content.
+          claude --print --allowedTools Bash,Write < /tmp/eval_context.md
 
-          Run one or more dotCMS AI semantic searches to assess current documentation
-          coverage. Use the Bash tool to execute each search:
-
-            curl -s -X POST "https://cdn.dotcms.dev/api/v1/ai/search" \
-              -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_AISEARCH" \
-              -H "Content-Type: application/json" \
-              -H "Origin: https://dev.dotcms.com" \
-              -H "Referer: https://dev.dotcms.com/" \
-              -d '{"model":"gpt-5.2","indexName":"default","prompt":"<your query here>","operator":"cosine","threshold":".25","searchLimit":20}'
-
-          Run multiple searches with varied queries to thoroughly assess coverage. Use the
-          results to determine whether documentation exists, is sufficient, or needs updating.
-
-          **Source material quality check:** before drafting anything, assess whether the
-          Epic and its PRs contain enough real technical detail to write accurate
-          documentation. If the Epic is a placeholder, has no associated PRs, or describes
-          a feature without specifying its behaviour, configuration, or user-facing surface —
-          set `action: none` and explain that the source material is insufficient. Do not
-          infer, invent, or pad from general knowledge. A short honest `none` report is
-          always preferable to a hallucinated draft.
-
-          Then write the report to the path shown at the bottom of this context block,
-          using the Write tool.
-
-          **Every report, regardless of outcome, must contain a machine-readable metadata
-          block placed immediately after the report header and before the `## Determination`
-          section.** Use exactly this structure and no other:
-
-          ```
-          <!-- BEGIN_DOC_META -->
-          action: none
-          <!-- END_DOC_META -->
-          ```
-
-          For `update` reports, add `urlTitle` (the urlTitle of the page being updated):
-
-          ```
-          <!-- BEGIN_DOC_META -->
-          action: update
-          urlTitle: saml-authentication
-          <!-- END_DOC_META -->
-          ```
-
-          For `create` reports, add `urlTitle` (proposed), `title`, `tags`
-          (comma-separated), and `seoDescription`:
-
-          ```
-          <!-- BEGIN_DOC_META -->
-          action: create
-          urlTitle: vanity-urls-s3-static-publishing
-          title: Vanity URLs in S3 Static Publishing
-          tags: static publishing, push publishing, vanity urls, AWS S3
-          seoDescription: Learn how to enable and configure opt-in Vanity URL materialization for AWS S3 static publishing in dotCMS.
-          <!-- END_DOC_META -->
-          ```
-
-          The style of report depends upon a determination that must be made here:
-
-          - There is a chance that no documentation change is warranted. This is common when
-            the Epic delivers internal architecture work, bug fixes, or a feature that is
-            already fully documented. Some cases will be clear and some uncertain — evaluate
-            whether the Epic's delivery is both end-user relevant and documentable. If no
-            documentation is needed, the report must explain why. No `<!-- BEGIN_DOC_DRAFT -->`
-            token appears anywhere in no-documentation reports.
-
-          - There is a chance that relevant documentation exists but needs an update. If the
-            docs are not fully current with what the Epic delivered, the report should first
-            present a differential explaining what changes are necessary and where. After all
-            analysis, the report must end with the token `<!-- BEGIN_DOC_DRAFT -->` on its
-            own line, immediately followed by the **complete, final content of the page's
-            `documentation` field** — the full existing document with all proposed changes
-            already incorporated. This is not a diff and not an insertion fragment: it is the
-            entire field value as it should exist after the update, ready to be submitted to
-            the API as-is. The draft runs to the end of the file with no trailing content
-            after it.
-
-          - There is a chance that the Epic introduces something documentable with no
-            existing coverage. In this case, the report should include a differential on the
-            documentation gap, a list of appropriate tags, a short SEO description, a
-            description of what feature this documentation should be grouped with, and what
-            user personas it is most relevant to. After all analysis, the report must end
-            with the token `<!-- BEGIN_DOC_DRAFT -->` on its own line, immediately followed
-            by the complete draft of the new documentation page. The draft runs to the end
-            of the file with no trailing content after it.
-
-            When drafting the documentation page, use horizontal rules (`---`) sparingly.
-            Headings already provide clear visual and structural separation; `---` should
-            be reserved only for the most stark structural breaks and must not appear
-            between ordinary subsections.
-          PROMPTEOF
-
-      - name: Build eval context
+      - name: Run finalize (apply + post comment + commit)
+        working-directory: dotcms-aios/autodoc
         run: |
-          cat > /tmp/ctx.py << 'PYEOF'
-          import json, os, subprocess, sys
+          git config user.name "autodoc[bot]"
+          git config user.email "autodoc-bot@users.noreply.github.com"
 
-          epic_num = os.environ['EPIC_NUMBER']
-          repo     = os.environ['REPO']
-          MAX_COMMENT_CHARS = 4000
-
-          result = subprocess.run(
-              ['gh', 'issue', 'view', epic_num, '--repo', repo,
-               '--json', 'number,title,body,labels,state,url,'
-                         'closedByPullRequestsReferences,comments'],
-              capture_output=True, text=True, check=True)
-          epic = json.loads(result.stdout)
-
-          labels  = ', '.join(l['name'] for l in epic.get('labels', []))
-          pr_nums = [r['number'] for r in epic.get('closedByPullRequestsReferences', [])]
-
-          def render_comments(comments):
-              parts, skipped = [], 0
-              for c in (comments or []):
-                  body = (c.get('body') or '').strip()
-                  if not body:
-                      continue
-                  if len(body) > MAX_COMMENT_CHARS:
-                      skipped += 1
-                      continue
-                  login = (c.get('author') or {}).get('login', '?')
-                  parts.append(f'**{login}:** {body}')
-              out = '\n\n'.join(parts)
-              if skipped:
-                  out += (f'\n\n*({skipped} comment{"s" if skipped > 1 else ""}'
-                          f' omitted — exceeded {MAX_COMMENT_CHARS}-character limit)*')
-              return out
-
-          lines = [
-              '# Evaluation Context', '',
-              f'## Epic: #{epic["number"]} — {repo}',
-              f'**Title:** {epic["title"]}',
-              f'**URL:** {epic.get("url", "")}',
-              f'**State:** {epic.get("state", "?")}',
-              f'**Labels:** {labels or "(none)"}',
-              f'**Related PRs:** {", ".join(f"#{n}" for n in pr_nums) or "(none)"}',
-              '', '### Epic Body', '',
-              (epic.get('body') or '').strip(),
-          ]
-          ct = render_comments(epic.get('comments'))
-          if ct:
-              lines += ['', '### Comments', '', ct]
-
-          for pr_num in pr_nums:
-              r = subprocess.run(
-                  ['gh', 'pr', 'view', str(pr_num), '--repo', repo,
-                   '--json', 'number,title,body,state,mergedAt,author,comments'],
-                  capture_output=True, text=True)
-              if r.returncode != 0:
-                  continue
-              pr = json.loads(r.stdout)
-              author = (pr.get('author') or {}).get('login', '?')
-              lines += [
-                  '', '---', '',
-                  f'## Related PR: #{pr["number"]} — {pr["title"]}',
-                  f'**State:** {pr.get("state","?")}  |  '
-                  f'**Author:** {author}  |  '
-                  f'**Merged:** {pr.get("mergedAt") or "N/A"}',
-                  '',
-                  (pr.get('body') or '').strip(),
-              ]
-              pct = render_comments(pr.get('comments'))
-              if pct:
-                  lines += ['', '### Comments', '', pct]
-
-          g = subprocess.run(
-              ['grep', '-rl', f'/issues/{epic_num}', 'dotcms-aios/work/epics/'],
-              capture_output=True, text=True)
-          vault_file = g.stdout.strip().split('\n')[0] if g.stdout.strip() else ''
-          if vault_file:
-              lines += ['', '---', '', '## Vault Context', '',
-                        open(vault_file).read().strip()]
-          else:
-              print(f'warning: no vault file for Epic #{epic_num}', file=sys.stderr)
-
-          prompt = open('/tmp/burlap.txt').read().strip()
-          report_path = f'/tmp/Epic-{epic_num}_burlap.md'
-          lines += [
-              '', '---', '', '## Prompt: burlap', '', prompt,
-              '', '---', '',
-              f'**Report path:** `{report_path}`',
-              '',
-              'Use the Write tool to write the report to exactly that path.',
-          ]
-
-          with open('/tmp/eval_context.md', 'w') as f:
-              f.write('\n'.join(lines))
-          PYEOF
-          python3 /tmp/ctx.py
-
-      - name: Load eval context
-        id: eval_context
-        run: |
-          {
-            echo 'content<<__AUTODOC_EOF__'
-            cat /tmp/eval_context.md
-            echo '__AUTODOC_EOF__'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Compose Claude args
-        id: claude_args
-        env:
-          BEDROCK_MODEL_ID: ${{ vars.BEDROCK_MODEL_ID }}
-        run: |
-          ARGS="--allowedTools Bash,Write"
-          if [ -n "$BEDROCK_MODEL_ID" ]; then
-            ARGS="--model $BEDROCK_MODEL_ID $ARGS"
-          fi
-          echo "value=$ARGS" >> "$GITHUB_OUTPUT"
-
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          use_bedrock: ${{ vars.BEDROCK_ROLE_ARN != '' && 'true' || 'false' }}
-          prompt: ${{ steps.eval_context.outputs.content }}
-          claude_args: ${{ steps.claude_args.outputs.value }}
-          use_sticky_comment: 'false'
-          track_progress: 'false'
-
-      - name: Post report comment
-        run: |
-          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
-
-          if [ ! -f "$REPORT" ]; then
-            echo "No report at $REPORT — skipping finalize."
-            echo "ACTION=none" >> "$GITHUB_ENV"
-            exit 0
-          fi
-
-          # Build comment body: prepend idempotency marker and collapse the doc draft
-          # under a <details> block so the comment isn't a wall of text.
-          export REPORT
-          python3 << 'PYEOF'
-          import os
-          report = open(os.environ['REPORT']).read()
-          marker = '<!-- BEGIN_DOC_DRAFT -->'
-          if marker in report:
-              before, draft = report.split(marker, 1)
-              body = (before.rstrip()
-                      + '\n\n<details>\n<summary>Documentation Draft</summary>\n\n'
-                      + draft.lstrip('\n')
-                      + '\n</details>')
-          else:
-              body = report
-          with open('/tmp/comment_body.md', 'w') as f:
-              f.write('<!-- autodoc-report -->\n' + body.rstrip())
-          PYEOF
-
-          # Edit the existing autodoc comment if one exists, otherwise create a new one.
-          # --paginate ensures we search all comments, not just the first page.
-          EXISTING=$(gh api "repos/$REPO/issues/$EPIC_NUMBER/comments" --paginate \
-            --jq '[.[] | select(.body | contains("<!-- autodoc-report -->")) | .id] | first // empty')
-          if [ -n "$EXISTING" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$EXISTING" \
-              -F "body=@/tmp/comment_body.md"
-          else
-            gh issue comment "$EPIC_NUMBER" --repo "$REPO" --body-file /tmp/comment_body.md
-          fi
-
-          # Parse action and urlTitle from the machine-readable meta block and export
-          # for the downstream apply steps.
-          ACTION=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^action:/{print $2; exit}' "$REPORT")
-          URL_TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^urlTitle:/{sub(/^urlTitle:[[:space:]]*/,"");print;exit}' "$REPORT")
-          echo "ACTION=${ACTION:-none}" >> "$GITHUB_ENV"
-          echo "URL_TITLE=$URL_TITLE"   >> "$GITHUB_ENV"
-
-      - name: Apply doc update to dotCMS
-        if: env.ACTION == 'update'
-        run: |
-          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
-
-          # Validate urlTitle is a URL slug before interpolating into the JSON query.
-          # Non-slug chars (quotes, backslashes) would break the shell-built JSON payload.
-          if ! echo "$URL_TITLE" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
-            echo "urlTitle '${URL_TITLE}' is not a valid slug — skipping."
-            exit 0
-          fi
-
-          IDENTIFIER=$(curl -s --fail-with-body -X POST "$AUTODOC_DOTCMS_BASE_URL/api/es/search" \
-            -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
-            -H "Content-Type: application/json" \
-            -d "{\"query\":{\"query_string\":{\"query\":\"+contentType:DotcmsDocumentation +DotcmsDocumentation.urlTitle:\\\"$URL_TITLE\\\"\"}},\"size\":1}" \
-            | jq -r '(.esresponse[0].hits.hits[0]._source.identifier) // empty')
-
-          # Verify the identifier is UUID-shaped before placing it in a URL.
-          if ! echo "$IDENTIFIER" | grep -qE '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'; then
-            echo "No valid contentlet found for urlTitle '${URL_TITLE}' — skipping."
-            exit 0
-          fi
-
-          export REPORT IDENTIFIER
-          python3 << 'PYEOF'
-          import json, os
-          report = open(os.environ['REPORT']).read()
-          marker = '<!-- BEGIN_DOC_DRAFT -->'
-          draft = report.split(marker, 1)[1].lstrip('\n') if marker in report else ''
-          payload = {'contentlet': {
-              'identifier': os.environ['IDENTIFIER'],
-              'languageId': 1, 'documentation': draft,
-              'disabledWYSIWYG': ['documentation']}}
-          json.dump(payload, open('/tmp/payload.json', 'w'))
-          PYEOF
-
-          curl -s --fail-with-body -X PUT \
-            "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/EDIT?identifier=$IDENTIFIER" \
-            -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
-            -H "Content-Type: application/json" \
-            --data @/tmp/payload.json
-
-      - name: Apply doc create to dotCMS
-        if: env.ACTION == 'create'
-        run: |
-          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
-
-          # Validate urlTitle is a URL slug before interpolating into the JSON query.
-          if ! echo "$URL_TITLE" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
-            echo "urlTitle '${URL_TITLE}' is not a valid slug — skipping."
-            exit 0
-          fi
-
-          TITLE=$(awk '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^title:/{sub(/^title:[[:space:]]*/,"");print;exit}' "$REPORT")
-          TAGS=$(awk  '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^tags:/{sub(/^tags:[[:space:]]*/,"");print;exit}'  "$REPORT")
-          SEO=$(awk   '/BEGIN_DOC_META/{p=1;next} /END_DOC_META/{p=0} p && /^seoDescription:/{sub(/^seoDescription:[[:space:]]*/,"");print;exit}' "$REPORT")
-          export REPORT URL_TITLE TITLE TAGS SEO
-          python3 << 'PYEOF'
-          import json, os
-          report = open(os.environ['REPORT']).read()
-          marker = '<!-- BEGIN_DOC_DRAFT -->'
-          draft = report.split(marker, 1)[1].lstrip('\n') if marker in report else ''
-          sf = os.environ.get('AUTODOC_DOTCMS_SITE_FOLDER', '').strip()
-          payload = {'contentlet': {
-              'contentType': 'DotcmsDocumentation',
-              'urlTitle': os.environ['URL_TITLE'],
-              'title': os.environ['TITLE'],
-              'tag': os.environ['TAGS'],
-              'seoDescription': os.environ['SEO'],
-              'languageId': 1, 'documentation': draft,
-              'disabledWYSIWYG': ['documentation']}}
-          if sf:
-              payload['contentlet']['navFolder'] = sf
-          json.dump(payload, open('/tmp/payload.json', 'w'))
-          PYEOF
-
-          curl -s --fail-with-body -X PUT \
-            "$AUTODOC_DOTCMS_BASE_URL/api/v1/workflow/actions/default/fire/NEW" \
-            -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
-            -H "Content-Type: application/json" \
-            --data @/tmp/payload.json
-
+          uv run python scripts/finalize.py \
+            --epic "$EPIC_NUMBER" \
+            --prompt burlap \
+            --repo "$REPO"

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -321,12 +321,12 @@ jobs:
     secrets:
       AUTODOC_DOTCMS_API_TOKEN_AISEARCH: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_AISEARCH }}
       AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
-      AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
     with:
       prompt: ${{ needs.prep.outputs.eval_context }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       autodoc_dotcms_site_folder: ${{ vars.AUTODOC_DOTCMS_SITE_FOLDER }}
+      autodoc_dotcms_base_url: ${{ vars.AUTODOC_DOTCMS_BASE_URL }}
 
   finalize:
     name: Post report and apply to dotCMS
@@ -342,7 +342,7 @@ jobs:
       REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
-      AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
+      AUTODOC_DOTCMS_BASE_URL: ${{ vars.AUTODOC_DOTCMS_BASE_URL }}
       AUTODOC_DOTCMS_SITE_FOLDER: ${{ vars.AUTODOC_DOTCMS_SITE_FOLDER }}
 
     steps:

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -1,3 +1,25 @@
+# Automated documentation audit for closed issues.
+#
+# When an issue closes, this workflow decides whether its delivery warrants a
+# documentation change: it runs for Epics and for issues labeled
+# "Doc : Needs Doc" or "Changelog: Needs Doc", and skips sub-tasks of an Epic
+# (the Epic's own closure covers them).
+#
+# For qualifying issues it assembles the issue, its related PRs, and any
+# dotcms-aios vault context into an evaluation prompt, then runs Claude to
+# audit current documentation coverage via dotCMS AI semantic search. Claude
+# produces a report that determines one of three actions: none (no doc change
+# needed), update (revise an existing page), or create (draft a new page).
+# The report is posted as a comment on the issue, and update/create drafts
+# are applied to the dotCMS documentation site through its content API.
+#
+# Job structure:
+#   preflight → prep → claude (via ai-workflows/autodoc-executor) → finalize
+#
+# The claude job uses dotCMS/ai-workflows as a reusable workflow so that the
+# OIDC job_workflow_ref claim matches the trust condition on the
+# GitHubActions-BedrockCodeReview IAM role. prep and finalize run directly
+# in this workflow and do not touch AWS.
 name: Autodoc — Epic Documentation Audit
 
 on:
@@ -57,26 +79,21 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi
 
-  autodoc:
-    name: Run documentation audit
+  prep:
+    name: Build evaluation context
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
       contents: read
-      id-token: write
+      issues: read
+    outputs:
+      eval_context: ${{ steps.ctx.outputs.content }}
 
     env:
       EPIC_NUMBER: ${{ github.event.issue.number }}
       REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      # Used by the Claude subprocess when it executes the curl in burlap.txt — not called directly here.
-      AUTODOC_DOTCMS_API_TOKEN_AISEARCH: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_AISEARCH }}
-      AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
-      AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
-      AUTODOC_DOTCMS_SITE_FOLDER: ${{ secrets.AUTODOC_DOTCMS_SITE_FOLDER }}
 
     steps:
       - name: Checkout triggering repo
@@ -88,13 +105,6 @@ jobs:
           repository: dotCMS/dotcms-aios
           token: ${{ secrets.CI_MACHINE_TOKEN }}
           path: dotcms-aios
-
-      - name: Configure AWS credentials (Bedrock)
-        if: vars.BEDROCK_ROLE_ARN != ''
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.BEDROCK_ROLE_ARN }}
-          aws-region: ${{ vars.BEDROCK_AWS_REGION || 'us-east-1' }}
 
       - name: Write prompt
         run: |
@@ -200,6 +210,7 @@ jobs:
           PROMPTEOF
 
       - name: Build eval context
+        id: ctx
         run: |
           cat > /tmp/ctx.py << 'PYEOF'
           import json, os, subprocess, sys
@@ -283,7 +294,7 @@ jobs:
               print(f'warning: no vault file for Epic #{epic_num}', file=sys.stderr)
 
           prompt = open('/tmp/burlap.txt').read().strip()
-          report_path = f'/tmp/Epic-{epic_num}_burlap.md'
+          report_path = '/tmp/autodoc-report.md'
           lines += [
               '', '---', '', '## Prompt: burlap', '', prompt,
               '', '---', '',
@@ -297,39 +308,50 @@ jobs:
           PYEOF
           python3 /tmp/ctx.py
 
-      - name: Load eval context
-        id: eval_context
-        run: |
           {
             echo 'content<<__AUTODOC_EOF__'
             cat /tmp/eval_context.md
             echo '__AUTODOC_EOF__'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Compose Claude args
-        id: claude_args
-        env:
-          BEDROCK_MODEL_ID: ${{ vars.BEDROCK_MODEL_ID }}
-        run: |
-          ARGS="--allowedTools Bash,Write"
-          if [ -n "$BEDROCK_MODEL_ID" ]; then
-            ARGS="--model $BEDROCK_MODEL_ID $ARGS"
-          fi
-          echo "value=$ARGS" >> "$GITHUB_OUTPUT"
+  claude:
+    name: Run Claude (Bedrock)
+    needs: prep
+    uses: dotCMS/ai-workflows/.github/workflows/autodoc-executor.yml@v3.5.0
+    secrets: inherit
+    with:
+      prompt: ${{ needs.prep.outputs.eval_context }}
+      bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
+      model_id: ${{ vars.BEDROCK_MODEL_ID }}
 
-      - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+  finalize:
+    name: Post report and apply to dotCMS
+    needs: claude
+    if: always() && needs.claude.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    env:
+      EPIC_NUMBER: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AUTODOC_DOTCMS_API_TOKEN_DRAFTING: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_DRAFTING }}
+      AUTODOC_DOTCMS_BASE_URL: ${{ secrets.AUTODOC_DOTCMS_BASE_URL }}
+      AUTODOC_DOTCMS_SITE_FOLDER: ${{ secrets.AUTODOC_DOTCMS_SITE_FOLDER }}
+
+    steps:
+      - name: Download report artifact
+        uses: actions/download-artifact@v4
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          use_bedrock: ${{ vars.BEDROCK_ROLE_ARN != '' && 'true' || 'false' }}
-          prompt: ${{ steps.eval_context.outputs.content }}
-          claude_args: ${{ steps.claude_args.outputs.value }}
-          use_sticky_comment: 'false'
-          track_progress: 'false'
+          name: autodoc-report
+          path: /tmp/
+        continue-on-error: true
 
       - name: Post report comment
         run: |
-          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
+          REPORT="/tmp/autodoc-report.md"
 
           if [ ! -f "$REPORT" ]; then
             echo "No report at $REPORT — skipping finalize."
@@ -377,7 +399,7 @@ jobs:
       - name: Apply doc update to dotCMS
         if: env.ACTION == 'update'
         run: |
-          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
+          REPORT="/tmp/autodoc-report.md"
 
           # Validate urlTitle is a URL slug before interpolating into the JSON query.
           # Non-slug chars (quotes, backslashes) would break the shell-built JSON payload.
@@ -420,7 +442,7 @@ jobs:
       - name: Apply doc create to dotCMS
         if: env.ACTION == 'create'
         run: |
-          REPORT="/tmp/Epic-${EPIC_NUMBER}_burlap.md"
+          REPORT="/tmp/autodoc-report.md"
 
           # Validate urlTitle is a URL slug before interpolating into the JSON query.
           if ! echo "$URL_TITLE" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
@@ -456,4 +478,3 @@ jobs:
             -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING" \
             -H "Content-Type: application/json" \
             --data @/tmp/payload.json
-

--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -317,6 +317,9 @@ jobs:
   claude:
     name: Run Claude (Bedrock)
     needs: prep
+    permissions:
+      id-token: write
+      contents: read
     uses: dotCMS/ai-workflows/.github/workflows/autodoc-executor.yml@v3.5.0
     secrets:
       AUTODOC_DOTCMS_API_TOKEN_AISEARCH: ${{ secrets.AUTODOC_DOTCMS_API_TOKEN_AISEARCH }}
@@ -431,12 +434,21 @@ jobs:
           # live==false → a draft exists on top of the published version.
           #   modUser == service account → automation owns the draft → safe.
           #   modUser == anyone else     → human has an outstanding draft → skip.
-          CONTENT_CHECK=$(curl -s \
+          CONTENT_CHECK=$(curl -s --fail-with-body \
             "$AUTODOC_DOTCMS_BASE_URL/api/v1/content/$IDENTIFIER" \
             -H "Authorization: Bearer $AUTODOC_DOTCMS_API_TOKEN_DRAFTING")
-          IS_LIVE=$(echo "$CONTENT_CHECK" | jq -r '.entity.live // true')
+          if [ $? -ne 0 ]; then
+            echo "SKIP: content check request failed — cannot confirm draft ownership. Skipping to avoid clobbering a potential human edit."
+            exit 0
+          fi
+          IS_LIVE=$(echo "$CONTENT_CHECK" | jq -r '.entity.live // empty')
           MOD_USER=$(echo "$CONTENT_CHECK" | jq -r '.entity.modUser // ""')
           SERVICE_ACCOUNT='user-3244a6be-d28b-4d80-a3fc-9f66a1d832ae'
+
+          if [ -z "$IS_LIVE" ]; then
+            echo "SKIP: content check returned unexpected response — cannot confirm draft ownership. Skipping to avoid clobbering a potential human edit."
+            exit 0
+          fi
 
           if [ "$IS_LIVE" = "false" ] && [ "$MOD_USER" != "$SERVICE_ACCOUNT" ]; then
             echo "SKIP: outstanding draft last saved by '${MOD_USER}' (not the CI Autodoc service account)."


### PR DESCRIPTION
## What broke and why

The first real trigger of the new `prep → claude → finalize` job pipeline (#36495, closed after the OIDC restructure merged) failed in `Build evaluation context` with:

```
##[error]Invalid value. Matching delimiter not found '__AUTODOC_EOF__'
```

**Root cause:** the Python script wrote `/tmp/eval_context.md` via `'\n'.join(lines)` with no trailing newline. The file's last character was `.` (end of `"Use the Write tool to write the report to exactly that path."`). When `cat` piped that into `GITHUB_OUTPUT`, `echo '__AUTODOC_EOF__'` appended directly to that line rather than starting a new one. The runner looked for `__AUTODOC_EOF__` as a standalone line and never found it.

This code path was introduced in the OIDC restructure and had never run against a real issue before this trigger.

## Fixes

1. **Trailing newline:** `'\n'.join(lines) + '\n'` — ensures the delimiter lands on its own line.
2. **Random delimiter:** `openssl rand -hex 16` — defense-in-depth so no future issue or PR body can accidentally inject the closing token. This is the [GitHub-recommended pattern](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings) for multiline outputs.

Fixes #36949

🤖 Generated with [Claude Code](https://claude.com/claude-code)