### PR TITLE
fix(autodoc): trailing newline + random delimiter in eval context output

### DIFF
--- a/.github/workflows/issue_autodoc.yml
+++ b/.github/workflows/issue_autodoc.yml
@@ -304,14 +304,15 @@ jobs:
           ]
 
           with open('/tmp/eval_context.md', 'w') as f:
-              f.write('\n'.join(lines))
+              f.write('\n'.join(lines) + '\n')
           PYEOF
           python3 /tmp/ctx.py
 
+          DELIM="$(openssl rand -hex 16)"
           {
-            echo 'content<<__AUTODOC_EOF__'
+            echo "content<<${DELIM}"
             cat /tmp/eval_context.md
-            echo '__AUTODOC_EOF__'
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
   claude:


### PR DESCRIPTION
## What broke and why

The first real trigger of the `prep → claude → finalize` pipeline (#36495) failed in `Build evaluation context` with:

```
##[error]Invalid value. Matching delimiter not found '__AUTODOC_EOF__'
```

**Root cause:** the Python script wrote `/tmp/eval_context.md` via `'\n'.join(lines)` with no trailing newline. The file's last character was `.` (end of `"Use the Write tool to write the report to exactly that path."`). When `cat` piped that into `GITHUB_OUTPUT`, `echo '__AUTODOC_EOF__'` appended directly to the last line of content rather than starting a new one. The runner looked for `__AUTODOC_EOF__` as a standalone line and never found it.

This code path was introduced in the OIDC restructure and had never successfully run against a real issue before this trigger.

## Fixes

1. **Trailing newline:** `'\n'.join(lines) + '\n'` — ensures the delimiter always lands on its own line.
2. **Random delimiter:** `openssl rand -hex 16` — defense-in-depth so no future issue or PR body can accidentally inject the closing token. This is the [GitHub-recommended pattern](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings) for multiline outputs.

Fixes #36949

🤖 Generated with [Claude Code](https://claude.com/claude-code)