### PR TITLE
feat(evergreen-tracks): add a tracks input so latest can be moved without cutting a release

### DIFF
--- a/.github/workflows/cicd_evergreen-tracks-promote.yml
+++ b/.github/workflows/cicd_evergreen-tracks-promote.yml
@@ -1,6 +1,12 @@
 name: evergreen-tracks-promote
-# Advances the floating `standard` / `trailing` tags. `latest` is NOT touched here —
-# the release pipeline moves it on every GA cut (cicd_6-release.yml, --tracks latest).
+# Advances the floating `standard` / `trailing` tags. `latest` is owned by the release
+# pipeline, which moves it on every GA cut (cicd_6-release.yml, --tracks latest), so the
+# daily cron deliberately leaves it alone.
+#
+# The `tracks` dispatch input can still aim this workflow at `latest` — the break-glass
+# path for when a release cut moved everything EXCEPT latest (e.g. the 2026-08-12 Hub
+# 403, #37025), where the alternative was cutting a throwaway release to repoint a tag.
+# It is dispatch-only and lands behind the same approval gate as any other manual move.
 #
 # Two triggers, one engine:
 #   * SCHEDULE (daily, 06:00 ET) — runs plan → apply unattended. No human in the loop.
@@ -43,6 +49,10 @@ on:
         description: 'Min age (days) for the trailing track'
         required: false
         default: '28'
+      tracks:
+        description: 'Tracks to move (comma-separated: latest,standard,trailing)'
+        required: false
+        default: 'standard,trailing'
 
 permissions:
   contents: read
@@ -81,21 +91,24 @@ jobs:
           REPO: ${{ github.event.inputs.repo || 'dotcms/dotcms' }}
           STANDARD_DAYS: ${{ github.event.inputs.standard_days || '14' }}
           TRAILING_DAYS: ${{ github.event.inputs.trailing_days || '28' }}
+          TRACKS: ${{ github.event.inputs.tracks || 'standard,trailing' }}
           # Hub refuses ANONYMOUS pagination past offset 1000, and dotcms/dotcms is
           # ~79 pages, so even this read-only dry-run needs credentials.
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
         run: |
           echo "repo=$REPO (dry-run plan; trigger=${{ github.event_name }})"
-          # --tracks standard,trailing: this workflow never moves `latest` — the
-          # release pipeline owns it and moves it unattended (possibly mid-approval).
-          # Scoping here keeps the drift check below immune to `latest` churn.
+          # Default scope is standard,trailing: the release pipeline owns `latest` and
+          # moves it unattended (possibly mid-approval), so leaving it out keeps the
+          # drift check below immune to `latest` churn. Dispatching with tracks=latest
+          # deliberately opts INTO that check — if a GA cut repoints latest while the
+          # approval sits, apply refuses rather than fighting the release pipeline.
           # stderr goes to a file, not /dev/null: it must stay off stdout (that is
           # the plan text, diffed in `apply`) but discarding it cost us a whole
           # morning once — a Hub 403 surfaced as a bare "exit code 1".
           if ! PLAN=$(uv run evergreen-tracks promote \
             --repo "$REPO" \
-            --tracks standard,trailing \
+            --tracks "$TRACKS" \
             --standard-days "$STANDARD_DAYS" \
             --trailing-days "$TRAILING_DAYS" 2>plan.err); then
             echo "::error::evergreen-tracks promote (dry-run) failed:"
@@ -180,6 +193,8 @@ jobs:
           STANDARD_DAYS: ${{ github.event.inputs.standard_days || '14' }}
           TRAILING_DAYS: ${{ github.event.inputs.trailing_days || '28' }}
           APPROVED_PLAN: ${{ needs.plan.outputs.plan }}
+          # Must match the plan job exactly — `apply` diffs the two plans.
+          TRACKS: ${{ github.event.inputs.tracks || 'standard,trailing' }}
           # Needed for the READ path too, not just the mutation — see the plan job.
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
@@ -189,7 +204,7 @@ jobs:
           # between, fail rather than move tags nobody planned.
           if ! CURRENT_PLAN=$(uv run evergreen-tracks promote \
             --repo "$REPO" \
-            --tracks standard,trailing \
+            --tracks "$TRACKS" \
             --standard-days "$STANDARD_DAYS" \
             --trailing-days "$TRAILING_DAYS" 2>current.err); then
             echo "::error::evergreen-tracks promote (re-plan) failed:"
@@ -212,7 +227,7 @@ jobs:
           echo "repo=$REPO — plan unchanged; applying"
           uv run evergreen-tracks promote \
             --repo "$REPO" \
-            --tracks standard,trailing \
+            --tracks "$TRACKS" \
             --standard-days "$STANDARD_DAYS" \
             --trailing-days "$TRAILING_DAYS" \
             --apply
@@ -223,7 +238,7 @@ jobs:
           # ("standard (held) -> reconcile to standard_hold"): the engine really
           # does re-point that tag, so it must not be silently omitted here.
           MOVES=$(printf '%s\n' "$CURRENT_PLAN" \
-            | grep -E '^(standard|trailing) (\(held\) )?-> ' \
+            | grep -E '^(latest|standard|trailing) (\(held\) )?-> ' \
             | sed 's/ (sha256:.*//' || true)
           if [ -n "$MOVES" ]; then
             echo "moved=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Adds a `tracks` input to the promote workflow so `latest` can be repointed without cutting a release.

## Why

When the 2026-08-12 release cut failed to move `latest` (#37025 — Hub started refusing anonymous tag pagination), there was no supported way to fix it. The promote workflow hardcoded `--tracks standard,trailing`, the admin workflow only does taint/hold, and re-running the failed release job replays the pre-fix commit. We ended up cutting `26.08.12-02` — code-identical to `-01` apart from the CI fix — to move one floating tag. That works (verified below), but it rebuilds artifacts, redeploys to Artifactory, regenerates release notes and publishes a changelog entry to dev.dotcms.com, and leaves a phantom release in front of customers.

## What changes

| | before | after |
|---|---|---|
| daily cron | `standard,trailing` | `standard,trailing` (unchanged) |
| dispatch, no input | `standard,trailing` | `standard,trailing` (unchanged) |
| dispatch `tracks=latest` | not possible | moves `latest`, behind the approval gate |

A `schedule` event carries no inputs at all, so the `|| 'standard,trailing'` fallback is what keeps the cron on its current behaviour — same pattern the existing `repo` / `*_days` inputs already use.

`latest` stays owned by the release pipeline; this is explicitly the break-glass path, and the header comment says so. The apply job still holds the `evergreen-tracks-registry` lock, so it cannot race the release pipeline's latest-promote — and if a GA cut repoints `latest` while an approval sits, the existing drift check makes apply refuse rather than fight it, which is the outcome we want.

## Latent bug fixed along the way

The moved-summary grep matched only `^(standard|trailing)`, so a `latest` move would have applied correctly but reported `moved=false` and posted **no Slack notice**. Silent success is the one outcome this workflow exists to prevent. Now `^(latest|standard|trailing)`.

Worth flagging for review: this bug was invisible until the input existed, and it would have shown up as "we moved latest and nobody heard about it" — the same shape as the original incident.

## Verification

- YAML parses; `plan` and `apply` resolve `TRACKS` to the identical expression, which they must — `apply` diffs its re-derived plan against the approved one, so any divergence would fail every run.
- All three `--tracks` call sites now read `$TRACKS` (plan, apply's re-plan, apply's mutation).
- Empty/cron path resolves to `standard,trailing`.
- The engine plans a `latest`-only scope correctly against the live registry in 2 calls.
- End-to-end evidence that the underlying path is sound: release `26.08.12-02` ([run 31628506475](https://github.com/dotCMS/core/actions/runs/31628506475)) moved `latest` on both repos in 2 filtered calls each — `dotcms/dotcms` → `07e6e29f…`, `dotcms/dotcms-dev` → `982dc0fd…`, both matching `26.08.12-02`.

Closes: #37036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqQqV1iv96Db8AzBSWTXV4

This PR fixes: #37036