### PR TITLE
#36939: feat(roles): add DELETE /v1/roles/{roleId} for role deletion

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/AbstractRoleDeletionView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/AbstractRoleDeletionView.java
@@ -1,0 +1,62 @@
+package com.dotcms.rest.api.v1.system.role;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.immutables.value.Value;
+
+/**
+ * Result of deleting a role through {@code DELETE /v1/roles/{roleId}}.
+ * Reports the id of the removed role and how many users had the role at the moment of
+ * deletion — the deletion cascades, so those users lost the role (issue #36939).
+ *
+ * @author hassandotcms
+ * @since Aug 2026
+ */
+@Value.Style(typeImmutable = "*", typeAbstract = "Abstract*")
+@Value.Immutable
+@JsonSerialize(as = RoleDeletionView.class)
+@JsonDeserialize(as = RoleDeletionView.class)
+@Schema(description = "Role deletion result with the cascade blast radius")
+public interface AbstractRoleDeletionView {
+
+    /**
+     * Whether the role was deleted.
+     *
+     * @return {@code true} when the role was deleted
+     */
+    @Schema(
+            description = "Whether the role was deleted",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    boolean deleted();
+
+    /**
+     * Id of the deleted role.
+     *
+     * @return the deleted role's id
+     */
+    @Schema(
+            description = "Id of the deleted role",
+            example = "48190c8c-42c4-46af-8d1a-0cd5db894797",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String roleId();
+
+    /**
+     * Number of users the role was directly assigned to when it was deleted. The deletion
+     * cascades: the role was removed from every one of these users. Users who only inherited
+     * the role through the role hierarchy are not counted.
+     *
+     * @return count of directly-assigned users that lost the role
+     */
+    @Schema(
+            description = "Number of users the role was removed from by the cascading deletion. "
+                    + "Counts direct assignments only; users inheriting the role through the "
+                    + "role hierarchy are not included",
+            example = "3",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    int usersAffected();
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/ResponseEntityRoleDeletionView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/ResponseEntityRoleDeletionView.java
@@ -1,0 +1,16 @@
+package com.dotcms.rest.api.v1.system.role;
+
+import com.dotcms.rest.ResponseEntityView;
+
+/**
+ * Typed response wrapper for the {@code DELETE /v1/roles/{roleId}} endpoint (issue #36939).
+ *
+ * @author hassandotcms
+ * @since Aug 2026
+ */
+public class ResponseEntityRoleDeletionView extends ResponseEntityView<RoleDeletionView> {
+
+    public ResponseEntityRoleDeletionView(final RoleDeletionView entity) {
+        super(entity);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
@@ -7,6 +7,7 @@ import com.dotcms.business.WrapInTransaction;
 import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ConflictException;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.DuplicateRoleException;
 import com.dotmarketing.business.DuplicateRoleKeyException;
 import com.dotmarketing.business.Layout;
@@ -17,6 +18,9 @@ import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.exception.RoleNameException;
+import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
+import com.dotmarketing.portlets.workflows.model.WorkflowAction;
+import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
 import com.dotmarketing.util.ActivityLogger;
 import com.dotmarketing.util.AdminLogger;
 import com.dotmarketing.util.DateUtil;
@@ -151,6 +155,109 @@ public class RoleHelper {
                 "Date: " + date + "; User:" + modUser.getUserId() + "; RoleID: " + role.getId());
 
         return updatedRole;
+    }
+
+    /**
+     * Deletes an existing role. The deletion CASCADES — legacy parity with
+     * {@code RoleAPIImpl.delete}: the role is removed from every user that has it, all its
+     * permissions are stripped, and its layout assignments are detached before the role row
+     * is removed. Deletion is blocked only where legacy blocks it (see #36939):
+     * <ul>
+     *   <li>missing role → {@link DoesNotExistException} (404)</li>
+     *   <li>system or locked role → {@link DotSecurityException} (403)</li>
+     *   <li>role with children → {@link ConflictException} (409); the legacy DWR endpoint
+     *       silently returned {@code false} for this case</li>
+     *   <li>role referenced by a workflow action's Assign To → {@link ConflictException} (409),
+     *       pre-checked here because the same check inside {@code RoleAPIImpl.delete} is
+     *       swallowed by its catch(Exception) and would surface as a generic failure</li>
+     * </ul>
+     *
+     * No transaction wrapper here: the pre-flights are reads and {@code roleAPI.delete} is
+     * already transactional.
+     *
+     * @param roleId  id of the role to delete
+     * @param modUser authenticated user performing the deletion (audit logging)
+     * @return number of users the role was removed from by the cascade
+     */
+    public int deleteRole(final String roleId, final User modUser)
+            throws DotDataException, DotSecurityException {
+
+        final Role role = this.roleAPI.loadRoleById(roleId);
+        if (null == role || !UtilMethods.isSet(role.getId())) {
+            throw new DoesNotExistException("Role not found: " + roleId);
+        }
+
+        if (role.isSystem() || role.isLocked()) {
+            throw new DotSecurityException(
+                    String.format("Role '%s' (%s) is a system or locked role and cannot be deleted",
+                            role.getName(), role.getId()));
+        }
+
+        final List<String> children = role.getRoleChildren();
+        if (null != children && !children.isEmpty()) {
+            throw new ConflictException(String.format(
+                    "Role '%s' (%s) has %d child role(s) and cannot be deleted; delete or reparent its children first",
+                    role.getName(), role.getId(), children.size()));
+        }
+
+        this.checkNoDependentWorkflowActions(role);
+
+        final int usersAffected = this.roleAPI.findUserIdsForRole(role).size();
+
+        // the role row is gone after the delete, so the audit lines must carry enough to
+        // identify it (name/key) and its blast radius without a DB lookup
+        final String auditDetail = "Date: " + DateUtil.getCurrentDate()
+                + "; User:" + modUser.getUserId() + "; RoleID: " + role.getId()
+                + "; Name: " + role.getName() + "; Key: " + role.getRoleKey()
+                + "; UsersAffected: " + usersAffected;
+
+        ActivityLogger.logInfo(getClass(), "Deleting Role", auditDetail);
+        AdminLogger.log(getClass(), "Deleting Role", auditDetail);
+
+        try {
+            this.roleAPI.delete(role);
+        } catch (final DotDataException | DotStateException e) {
+            ActivityLogger.logInfo(getClass(), "Error Deleting Role", auditDetail);
+            AdminLogger.log(getClass(), "Error Deleting Role", auditDetail);
+            throw e;
+        }
+
+        ActivityLogger.logInfo(getClass(), "Role Deleted", auditDetail);
+        AdminLogger.log(getClass(), "Role Deleted", auditDetail);
+
+        return usersAffected;
+    }
+
+    /**
+     * Pre-flight version of {@code RoleAPIImpl#findDependentWorkflowActions}: any workflow
+     * action whose Assign To references the role blocks the deletion with a structured 409
+     * naming the offending schemes and actions.
+     *
+     * @param role the role about to be deleted
+     */
+    private void checkNoDependentWorkflowActions(final Role role)
+            throws DotDataException, DotSecurityException {
+
+        final WorkflowAPI workflowAPI = APILocator.getWorkflowAPI();
+        final User systemUser = APILocator.systemUser();
+        final StringBuilder schemesAndActions = new StringBuilder();
+        for (final WorkflowScheme scheme : workflowAPI.findSchemes(true)) {
+            final List<WorkflowAction> actions = workflowAPI.findActions(scheme, systemUser,
+                    (WorkflowAction action) -> role.getId().equals(action.getNextAssign()));
+            if (!actions.isEmpty()) {
+                final String conflictingActions = actions.stream()
+                        .map(WorkflowAction::getName)
+                        .collect(Collectors.joining(", "));
+                schemesAndActions.append(scheme.getName()).append(" [action(s) : ")
+                        .append(conflictingActions).append("] ");
+            }
+        }
+
+        if (schemesAndActions.length() > 0) {
+            throw new ConflictException(String.format(
+                    "Please remove all references to the '%s' Role from the following Workflow Scheme Actions: %s",
+                    role.getName(), schemesAndActions));
+        }
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
@@ -4,16 +4,32 @@ import com.dotcms.api.system.event.Payload;
 import com.dotcms.api.system.event.SystemEventType;
 import com.dotcms.api.system.event.SystemEventsAPI;
 import com.dotcms.business.WrapInTransaction;
+import com.dotcms.rest.exception.BadRequestException;
+import com.dotcms.rest.exception.ConflictException;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.DuplicateRoleException;
+import com.dotmarketing.business.DuplicateRoleKeyException;
 import com.dotmarketing.business.Layout;
 import com.dotmarketing.business.LayoutAPI;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.business.RoleAPI;
+import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.exception.RoleNameException;
+import com.dotmarketing.util.ActivityLogger;
+import com.dotmarketing.util.AdminLogger;
+import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.UtilMethods;
+import com.google.common.annotations.VisibleForTesting;
+import com.liferay.portal.model.User;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -21,7 +37,118 @@ import java.util.stream.Collectors;
  * Helper to encapsulate Roles logic
  * @author jsanca
  */
+@ApplicationScoped
 public class RoleHelper {
+
+    private final RoleAPI roleAPI;
+
+    public RoleHelper() {
+        this(APILocator.getRoleAPI());
+    }
+
+    @Inject
+    @VisibleForTesting
+    public RoleHelper(final RoleAPI roleAPI) {
+        this.roleAPI = roleAPI;
+    }
+
+    /**
+     * Updates an existing role — name, key, description, can-grant flags, and parent
+     * (reparent). Mirrors the legacy DWR {@code RoleAjax#updateRole} behavior: a null
+     * {@code parentRoleId} turns the role into a root role (parent == own id).
+     *
+     * Guards (see #36936):
+     * <ul>
+     *   <li>missing role or parent → {@link DoesNotExistException} (404)</li>
+     *   <li>system or locked role → {@link DotSecurityException} (403) — same condition
+     *       {@code RoleAPIImpl.save} enforces, surfaced cleanly</li>
+     *   <li>reparent to self or to a descendant (cycle) → {@link BadRequestException} (400);
+     *       net-new guard vs legacy, prevents hierarchy corruption</li>
+     *   <li>invalid name → {@link BadRequestException} (400); duplicate key/name →
+     *       {@link ConflictException} (409)</li>
+     * </ul>
+     *
+     * @param roleId   id of the role to update
+     * @param roleForm new field values (same shape POST /v1/roles consumes)
+     * @param modUser  authenticated user performing the change (audit logging)
+     * @return the updated {@link Role}
+     */
+    @WrapInTransaction
+    public Role updateRole(final String roleId, final RoleForm roleForm, final User modUser)
+            throws DotDataException, DotSecurityException {
+
+        final Role role = this.roleAPI.loadRoleById(roleId);
+        if (null == role || !UtilMethods.isSet(role.getId())) {
+            throw new DoesNotExistException("Role not found: " + roleId);
+        }
+
+        if (role.isSystem() || role.isLocked()) {
+            throw new DotSecurityException(
+                    String.format("Role '%s' (%s) is a system or locked role and cannot be updated",
+                            role.getName(), role.getId()));
+        }
+
+        role.setName(roleForm.getRoleName());
+        role.setRoleKey(roleForm.getRoleKey());
+        role.setEditUsers(roleForm.isCanEditUsers());
+        role.setEditPermissions(roleForm.isCanEditPermissions());
+        role.setEditLayouts(roleForm.isCanEditLayouts());
+        role.setDescription(roleForm.getDescription());
+
+        final String parentRoleId = roleForm.getParentRoleId();
+        if (Objects.nonNull(parentRoleId)) {
+
+            if (parentRoleId.equals(roleId)) {
+                throw new BadRequestException("A role cannot be its own parent: " + roleId);
+            }
+
+            final Role parentRole = this.roleAPI.loadRoleById(parentRoleId);
+            if (null == parentRole || !UtilMethods.isSet(parentRole.getId())) {
+                throw new DoesNotExistException("Parent role not found: " + parentRoleId);
+            }
+
+            // findRoleHierarchy walks getParent() up to the root, so it returns the proposed
+            // parent and all its ancestors — if the edited role is among them, the reparent
+            // would create a cycle
+            for (final Role ancestor : this.roleAPI.findRoleHierarchy(parentRole)) {
+                if (roleId.equals(ancestor.getId())) {
+                    throw new BadRequestException(String.format(
+                            "Cannot move role '%s' under '%s': the target parent is one of its descendants",
+                            roleId, parentRoleId));
+                }
+            }
+
+            role.setParent(parentRole.getId());
+        } else {
+            role.setParent(role.getId());
+        }
+
+        final String date = DateUtil.getCurrentDate();
+        ActivityLogger.logInfo(getClass(), "Modifying Role",
+                "Date: " + date + "; User:" + modUser.getUserId() + "; RoleID: " + role.getId());
+        AdminLogger.log(getClass(), "Modifying Role",
+                "Date: " + date + "; User:" + modUser.getUserId() + "; RoleID: " + role.getId());
+
+        final Role updatedRole;
+        try {
+            updatedRole = this.roleAPI.save(role);
+        } catch (final DuplicateRoleKeyException e) {
+            throw new ConflictException(
+                    "A role with key '" + roleForm.getRoleKey() + "' already exists", e);
+        } catch (final DuplicateRoleException e) {
+            throw new ConflictException(
+                    "A role named '" + roleForm.getRoleName() + "' already exists under the same parent", e);
+        } catch (final RoleNameException e) {
+            throw new BadRequestException("Role name is not valid: " + roleForm.getRoleName());
+        }
+
+        ActivityLogger.logInfo(getClass(), "Role Modified",
+                "Date: " + date + "; User:" + modUser.getUserId() + "; RoleID: " + role.getId());
+        AdminLogger.log(getClass(), "Role Modified",
+                "Date: " + date + "; User:" + modUser.getUserId() + "; RoleID: " + role.getId());
+
+        return updatedRole;
+    }
 
     /**
      * Saves only the existing layouts on layoutIds, any issue previous added not in the list will be removed

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
@@ -23,9 +23,9 @@ import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
+import org.apache.commons.beanutils.BeanUtils;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
  * Helper to encapsulate Roles logic
  * @author jsanca
  */
-@ApplicationScoped
 public class RoleHelper {
 
     private final RoleAPI roleAPI;
@@ -46,7 +45,6 @@ public class RoleHelper {
         this(APILocator.getRoleAPI());
     }
 
-    @Inject
     @VisibleForTesting
     public RoleHelper(final RoleAPI roleAPI) {
         this.roleAPI = roleAPI;
@@ -88,40 +86,45 @@ public class RoleHelper {
                             role.getName(), role.getId()));
         }
 
-        role.setName(roleForm.getRoleName());
-        role.setRoleKey(roleForm.getRoleKey());
-        role.setEditUsers(roleForm.isCanEditUsers());
-        role.setEditPermissions(roleForm.isCanEditPermissions());
-        role.setEditLayouts(roleForm.isCanEditLayouts());
-        role.setDescription(roleForm.getDescription());
-
+        // validate the parent BEFORE mutating anything — see the copy note below
         final String parentRoleId = roleForm.getParentRoleId();
+        Role parentRole = null;
         if (Objects.nonNull(parentRoleId)) {
 
             if (parentRoleId.equals(roleId)) {
                 throw new BadRequestException("A role cannot be its own parent: " + roleId);
             }
 
-            final Role parentRole = this.roleAPI.loadRoleById(parentRoleId);
+            parentRole = this.roleAPI.loadRoleById(parentRoleId);
             if (null == parentRole || !UtilMethods.isSet(parentRole.getId())) {
                 throw new DoesNotExistException("Parent role not found: " + parentRoleId);
             }
 
-            // findRoleHierarchy walks getParent() up to the root, so it returns the proposed
-            // parent and all its ancestors — if the edited role is among them, the reparent
-            // would create a cycle
-            for (final Role ancestor : this.roleAPI.findRoleHierarchy(parentRole)) {
-                if (roleId.equals(ancestor.getId())) {
-                    throw new BadRequestException(String.format(
-                            "Cannot move role '%s' under '%s': the target parent is one of its descendants",
-                            roleId, parentRoleId));
-                }
+            // reject the cycle: the edited role must not be an ancestor of the proposed parent
+            if (this.roleAPI.isParentRole(role, parentRole)) {
+                throw new BadRequestException(String.format(
+                        "Cannot move role '%s' under '%s': the target parent is one of its descendants",
+                        roleId, parentRoleId));
             }
-
-            role.setParent(parentRole.getId());
-        } else {
-            role.setParent(role.getId());
         }
+
+        // loadRoleById returns the cache-resident instance — apply the update to a detached
+        // copy so a save rejected by RoleAPIImpl (duplicate key/name, invalid name) cannot
+        // leave phantom values in the role cache
+        final Role roleToSave = new Role();
+        try {
+            BeanUtils.copyProperties(roleToSave, role);
+        } catch (final IllegalAccessException | InvocationTargetException e) {
+            throw new DotDataException("Error copying role for update: " + roleId, e);
+        }
+
+        roleToSave.setName(roleForm.getRoleName());
+        roleToSave.setRoleKey(roleForm.getRoleKey());
+        roleToSave.setEditUsers(roleForm.isCanEditUsers());
+        roleToSave.setEditPermissions(roleForm.isCanEditPermissions());
+        roleToSave.setEditLayouts(roleForm.isCanEditLayouts());
+        roleToSave.setDescription(roleForm.getDescription());
+        roleToSave.setParent(null != parentRole ? parentRole.getId() : role.getId());
 
         final String date = DateUtil.getCurrentDate();
         ActivityLogger.logInfo(getClass(), "Modifying Role",
@@ -131,7 +134,7 @@ public class RoleHelper {
 
         final Role updatedRole;
         try {
-            updatedRole = this.roleAPI.save(role);
+            updatedRole = this.roleAPI.save(roleToSave);
         } catch (final DuplicateRoleKeyException e) {
             throw new ConflictException(
                     "A role with key '" + roleForm.getRoleKey() + "' already exists", e);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
@@ -392,14 +392,14 @@ public class RoleResource implements Serializable {
 					content = @Content(mediaType = "application/json"))
 	})
 	@PUT
-	@Path("/{roleId}")
+	@Path("/{roleid}")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	public ResponseEntityRoleDetailView updateRole(
 			final @Context HttpServletRequest request,
 			final @Context HttpServletResponse response,
 			@Parameter(description = "Id of the role to update", required = true)
-			final @PathParam("roleId") String roleId,
+			final @PathParam("roleid") String roleId,
 			@io.swagger.v3.oas.annotations.parameters.RequestBody(
 				description = "Role information — same shape as POST /v1/roles",
 				required = true,

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
@@ -423,6 +423,63 @@ public class RoleResource implements Serializable {
 	}
 
 	/**
+	 * Deletes an existing role. The deletion CASCADES, matching the legacy behavior the old
+	 * Roles &amp; Tools portlet has always had: the role is removed from every user that has it,
+	 * all its permissions are deleted, and its layout (tool-group) assignments are detached.
+	 * Deletion is blocked only where legacy blocks it: roles with children (409), roles
+	 * referenced by a workflow action's Assign To (409), and system or locked roles (403).
+	 * The caller must be a backend user with access to the Roles portlet and the CMS
+	 * Administrator role.
+	 */
+	@Operation(
+		operationId = "deleteRole",
+		summary = "Delete a role",
+		description = "Deletes a role. The deletion CASCADES and is not reversible: the role is " +
+				"removed from all users that have it, all permissions granted to the role are " +
+				"deleted, and its layout (tool-group) assignments are detached. The response " +
+				"reports how many users were affected. Deletion is rejected when the role has " +
+				"child roles or is referenced by a workflow action's Assign To (409), and for " +
+				"system or locked roles (403)."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200",
+					description = "Role deleted successfully; usersAffected reports the cascade blast radius",
+					content = @Content(mediaType = "application/json",
+									  schema = @Schema(implementation = ResponseEntityRoleDeletionView.class))),
+		@ApiResponse(responseCode = "401",
+					description = "Unauthorized - authentication required",
+					content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "403",
+					description = "Forbidden - admin permissions required, or the role is a system or locked role",
+					content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "404",
+					description = "Role not found",
+					content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "409",
+					description = "Conflict - the role has child roles, or a workflow action references it",
+					content = @Content(mediaType = "application/json"))
+	})
+	@DELETE
+	@Path("/{roleId}")
+	@Produces(MediaType.APPLICATION_JSON)
+	public ResponseEntityRoleDeletionView deleteRole(
+			final @Context HttpServletRequest request,
+			final @Context HttpServletResponse response,
+			@Parameter(description = "Id of the role to delete", required = true)
+			final @PathParam("roleId") String roleId) throws DotDataException, DotSecurityException {
+
+		final User user = this.initRequireRolesPortletAndCmsAdmin(request, response);
+
+		final int usersAffected = this.roleHelper.deleteRole(roleId, user);
+
+		return new ResponseEntityRoleDeletionView(RoleDeletionView.builder()
+				.deleted(true)
+				.roleId(roleId)
+				.usersAffected(usersAffected)
+				.build());
+	}
+
+	/**
 	 * Saves set of layout into a role
 	 * The user must have to be a BE and has to have access to roles portlet
 	 */

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
@@ -53,6 +53,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -281,60 +282,141 @@ public class RoleResource implements Serializable {
 			)
 			final RoleForm roleForm) throws DotDataException, DotSecurityException {
 
+		final User user = this.initRequireRolesPortletAndCmsAdmin(request, response);
+
+		Role role = new Role();
+		role.setName(roleForm.getRoleName());
+		role.setRoleKey(roleForm.getRoleKey());
+		role.setEditUsers(roleForm.isCanEditUsers());
+		role.setEditPermissions(roleForm.isCanEditPermissions());
+		role.setEditLayouts(roleForm.isCanEditLayouts());
+		role.setDescription(roleForm.getDescription());
+
+		if(Objects.nonNull(roleForm.getParentRoleId())) {
+
+			final Role parentRole = roleAPI.loadRoleById(roleForm.getParentRoleId());
+			role.setParent(parentRole.getId());
+		}
+
+		final String date = DateUtil.getCurrentDate();
+
+		ActivityLogger.logInfo(getClass(), "Adding Role", "Date: " + date + "; "+ "User:" + user.getUserId());
+		AdminLogger.log(getClass(), "Adding Role", "Date: " + date + "; "+ "User:" + user.getUserId());
+
+		try {
+
+			role = roleAPI.save(role);
+		}  catch(RoleNameException e) {
+
+			ActivityLogger.logInfo(getClass(), "Error Adding Role. Invalid Name", "Date: " + date + ";  "+ "User:" + user.getUserId());
+			AdminLogger.log(getClass(), "Error Adding Role. Invalid Name", "Date: " + date + ";  "+ "User:" + user.getUserId());
+			throw new DotDataException(
+					Try.of(()->LanguageUtil.get(user,"Role-Save-Name-Failed")).getOrElse("Role Name not valid"),
+					"Role-Save-Name-Failed", e);
+
+		} catch(DotDataException | DotStateException e) {
+			ActivityLogger.logInfo(getClass(), "Error Adding Role", "Date: " + date + ";  "+ "User:" + user.getUserId());
+			AdminLogger.log(getClass(), "Error Adding Role", "Date: " + date + ";  "+ "User:" + user.getUserId());
+			throw e;
+		}
+
+		ActivityLogger.logInfo(getClass(), "Role Created", "Date: " + date + "; "+ "User:" + user.getUserId() + "; RoleID: " + role.getId() );
+		AdminLogger.log(getClass(), "Role Created", "Date: " + date + "; "+ "User:" + user.getUserId() + "; RoleID: " + role.getId() );
+
+		return Response.ok(new RoleResponseEntityView(role.toMap())).build();
+	}
+
+	/**
+	 * Shared authorization gate for the role-mutation endpoints (#36936–#36939): requires an
+	 * authenticated backend user with access to the Roles portlet AND the CMS Administrator
+	 * role. Rejections are security-logged.
+	 *
+	 * @return the authenticated, authorized user
+	 */
+	private User initRequireRolesPortletAndCmsAdmin(final HttpServletRequest request,
+			final HttpServletResponse response) throws DotDataException, DotSecurityException {
+
 		final InitDataObject initDataObject = new WebResource.InitBuilder(this.webResource)
 				.requiredFrontendUser(false).rejectWhenNoUser(true)
 				.requiredBackendUser(true).requiredPortlet("roles")
 				.requestAndResponse(request, response).init();
 
-		if (this.roleAPI.doesUserHaveRole(initDataObject.getUser(), this.roleAPI.loadCMSAdminRole())) {
+		final User user = initDataObject.getUser();
+		if (!this.roleAPI.doesUserHaveRole(user, this.roleAPI.loadCMSAdminRole())) {
 
-			final User user = initDataObject.getUser();
-			Role role = new Role();
-			role.setName(roleForm.getRoleName());
-			role.setRoleKey(roleForm.getRoleKey());
-			role.setEditUsers(roleForm.isCanEditUsers());
-			role.setEditPermissions(roleForm.isCanEditPermissions());
-			role.setEditLayouts(roleForm.isCanEditLayouts());
-			role.setDescription(roleForm.getDescription());
-
-			if(Objects.nonNull(roleForm.getParentRoleId())) {
-
-				final Role parentRole = roleAPI.loadRoleById(roleForm.getParentRoleId());
-				role.setParent(parentRole.getId());
-			}
-
-			final String date = DateUtil.getCurrentDate();
-
-			ActivityLogger.logInfo(getClass(), "Adding Role", "Date: " + date + "; "+ "User:" + user.getUserId());
-			AdminLogger.log(getClass(), "Adding Role", "Date: " + date + "; "+ "User:" + user.getUserId());
-
-			try {
-
-				role = roleAPI.save(role);
-			}  catch(RoleNameException e) {
-
-				ActivityLogger.logInfo(getClass(), "Error Adding Role. Invalid Name", "Date: " + date + ";  "+ "User:" + user.getUserId());
-				AdminLogger.log(getClass(), "Error Adding Role. Invalid Name", "Date: " + date + ";  "+ "User:" + user.getUserId());
-				throw new DotDataException(
-						Try.of(()->LanguageUtil.get(initDataObject.getUser(),"Role-Save-Name-Failed")).getOrElse("Role Name not valid"),
-						"Role-Save-Name-Failed", e);
-
-			} catch(DotDataException | DotStateException e) {
-				ActivityLogger.logInfo(getClass(), "Error Adding Role", "Date: " + date + ";  "+ "User:" + user.getUserId());
-				AdminLogger.log(getClass(), "Error Adding Role", "Date: " + date + ";  "+ "User:" + user.getUserId());
-				throw e;
-			}
-
-			ActivityLogger.logInfo(getClass(), "Role Created", "Date: " + date + "; "+ "User:" + user.getUserId() + "; RoleID: " + role.getId() );
-			AdminLogger.log(getClass(), "Role Created", "Date: " + date + "; "+ "User:" + user.getUserId() + "; RoleID: " + role.getId() );
-
-			return Response.ok(new RoleResponseEntityView(role.toMap())).build();
+			SecurityLogger.logInfo(this.getClass(), "unauthorized attempt to modify roles by user "
+					+ user.getUserId() + " from " + request.getRemoteHost());
+			throw new DotSecurityException("User: '" + user.getUserId() + "' not authorized");
 		}
 
-		final String remoteIp = request.getRemoteHost();
-		SecurityLogger.logInfo(UserAjax.class, "unauthorized attempt to call create a role by user "+
-				initDataObject.getUser().getUserId() + " from " + remoteIp);
-		throw new DotSecurityException("User: '" +  initDataObject.getUser().getUserId() + "' not authorized");
+		return user;
+	}
+
+	/**
+	 * Updates an existing role — name, key, description, can-grant flags and parent
+	 * (reparent). A null {@code parentRoleId} turns the role into a root role, mirroring the
+	 * legacy DWR {@code RoleAjax#updateRole} behavior. System and locked roles are rejected.
+	 * The caller must be a backend user with access to the Roles portlet and the CMS
+	 * Administrator role.
+	 */
+	@Operation(
+		operationId = "updateRole",
+		summary = "Update a role",
+		description = "Updates an existing role's name, key, description, can-grant flags and parent. " +
+				"A null parentRoleId turns the role into a root role. Reparenting under the role's own " +
+				"descendant is rejected. System and locked roles cannot be updated. Note: the role is " +
+				"updated in place — grants and permissions attached to the role are preserved."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200",
+					description = "Role updated successfully",
+					content = @Content(mediaType = "application/json",
+									  schema = @Schema(implementation = ResponseEntityRoleDetailView.class))),
+		@ApiResponse(responseCode = "400",
+					description = "Bad request - invalid role name, or the reparent would create a hierarchy cycle",
+					content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "401",
+					description = "Unauthorized - authentication required",
+					content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "403",
+					description = "Forbidden - admin permissions required, or the role is a system or locked role",
+					content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "404",
+					description = "Role or parent role not found",
+					content = @Content(mediaType = "application/json")),
+		@ApiResponse(responseCode = "409",
+					description = "Conflict - duplicate role key, or duplicate role name under the same parent",
+					content = @Content(mediaType = "application/json"))
+	})
+	@PUT
+	@Path("/{roleId}")
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	public ResponseEntityRoleDetailView updateRole(
+			final @Context HttpServletRequest request,
+			final @Context HttpServletResponse response,
+			@Parameter(description = "Id of the role to update", required = true)
+			final @PathParam("roleId") String roleId,
+			@io.swagger.v3.oas.annotations.parameters.RequestBody(
+				description = "Role information — same shape as POST /v1/roles",
+				required = true,
+				content = @Content(schema = @Schema(implementation = RoleForm.class))
+			)
+			final RoleForm roleForm) throws DotDataException, DotSecurityException {
+
+		final User user = this.initRequireRolesPortletAndCmsAdmin(request, response);
+
+		final Role updatedRole = this.roleHelper.updateRole(roleId, roleForm, user);
+
+		// same response shape as GET /v1/roles/{roleid}
+		final List<RoleView> childrenRoles = new ArrayList<>();
+		final List<String> roleChildrenIdList = null != updatedRole.getRoleChildren()
+				? updatedRole.getRoleChildren() : new ArrayList<>();
+		for (final String childRoleId : roleChildrenIdList) {
+			childrenRoles.add(new RoleView(this.roleAPI.loadRoleById(childRoleId), new ArrayList<>()));
+		}
+
+		return new ResponseEntityRoleDetailView(new RoleView(updatedRole, childrenRoles));
 	}
 
 	/**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
@@ -363,8 +363,11 @@ public class RoleResource implements Serializable {
 		operationId = "updateRole",
 		summary = "Update a role",
 		description = "Updates an existing role's name, key, description, can-grant flags and parent. " +
-				"A null parentRoleId turns the role into a root role. Reparenting under the role's own " +
-				"descendant is rejected. System and locked roles cannot be updated. Note: the role is " +
+				"PUT is a full replace: every field of the role is overwritten from the request body, so " +
+				"clients must send the complete role representation — omitted fields are reset (booleans " +
+				"default to false, omitted roleKey/description are cleared, omitted parentRoleId reparents " +
+				"to root). A null parentRoleId turns the role into a root role. Reparenting under the role's " +
+				"own descendant is rejected. System and locked roles cannot be updated. Note: the role is " +
 				"updated in place — grants and permissions attached to the role are preserved."
 	)
 	@ApiResponses(value = {

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -15129,10 +15129,13 @@ paths:
   /v1/roles/{roleId}:
     put:
       description: "Updates an existing role's name, key, description, can-grant flags\
-        \ and parent. A null parentRoleId turns the role into a root role. Reparenting\
-        \ under the role's own descendant is rejected. System and locked roles cannot\
-        \ be updated. Note: the role is updated in place — grants and permissions\
-        \ attached to the role are preserved."
+        \ and parent. PUT is a full replace: every field of the role is overwritten\
+        \ from the request body, so clients must send the complete role representation\
+        \ — omitted fields are reset (booleans default to false, omitted roleKey/description\
+        \ are cleared, omitted parentRoleId reparents to root). A null parentRoleId\
+        \ turns the role into a root role. Reparenting under the role's own descendant\
+        \ is rejected. System and locked roles cannot be updated. Note: the role is\
+        \ updated in place — grants and permissions attached to the role are preserved."
       operationId: updateRole
       parameters:
       - description: Id of the role to update

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -15126,6 +15126,61 @@ paths:
       summary: Load user roles
       tags:
       - Roles
+  /v1/roles/{roleId}:
+    put:
+      description: "Updates an existing role's name, key, description, can-grant flags\
+        \ and parent. A null parentRoleId turns the role into a root role. Reparenting\
+        \ under the role's own descendant is rejected. System and locked roles cannot\
+        \ be updated. Note: the role is updated in place — grants and permissions\
+        \ attached to the role are preserved."
+      operationId: updateRole
+      parameters:
+      - description: Id of the role to update
+        in: path
+        name: roleId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleForm"
+        description: Role information — same shape as POST /v1/roles
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityRoleDetailView"
+          description: Role updated successfully
+        "400":
+          content:
+            application/json: {}
+          description: "Bad request - invalid role name, or the reparent would create\
+            \ a hierarchy cycle"
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: "Forbidden - admin permissions required, or the role is a system\
+            \ or locked role"
+        "404":
+          content:
+            application/json: {}
+          description: Role or parent role not found
+        "409":
+          content:
+            application/json: {}
+          description: "Conflict - duplicate role key, or duplicate role name under\
+            \ the same parent"
+      summary: Update a role
+      tags:
+      - Roles
   /v1/roles/{roleId}/layouts:
     get:
       description: Returns a collection of layouts associated to a role
@@ -35424,6 +35479,10 @@ components:
           type: string
         parent:
           type: string
+        roleChildren:
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleView"
         roleKey:
           type: string
         system:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -15126,64 +15126,6 @@ paths:
       summary: Load user roles
       tags:
       - Roles
-  /v1/roles/{roleId}:
-    put:
-      description: "Updates an existing role's name, key, description, can-grant flags\
-        \ and parent. PUT is a full replace: every field of the role is overwritten\
-        \ from the request body, so clients must send the complete role representation\
-        \ — omitted fields are reset (booleans default to false, omitted roleKey/description\
-        \ are cleared, omitted parentRoleId reparents to root). A null parentRoleId\
-        \ turns the role into a root role. Reparenting under the role's own descendant\
-        \ is rejected. System and locked roles cannot be updated. Note: the role is\
-        \ updated in place — grants and permissions attached to the role are preserved."
-      operationId: updateRole
-      parameters:
-      - description: Id of the role to update
-        in: path
-        name: roleId
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RoleForm"
-        description: Role information — same shape as POST /v1/roles
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseEntityRoleDetailView"
-          description: Role updated successfully
-        "400":
-          content:
-            application/json: {}
-          description: "Bad request - invalid role name, or the reparent would create\
-            \ a hierarchy cycle"
-        "401":
-          content:
-            application/json: {}
-          description: Unauthorized - authentication required
-        "403":
-          content:
-            application/json: {}
-          description: "Forbidden - admin permissions required, or the role is a system\
-            \ or locked role"
-        "404":
-          content:
-            application/json: {}
-          description: Role or parent role not found
-        "409":
-          content:
-            application/json: {}
-          description: "Conflict - duplicate role key, or duplicate role name under\
-            \ the same parent"
-      summary: Update a role
-      tags:
-      - Roles
   /v1/roles/{roleId}/layouts:
     get:
       description: Returns a collection of layouts associated to a role
@@ -15258,6 +15200,63 @@ paths:
             application/json: {}
           description: Role not found
       summary: Load role by role ID
+      tags:
+      - Roles
+    put:
+      description: "Updates an existing role's name, key, description, can-grant flags\
+        \ and parent. PUT is a full replace: every field of the role is overwritten\
+        \ from the request body, so clients must send the complete role representation\
+        \ — omitted fields are reset (booleans default to false, omitted roleKey/description\
+        \ are cleared, omitted parentRoleId reparents to root). A null parentRoleId\
+        \ turns the role into a root role. Reparenting under the role's own descendant\
+        \ is rejected. System and locked roles cannot be updated. Note: the role is\
+        \ updated in place — grants and permissions attached to the role are preserved."
+      operationId: updateRole
+      parameters:
+      - description: Id of the role to update
+        in: path
+        name: roleid
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleForm"
+        description: Role information — same shape as POST /v1/roles
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityRoleDetailView"
+          description: Role updated successfully
+        "400":
+          content:
+            application/json: {}
+          description: "Bad request - invalid role name, or the reparent would create\
+            \ a hierarchy cycle"
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: "Forbidden - admin permissions required, or the role is a system\
+            \ or locked role"
+        "404":
+          content:
+            application/json: {}
+          description: Role or parent role not found
+        "409":
+          content:
+            application/json: {}
+          description: "Conflict - duplicate role key, or duplicate role name under\
+            \ the same parent"
+      summary: Update a role
       tags:
       - Roles
   /v1/roles/{roleid}/rolehierarchyanduserroles:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -15126,6 +15126,51 @@ paths:
       summary: Load user roles
       tags:
       - Roles
+  /v1/roles/{roleId}:
+    delete:
+      description: "Deletes a role. The deletion CASCADES and is not reversible: the\
+        \ role is removed from all users that have it, all permissions granted to\
+        \ the role are deleted, and its layout (tool-group) assignments are detached.\
+        \ The response reports how many users were affected. Deletion is rejected\
+        \ when the role has child roles or is referenced by a workflow action's Assign\
+        \ To (409), and for system or locked roles (403)."
+      operationId: deleteRole
+      parameters:
+      - description: Id of the role to delete
+        in: path
+        name: roleId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityRoleDeletionView"
+          description: Role deleted successfully; usersAffected reports the cascade
+            blast radius
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: "Forbidden - admin permissions required, or the role is a system\
+            \ or locked role"
+        "404":
+          content:
+            application/json: {}
+          description: Role not found
+        "409":
+          content:
+            application/json: {}
+          description: "Conflict - the role has child roles, or a workflow action\
+            \ references it"
+      summary: Delete a role
+      tags:
+      - Roles
   /v1/roles/{roleId}/layouts:
     get:
       description: Returns a collection of layouts associated to a role
@@ -33323,6 +33368,29 @@ components:
           type: array
           items:
             type: string
+    ResponseEntityRoleDeletionView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/RoleDeletionView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
     ResponseEntityRoleDetailView:
       type: object
       properties:
@@ -35139,6 +35207,28 @@ components:
           type: boolean
         user:
           type: boolean
+    RoleDeletionView:
+      type: object
+      properties:
+        deleted:
+          type: boolean
+          description: Whether the role was deleted
+          example: true
+        roleId:
+          type: string
+          description: Id of the deleted role
+          example: 48190c8c-42c4-46af-8d1a-0cd5db894797
+        usersAffected:
+          type: integer
+          format: int32
+          description: Number of users the role was removed from by the cascading
+            deletion. Counts direct assignments only; users inheriting the role through
+            the role hierarchy are not included
+          example: 3
+      required:
+      - deleted
+      - roleId
+      - usersAffected
     RoleForm:
       type: object
       properties:

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -102,6 +102,7 @@ import org.junit.runners.Suite;
         ContentToStringUtilTest.class,
         CacheResourceIntegrationTest.class,
         InodeExistenceCheckIntegrationTest.class,
+        com.dotcms.rest.api.v1.system.role.RoleResourceIntegrationTest.class,
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -14,6 +14,7 @@ import com.dotcms.rest.api.v1.drive.ContentDriveKeywordSearchTest;
 import com.dotcms.rest.api.v1.drive.ContentDriveWorkflowArchiveStepTest;
 import com.dotcms.rest.api.v1.drive.ContentDriveWorkflowFilterTest;
 import com.dotcms.rest.api.v1.system.cache.CacheResourceIntegrationTest;
+import com.dotcms.rest.api.v1.system.role.RoleResourceIntegrationTest;
 import com.dotcms.security.apps.AppsAPIImplTest;
 import com.dotcms.telemetry.collectors.MetricTimeoutTest;
 import com.dotcms.telemetry.collectors.experiment.CountPagesWithAllEndedExperimentsMetricTypeTest;
@@ -102,7 +103,7 @@ import org.junit.runners.Suite;
         ContentToStringUtilTest.class,
         CacheResourceIntegrationTest.class,
         InodeExistenceCheckIntegrationTest.class,
-        com.dotcms.rest.api.v1.system.role.RoleResourceIntegrationTest.class,
+        RoleResourceIntegrationTest.class,
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
@@ -1,0 +1,421 @@
+package com.dotcms.rest.api.v1.system.role;
+
+import com.dotmarketing.exception.DoesNotExistException;
+import com.dotcms.datagen.RoleDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.mock.request.MockAttributeRequest;
+import com.dotcms.mock.request.MockHeaderRequest;
+import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
+import com.dotcms.mock.request.MockSessionRequest;
+import com.dotcms.mock.response.MockHttpResponse;
+import com.dotcms.rest.exception.BadRequestException;
+import com.dotcms.rest.exception.ConflictException;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.Role;
+import com.dotmarketing.business.RoleAPI;
+import com.dotmarketing.exception.DotSecurityException;
+import com.liferay.portal.ejb.UserTestUtil;
+import com.liferay.portal.model.User;
+import com.liferay.util.Base64;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration tests for the {@link RoleResource} role-mutation endpoints introduced for the
+ * Angular Roles &amp; Tools portlet migration (epic #36909).
+ *
+ * Covered here:
+ * - PUT /api/v1/roles/{roleId} (update role + reparent) — issue #36936
+ *
+ * These tests invoke the resource directly with mock authenticated requests, following the
+ * pattern established by {@code PermissionResourceIntegrationTest}.
+ *
+ * @author hassandotcms
+ */
+public class RoleResourceIntegrationTest {
+
+    private static RoleResource resource;
+    private static RoleAPI roleAPI;
+    private static Host testHost;
+    private static User limitedUser;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+
+        resource = new RoleResource();
+        roleAPI = APILocator.getRoleAPI();
+        testHost = new SiteDataGen().nextPersisted();
+
+        // Backend user WITHOUT roles-portlet access and WITHOUT the CMS admin role,
+        // for authorization tests
+        limitedUser = UserTestUtil.getUser("limiteduser", false, true);
+        final Role backendRole = roleAPI.loadBackEndUserRole();
+        if (!roleAPI.doesUserHaveRole(limitedUser, backendRole)) {
+            roleAPI.addRoleToUser(backendRole, limitedUser);
+        }
+    }
+
+    // ==================== Helpers ====================
+
+    private static HttpServletRequest adminRequest() {
+        final MockHeaderRequest request = new MockHeaderRequest(
+                new MockSessionRequest(
+                        new MockAttributeRequest(
+                                new MockHttpRequestIntegrationTest(testHost.getHostname(), "/").request())
+                                .request())
+                        .request());
+
+        request.setHeader("Authorization",
+                "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+        return request;
+    }
+
+    private static HttpServletRequest requestFor(final User user) {
+        final MockHeaderRequest request = new MockHeaderRequest(
+                new MockSessionRequest(
+                        new MockAttributeRequest(
+                                new MockHttpRequestIntegrationTest(testHost.getHostname(), "/").request())
+                                .request())
+                        .request());
+
+        request.getSession().setAttribute(com.liferay.portal.util.WebKeys.USER_ID, user.getUserId());
+        request.getSession().setAttribute(com.liferay.portal.util.WebKeys.USER, user);
+        return request;
+    }
+
+    private static RoleForm.Builder formFrom(final Role role) {
+        return new RoleForm.Builder()
+                .roleName(role.getName())
+                .roleKey(role.getRoleKey())
+                .description(role.getDescription())
+                .canEditUsers(role.isEditUsers())
+                .canEditPermissions(role.isEditPermissions())
+                .canEditLayouts(role.isEditLayouts());
+    }
+
+    private static String uniq() {
+        return Long.toString(System.nanoTime());
+    }
+
+    // ==================== PUT /v1/roles/{roleId} — #36936 ====================
+
+    /**
+     * Method to test: {@link RoleResource#updateRole(HttpServletRequest, HttpServletResponse, String, RoleForm)}
+     * Given Scenario: An admin updates every editable field of an existing role.
+     * Expected Result: 200; the response carries the updated role map and the changes are persisted.
+     */
+    @Test
+    public void testUpdateRole_success_updatesAllFields() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        final String newName = "updated-name-" + uniq();
+        final String newKey = "updated-key-" + uniq();
+        final String newDescription = "updated description";
+
+        final RoleForm form = new RoleForm.Builder()
+                .roleName(newName)
+                .roleKey(newKey)
+                .description(newDescription)
+                .canEditUsers(false)
+                .canEditPermissions(false)
+                .canEditLayouts(false)
+                .build();
+
+        final ResponseEntityRoleDetailView view = resource.updateRole(
+                adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+
+        final RoleView entity = view.getEntity();
+        assertNotNull(entity);
+        assertEquals(newName, entity.getName());
+        assertEquals(newKey, entity.getRoleKey());
+        assertFalse(entity.isEditUsers());
+
+        final Role reloaded = roleAPI.loadRoleById(role.getId());
+        assertEquals(newName, reloaded.getName());
+        assertEquals(newKey, reloaded.getRoleKey());
+        assertEquals(newDescription, reloaded.getDescription());
+        assertFalse(reloaded.isEditUsers());
+        assertFalse(reloaded.isEditPermissions());
+        assertFalse(reloaded.isEditLayouts());
+    }
+
+    /**
+     * Given Scenario: A child role is reparented under a different role.
+     * Expected Result: 200; the persisted role's parent is the new parent's id.
+     */
+    @Test
+    public void testUpdateRole_reparent_toAnotherRole() throws Exception {
+        final Role oldParent = new RoleDataGen().nextPersisted();
+        final Role newParent = new RoleDataGen().nextPersisted();
+        final Role child = new RoleDataGen().parent(oldParent.getId()).nextPersisted();
+
+        final RoleForm form = formFrom(child).parentRoleId(newParent.getId()).build();
+
+        final ResponseEntityRoleDetailView view = resource.updateRole(
+                adminRequest(), new MockHttpResponse().response(), child.getId(), form);
+
+        assertEquals(newParent.getId(), view.getEntity().getParent());
+        assertEquals(newParent.getId(), roleAPI.loadRoleById(child.getId()).getParent());
+    }
+
+    /**
+     * Given Scenario: A child role is updated with a null parentRoleId.
+     * Expected Result: 200; the role becomes a root role (parent == own id), matching legacy
+     * DWR behavior (RoleAjax#updateRole).
+     */
+    @Test
+    public void testUpdateRole_reparent_toRoot_whenParentNull() throws Exception {
+        final Role parent = new RoleDataGen().nextPersisted();
+        final Role child = new RoleDataGen().parent(parent.getId()).nextPersisted();
+
+        final RoleForm form = formFrom(child).parentRoleId(null).build();
+
+        final ResponseEntityRoleDetailView view = resource.updateRole(
+                adminRequest(), new MockHttpResponse().response(), child.getId(), form);
+
+        assertEquals(child.getId(), view.getEntity().getParent());
+        assertEquals(child.getId(), roleAPI.loadRoleById(child.getId()).getParent());
+    }
+
+    /**
+     * Given Scenario: A parent role is reparented under its own descendant (cycle).
+     * Expected Result: 400 BadRequestException and the hierarchy is unchanged. This guard is
+     * net-new vs legacy (the Dojo tree simply never offered the bad drop target).
+     */
+    @Test
+    public void testUpdateRole_reparent_cycle_badRequest() throws Exception {
+        final Role parent = new RoleDataGen().nextPersisted();
+        final Role child = new RoleDataGen().parent(parent.getId()).nextPersisted();
+        final String originalParentOfParent = parent.getParent();
+
+        final RoleForm form = formFrom(parent).parentRoleId(child.getId()).build();
+
+        try {
+            resource.updateRole(adminRequest(), new MockHttpResponse().response(), parent.getId(), form);
+            fail("Should have thrown BadRequestException for a hierarchy cycle");
+        } catch (final BadRequestException e) {
+            // expected
+        }
+
+        assertEquals(originalParentOfParent, roleAPI.loadRoleById(parent.getId()).getParent());
+        assertEquals(parent.getId(), roleAPI.loadRoleById(child.getId()).getParent());
+    }
+
+    /**
+     * Given Scenario: A role is reparented under itself.
+     * Expected Result: 400 BadRequestException.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testUpdateRole_reparent_toSelf_badRequest() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        final RoleForm form = formFrom(role).parentRoleId(role.getId()).build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+    }
+
+    /**
+     * Given Scenario: An admin attempts to update a system role.
+     * Expected Result: DotSecurityException (403). Legacy RoleAPIImpl.save blocks locked/system
+     * roles; the endpoint surfaces it as a clean 403 instead of a 500.
+     */
+    @Test(expected = DotSecurityException.class)
+    public void testUpdateRole_systemRole_forbidden() throws Exception {
+        // a user's individual role is flagged system=true on creation (RoleFactoryImpl#addUserRole)
+        final Role systemRole = roleAPI.getUserRole(limitedUser);
+        assertTrue(systemRole.isSystem());
+
+        final RoleForm form = formFrom(systemRole).roleName("renamed-" + uniq()).build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(), systemRole.getId(), form);
+    }
+
+    /**
+     * Given Scenario: An admin attempts to update a locked role.
+     * Expected Result: DotSecurityException (403).
+     */
+    @Test(expected = DotSecurityException.class)
+    public void testUpdateRole_lockedRole_forbidden() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+        roleAPI.lock(role);
+
+        try {
+            final RoleForm form = formFrom(role).roleName("renamed-" + uniq()).build();
+            resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+        } finally {
+            roleAPI.unLock(role);
+        }
+    }
+
+    /**
+     * Given Scenario: A role is updated to use another role's roleKey.
+     * Expected Result: 409 ConflictException (DuplicateRoleKeyException from RoleAPIImpl.save).
+     */
+    @Test(expected = ConflictException.class)
+    public void testUpdateRole_duplicateKey_conflict() throws Exception {
+        final Role roleA = new RoleDataGen().key("key-a-" + uniq()).nextPersisted();
+        final Role roleB = new RoleDataGen().key("key-b-" + uniq()).nextPersisted();
+
+        final RoleForm form = formFrom(roleB).roleKey(roleA.getRoleKey()).build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(), roleB.getId(), form);
+    }
+
+    /**
+     * Given Scenario: Two sibling roles under the same parent; one is renamed to the other's name.
+     * Expected Result: 409 ConflictException (DuplicateRoleException from RoleAPIImpl.save).
+     */
+    @Test(expected = ConflictException.class)
+    public void testUpdateRole_duplicateNameUnderSameParent_conflict() throws Exception {
+        final Role parent = new RoleDataGen().nextPersisted();
+        final Role roleA = new RoleDataGen().parent(parent.getId()).nextPersisted();
+        final Role roleB = new RoleDataGen().parent(parent.getId()).nextPersisted();
+
+        final RoleForm form = formFrom(roleB)
+                .roleName(roleA.getName())
+                .parentRoleId(parent.getId())
+                .build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(), roleB.getId(), form);
+    }
+
+    /**
+     * Given Scenario: A role is renamed to an invalid name (over the 100-char limit enforced by
+     * RoleAPIImpl.save's RoleNameException).
+     * Expected Result: 400 BadRequestException — a validation error, not a conflict.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testUpdateRole_invalidName_badRequest() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        final StringBuilder longName = new StringBuilder();
+        for (int i = 0; i <= 100; i++) {
+            longName.append('a');
+        }
+        final RoleForm form = formFrom(role).roleName(longName.toString()).build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+    }
+
+    /**
+     * Given Scenario: The roleId path parameter does not match any role.
+     * Expected Result: 404 DoesNotExistException.
+     */
+    @Test(expected = DoesNotExistException.class)
+    public void testUpdateRole_missingRole_notFound() throws Exception {
+        final RoleForm form = new RoleForm.Builder().roleName("whatever-" + uniq()).build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(),
+                UUID.randomUUID().toString(), form);
+    }
+
+    /**
+     * Given Scenario: The parentRoleId in the form does not match any role.
+     * Expected Result: 404 DoesNotExistException; the role is not modified.
+     */
+    @Test(expected = DoesNotExistException.class)
+    public void testUpdateRole_missingParent_notFound() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        final RoleForm form = formFrom(role).parentRoleId(UUID.randomUUID().toString()).build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+    }
+
+    /**
+     * Given Scenario: A backend user without the roles portlet and without the CMS admin role
+     * calls the endpoint.
+     * Expected Result: rejected with a security exception (403); the role is not modified.
+     */
+    @Test
+    public void testUpdateRole_nonAdmin_forbidden() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+        final String originalName = role.getName();
+
+        final RoleForm form = formFrom(role).roleName("hacked-" + uniq()).build();
+
+        try {
+            resource.updateRole(requestFor(limitedUser),
+                    new MockHttpResponse().response(), role.getId(), form);
+            fail("Should have thrown a security exception");
+        } catch (final DotSecurityException | com.dotcms.rest.exception.SecurityException e) {
+            // expected: the InitBuilder portlet gate throws the REST SecurityException (→ 403),
+            // the CMS-admin check throws DotSecurityException (→ 403)
+        }
+
+        assertEquals(originalName, roleAPI.loadRoleById(role.getId()).getName());
+    }
+
+    /**
+     * Given Scenario: A backend user WITH access to the roles portlet but WITHOUT the CMS admin
+     * role calls the endpoint. This exercises the CMS-admin gate specifically, as opposed to the
+     * portlet gate covered by {@link #testUpdateRole_nonAdmin_forbidden()}.
+     * Expected Result: rejected with a security exception (403); the role is not modified.
+     */
+    @Test
+    public void testUpdateRole_rolesPortletUserWithoutAdmin_forbidden() throws Exception {
+        final com.dotmarketing.business.Layout rolesLayout =
+                new com.dotcms.datagen.LayoutDataGen().portletIds("roles").nextPersisted();
+        final Role portletRole = new RoleDataGen().layout(rolesLayout).nextPersisted();
+        final User portletUser = UserTestUtil.getUser("rolesportletuser" + uniq(), false, true);
+        roleAPI.addRoleToUser(roleAPI.loadBackEndUserRole(), portletUser);
+        roleAPI.addRoleToUser(portletRole, portletUser);
+
+        final Role role = new RoleDataGen().nextPersisted();
+        final String originalName = role.getName();
+        final RoleForm form = formFrom(role).roleName("hacked-" + uniq()).build();
+
+        try {
+            resource.updateRole(requestFor(portletUser),
+                    new MockHttpResponse().response(), role.getId(), form);
+            fail("Should have thrown a security exception for a non-admin caller");
+        } catch (final DotSecurityException | com.dotcms.rest.exception.SecurityException e) {
+            // expected: the CMS-admin check
+        }
+
+        assertEquals(originalName, roleAPI.loadRoleById(role.getId()).getName());
+    }
+
+    /**
+     * Given Scenario: Regression guard — PR #36936 extracts the shared auth gate out of
+     * {@link RoleResource#addNewRole}. Creating a role through POST must keep working unchanged.
+     * Expected Result: 200; the role is persisted with the submitted fields.
+     */
+    @Test
+    public void testAddNewRole_regression_createStillWorks() throws Exception {
+        final String name = "created-role-" + uniq();
+
+        final RoleForm form = new RoleForm.Builder()
+                .roleName(name)
+                .roleKey("created-key-" + uniq())
+                .description("created by regression test")
+                .canEditUsers(true)
+                .canEditPermissions(true)
+                .canEditLayouts(true)
+                .build();
+
+        final Response restResponse = resource.addNewRole(
+                adminRequest(), new MockHttpResponse().response(), form);
+
+        assertEquals(200, restResponse.getStatus());
+        final Map<String, Object> entity =
+                ((RoleResponseEntityView) restResponse.getEntity()).getEntity();
+        assertNotNull(entity.get("id"));
+        assertEquals(name, roleAPI.loadRoleById((String) entity.get("id")).getName());
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
@@ -16,6 +16,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.business.RoleAPI;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.ejb.UserTestUtil;
 import com.liferay.portal.model.User;
 import com.liferay.util.Base64;
@@ -389,6 +390,42 @@ public class RoleResourceIntegrationTest {
         }
 
         assertEquals(originalName, roleAPI.loadRoleById(role.getId()).getName());
+    }
+
+    /**
+     * Given Scenario: PUT is a full replace — a minimal form (only the required roleName) is
+     * sent for a role that has key, description, can-grant flags, and a parent.
+     * Expected Result: every omitted field is overwritten: flags reset to false, roleKey and
+     * description become null, and the role is reparented to root. This pins the documented
+     * full-replace contract (clients must send the complete role representation) so any future
+     * drift to merge/PATCH semantics is a deliberate, test-breaking change.
+     */
+    @Test
+    public void testUpdateRole_fullReplace_omittedFieldsAreReset() throws Exception {
+        final Role parent = new RoleDataGen().nextPersisted();
+        final Role role = new RoleDataGen()
+                .parent(parent.getId())
+                .key("full-replace-key-" + uniq())
+                .description("full replace description")
+                .editUsers(true)
+                .editPermissions(true)
+                .editLayouts(true)
+                .nextPersisted();
+
+        final RoleForm minimalForm = new RoleForm.Builder()
+                .roleName(role.getName())
+                .build();
+
+        resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), minimalForm);
+
+        final Role reloaded = roleAPI.loadRoleById(role.getId());
+        assertFalse(reloaded.isEditUsers());
+        assertFalse(reloaded.isEditPermissions());
+        assertFalse(reloaded.isEditLayouts());
+        // the persistence layer normalizes omitted (null) values to empty strings
+        assertFalse(UtilMethods.isSet(reloaded.getRoleKey()));
+        assertFalse(UtilMethods.isSet(reloaded.getDescription()));
+        assertEquals(role.getId(), reloaded.getParent());
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
@@ -202,9 +202,21 @@ public class RoleResourceIntegrationTest {
     public void testUpdateRole_reparent_cycle_badRequest() throws Exception {
         final Role parent = new RoleDataGen().nextPersisted();
         final Role child = new RoleDataGen().parent(parent.getId()).nextPersisted();
-        final String originalParentOfParent = parent.getParent();
+        // pre-warm the role cache OUTSIDE the update's transaction — models production, where
+        // the edited role is already cached; entries created inside the failing transaction
+        // are rollback-evicted (CommitListenerCacheWrapper.put) and would mask the poisoning
+        roleAPI.loadRoleById(parent.getId());
 
-        final RoleForm form = formFrom(parent).parentRoleId(child.getId()).build();
+        final String originalParentOfParent = parent.getParent();
+        final String originalName = parent.getName();
+        final String originalKey = parent.getRoleKey();
+        final String originalDescription = parent.getDescription();
+
+        // the form also renames, so the post-rejection assertions can detect any partial mutation
+        final RoleForm form = formFrom(parent)
+                .roleName("cycle-rename-" + uniq())
+                .parentRoleId(child.getId())
+                .build();
 
         try {
             resource.updateRole(adminRequest(), new MockHttpResponse().response(), parent.getId(), form);
@@ -213,7 +225,11 @@ public class RoleResourceIntegrationTest {
             // expected
         }
 
-        assertEquals(originalParentOfParent, roleAPI.loadRoleById(parent.getId()).getParent());
+        final Role reloaded = roleAPI.loadRoleById(parent.getId());
+        assertEquals(originalName, reloaded.getName());
+        assertEquals(originalKey, reloaded.getRoleKey());
+        assertEquals(originalDescription, reloaded.getDescription());
+        assertEquals(originalParentOfParent, reloaded.getParent());
         assertEquals(parent.getId(), roleAPI.loadRoleById(child.getId()).getParent());
     }
 
@@ -267,32 +283,74 @@ public class RoleResourceIntegrationTest {
      * Given Scenario: A role is updated to use another role's roleKey.
      * Expected Result: 409 ConflictException (DuplicateRoleKeyException from RoleAPIImpl.save).
      */
-    @Test(expected = ConflictException.class)
+    @Test
     public void testUpdateRole_duplicateKey_conflict() throws Exception {
         final Role roleA = new RoleDataGen().key("key-a-" + uniq()).nextPersisted();
         final Role roleB = new RoleDataGen().key("key-b-" + uniq()).nextPersisted();
 
-        final RoleForm form = formFrom(roleB).roleKey(roleA.getRoleKey()).build();
+        // pre-warm the role cache OUTSIDE the update's transaction — models production, where
+        // the edited role is already cached; entries created inside the failing transaction
+        // are rollback-evicted (CommitListenerCacheWrapper.put) and would mask the poisoning
+        roleAPI.loadRoleById(roleB.getId());
 
-        resource.updateRole(adminRequest(), new MockHttpResponse().response(), roleB.getId(), form);
+        final String originalName = roleB.getName();
+        final String originalKey = roleB.getRoleKey();
+        final String originalDescription = roleB.getDescription();
+
+        final RoleForm form = formFrom(roleB)
+                .roleName("dup-key-rename-" + uniq())
+                .roleKey(roleA.getRoleKey())
+                .build();
+
+        try {
+            resource.updateRole(adminRequest(), new MockHttpResponse().response(), roleB.getId(), form);
+            fail("Should have thrown ConflictException for a duplicate role key");
+        } catch (final ConflictException e) {
+            // expected
+        }
+
+        // a rejected update must leave no trace — not in the DB and not in the role cache
+        final Role reloaded = roleAPI.loadRoleById(roleB.getId());
+        assertEquals(originalName, reloaded.getName());
+        assertEquals(originalKey, reloaded.getRoleKey());
+        assertEquals(originalDescription, reloaded.getDescription());
     }
 
     /**
      * Given Scenario: Two sibling roles under the same parent; one is renamed to the other's name.
      * Expected Result: 409 ConflictException (DuplicateRoleException from RoleAPIImpl.save).
      */
-    @Test(expected = ConflictException.class)
+    @Test
     public void testUpdateRole_duplicateNameUnderSameParent_conflict() throws Exception {
         final Role parent = new RoleDataGen().nextPersisted();
         final Role roleA = new RoleDataGen().parent(parent.getId()).nextPersisted();
         final Role roleB = new RoleDataGen().parent(parent.getId()).nextPersisted();
+
+        // pre-warm the role cache OUTSIDE the update's transaction — models production, where
+        // the edited role is already cached; entries created inside the failing transaction
+        // are rollback-evicted (CommitListenerCacheWrapper.put) and would mask the poisoning
+        roleAPI.loadRoleById(roleB.getId());
+
+        final String originalName = roleB.getName();
+        final String originalKey = roleB.getRoleKey();
+        final String originalDescription = roleB.getDescription();
 
         final RoleForm form = formFrom(roleB)
                 .roleName(roleA.getName())
                 .parentRoleId(parent.getId())
                 .build();
 
-        resource.updateRole(adminRequest(), new MockHttpResponse().response(), roleB.getId(), form);
+        try {
+            resource.updateRole(adminRequest(), new MockHttpResponse().response(), roleB.getId(), form);
+            fail("Should have thrown ConflictException for a duplicate role name");
+        } catch (final ConflictException e) {
+            // expected
+        }
+
+        final Role reloaded = roleAPI.loadRoleById(roleB.getId());
+        assertEquals(originalName, reloaded.getName());
+        assertEquals(originalKey, reloaded.getRoleKey());
+        assertEquals(originalDescription, reloaded.getDescription());
     }
 
     /**
@@ -300,7 +358,7 @@ public class RoleResourceIntegrationTest {
      * RoleAPIImpl.save's RoleNameException).
      * Expected Result: 400 BadRequestException — a validation error, not a conflict.
      */
-    @Test(expected = BadRequestException.class)
+    @Test
     public void testUpdateRole_invalidName_badRequest() throws Exception {
         final Role role = new RoleDataGen().nextPersisted();
 
@@ -308,9 +366,28 @@ public class RoleResourceIntegrationTest {
         for (int i = 0; i <= 100; i++) {
             longName.append('a');
         }
+        // pre-warm the role cache OUTSIDE the update's transaction — models production, where
+        // the edited role is already cached; entries created inside the failing transaction
+        // are rollback-evicted (CommitListenerCacheWrapper.put) and would mask the poisoning
+        roleAPI.loadRoleById(role.getId());
+
+        final String originalName = role.getName();
+        final String originalKey = role.getRoleKey();
+        final String originalDescription = role.getDescription();
+
         final RoleForm form = formFrom(role).roleName(longName.toString()).build();
 
-        resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+        try {
+            resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+            fail("Should have thrown BadRequestException for an invalid role name");
+        } catch (final BadRequestException e) {
+            // expected
+        }
+
+        final Role reloaded = roleAPI.loadRoleById(role.getId());
+        assertEquals(originalName, reloaded.getName());
+        assertEquals(originalKey, reloaded.getRoleKey());
+        assertEquals(originalDescription, reloaded.getDescription());
     }
 
     /**
@@ -329,13 +406,37 @@ public class RoleResourceIntegrationTest {
      * Given Scenario: The parentRoleId in the form does not match any role.
      * Expected Result: 404 DoesNotExistException; the role is not modified.
      */
-    @Test(expected = DoesNotExistException.class)
+    @Test
     public void testUpdateRole_missingParent_notFound() throws Exception {
         final Role role = new RoleDataGen().nextPersisted();
 
-        final RoleForm form = formFrom(role).parentRoleId(UUID.randomUUID().toString()).build();
+        // pre-warm the role cache OUTSIDE the update's transaction — models production, where
+        // the edited role is already cached; entries created inside the failing transaction
+        // are rollback-evicted (CommitListenerCacheWrapper.put) and would mask the poisoning
+        roleAPI.loadRoleById(role.getId());
 
-        resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+        final String originalName = role.getName();
+        final String originalKey = role.getRoleKey();
+        final String originalDescription = role.getDescription();
+        final String originalParent = role.getParent();
+
+        final RoleForm form = formFrom(role)
+                .roleName("missing-parent-rename-" + uniq())
+                .parentRoleId(UUID.randomUUID().toString())
+                .build();
+
+        try {
+            resource.updateRole(adminRequest(), new MockHttpResponse().response(), role.getId(), form);
+            fail("Should have thrown DoesNotExistException for a missing parent role");
+        } catch (final DoesNotExistException e) {
+            // expected
+        }
+
+        final Role reloaded = roleAPI.loadRoleById(role.getId());
+        assertEquals(originalName, reloaded.getName());
+        assertEquals(originalKey, reloaded.getRoleKey());
+        assertEquals(originalDescription, reloaded.getDescription());
+        assertEquals(originalParent, reloaded.getParent());
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
@@ -1,8 +1,12 @@
 package com.dotcms.rest.api.v1.system.role;
 
 import com.dotmarketing.exception.DoesNotExistException;
+import com.dotcms.datagen.LayoutDataGen;
 import com.dotcms.datagen.RoleDataGen;
 import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.WorkflowActionDataGen;
+import com.dotcms.datagen.WorkflowDataGen;
+import com.dotcms.datagen.WorkflowStepDataGen;
 import com.dotcms.mock.request.MockAttributeRequest;
 import com.dotcms.mock.request.MockHeaderRequest;
 import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
@@ -12,10 +16,16 @@ import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ConflictException;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Permission;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.Layout;
+import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.business.RoleAPI;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.workflows.model.WorkflowAction;
+import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
+import com.dotmarketing.portlets.workflows.model.WorkflowStep;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.ejb.UserTestUtil;
 import com.liferay.portal.model.User;
@@ -41,6 +51,7 @@ import static org.junit.Assert.fail;
  *
  * Covered here:
  * - PUT /api/v1/roles/{roleId} (update role + reparent) — issue #36936
+ * - DELETE /api/v1/roles/{roleId} (delete role, cascading) — issue #36939
  *
  * These tests invoke the resource directly with mock authenticated requests, following the
  * pattern established by {@code PermissionResourceIntegrationTest}.
@@ -97,6 +108,15 @@ public class RoleResourceIntegrationTest {
         request.getSession().setAttribute(com.liferay.portal.util.WebKeys.USER_ID, user.getUserId());
         request.getSession().setAttribute(com.liferay.portal.util.WebKeys.USER, user);
         return request;
+    }
+
+    private static HttpServletRequest anonymousRequest() {
+        return new MockHeaderRequest(
+                new MockSessionRequest(
+                        new MockAttributeRequest(
+                                new MockHttpRequestIntegrationTest(testHost.getHostname(), "/").request())
+                                .request())
+                        .request());
     }
 
     private static RoleForm.Builder formFrom(final Role role) {
@@ -555,5 +575,248 @@ public class RoleResourceIntegrationTest {
                 ((RoleResponseEntityView) restResponse.getEntity()).getEntity();
         assertNotNull(entity.get("id"));
         assertEquals(name, roleAPI.loadRoleById((String) entity.get("id")).getName());
+    }
+
+    // ==================== DELETE /v1/roles/{roleId} — #36939 ====================
+
+    /**
+     * Method to test: {@link RoleResource#deleteRole(HttpServletRequest, HttpServletResponse, String)}
+     * Given Scenario: An admin deletes a leaf role with no users, permissions, layouts, children,
+     * or workflow-action references.
+     * Expected Result: 200 with {deleted: true, roleId, usersAffected: 0}; the role no longer exists.
+     */
+    @Test
+    public void testDeleteRole_success_leafRole() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        final ResponseEntityRoleDeletionView view = resource.deleteRole(
+                adminRequest(), new MockHttpResponse().response(), role.getId());
+
+        final RoleDeletionView entity = view.getEntity();
+        assertNotNull(entity);
+        assertTrue(entity.deleted());
+        assertEquals(role.getId(), entity.roleId());
+        assertEquals(0, entity.usersAffected());
+
+        final Role reloaded = roleAPI.loadRoleById(role.getId());
+        assertTrue(null == reloaded || !UtilMethods.isSet(reloaded.getId()));
+    }
+
+    /**
+     * Given Scenario: The role being deleted is assigned to a user, grants a permission on a host,
+     * and has a layout attached. This mirrors what legacy RoleAPIImpl.delete has always done: it
+     * CASCADES — removes the role from every user, strips its permissions, detaches its layouts,
+     * then deletes.
+     * Expected Result: 200 (NOT 409 — deleting a role means revoking that access, legacy parity),
+     * usersAffected reports the blast radius, and every dependent row is gone.
+     *
+     * ⚠️ This test intentionally pins the cascade. If it starts failing because the endpoint began
+     * blocking on assigned users, that is removed functionality, not a fix — see #36939 decisions.
+     */
+    @Test
+    public void testDeleteRole_withUsersAssigned_cascades() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        final User member = UserTestUtil.getUser("cascadeuser" + uniq(), false, true);
+        roleAPI.addRoleToUser(role, member);
+        assertTrue(roleAPI.doesUserHaveRole(member, role));
+
+        final PermissionAPI permissionAPI = APILocator.getPermissionAPI();
+        permissionAPI.save(
+                new Permission(testHost.getPermissionId(), role.getId(), PermissionAPI.PERMISSION_READ, true),
+                testHost, APILocator.systemUser(), false);
+        assertFalse(permissionAPI.getPermissionsByRole(role, false).isEmpty());
+
+        final Layout layout = new LayoutDataGen().nextPersisted();
+        roleAPI.addLayoutToRole(layout, role);
+        assertFalse(APILocator.getLayoutAPI().loadLayoutsForRole(role).isEmpty());
+
+        final ResponseEntityRoleDeletionView view = resource.deleteRole(
+                adminRequest(), new MockHttpResponse().response(), role.getId());
+
+        final RoleDeletionView entity = view.getEntity();
+        assertTrue(entity.deleted());
+        assertEquals(1, entity.usersAffected());
+
+        final Role reloaded = roleAPI.loadRoleById(role.getId());
+        assertTrue(null == reloaded || !UtilMethods.isSet(reloaded.getId()));
+        assertFalse(roleAPI.doesUserHaveRole(member, role.getId()));
+        assertTrue(permissionAPI.getPermissionsByRole(role, false).isEmpty());
+        assertTrue(APILocator.getLayoutAPI().loadLayoutsForRole(role).isEmpty());
+    }
+
+    /**
+     * Given Scenario: The role has a child role.
+     * Expected Result: 409 ConflictException reporting the child count; neither role is modified.
+     * Legacy parity: DWR RoleAjax#deleteRole silently returns false for roles with children —
+     * the pre-flight surfaces the same block as a structured conflict.
+     */
+    @Test
+    public void testDeleteRole_withChildren_conflict() throws Exception {
+        final Role parent = new RoleDataGen().nextPersisted();
+        final Role child = new RoleDataGen().parent(parent.getId()).nextPersisted();
+
+        try {
+            resource.deleteRole(adminRequest(), new MockHttpResponse().response(), parent.getId());
+            fail("Should have thrown ConflictException for a role with children");
+        } catch (final ConflictException e) {
+            assertTrue("message should mention children: " + e.getMessage(),
+                    e.getMessage().toLowerCase().contains("child"));
+        }
+
+        assertNotNull(roleAPI.loadRoleById(parent.getId()));
+        assertEquals(parent.getId(), roleAPI.loadRoleById(child.getId()).getParent());
+    }
+
+    /**
+     * Given Scenario: A workflow action's "Assign To" (nextAssign) references the role.
+     * Expected Result: 409 ConflictException naming the workflow scheme and action; the role
+     * still exists. This dependency is enforced by RoleAPIImpl#findDependentWorkflowActions, but
+     * that check runs inside delete()'s catch(Exception) which re-wraps it into a generic
+     * DotDataException — the endpoint must pre-check it to produce this structured 409.
+     */
+    @Test
+    public void testDeleteRole_referencedByWorkflowAction_conflict() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        final WorkflowScheme scheme = new WorkflowDataGen()
+                .name("delete-role-scheme-" + uniq()).nextPersisted();
+        final WorkflowStep step = new WorkflowStepDataGen(scheme.getId()).nextPersisted();
+        final WorkflowAction action = new WorkflowActionDataGen(scheme.getId(), step.getId())
+                .nextAssign(role.getId())
+                .nextPersisted();
+
+        try {
+            resource.deleteRole(adminRequest(), new MockHttpResponse().response(), role.getId());
+            fail("Should have thrown ConflictException for a role referenced by a workflow action");
+        } catch (final ConflictException e) {
+            assertTrue("message should name the scheme: " + e.getMessage(),
+                    e.getMessage().contains(scheme.getName()));
+            assertTrue("message should name the action: " + e.getMessage(),
+                    e.getMessage().contains(action.getName()));
+        }
+
+        assertNotNull(roleAPI.loadRoleById(role.getId()));
+    }
+
+    /**
+     * Given Scenario: An admin attempts to delete a system role (a user's individual role is
+     * flagged system=true on creation).
+     * Expected Result: DotSecurityException (403); the role still exists.
+     */
+    @Test
+    public void testDeleteRole_systemRole_forbidden() throws Exception {
+        final Role systemRole = roleAPI.getUserRole(limitedUser);
+        assertTrue(systemRole.isSystem());
+
+        try {
+            resource.deleteRole(adminRequest(), new MockHttpResponse().response(), systemRole.getId());
+            fail("Should have thrown DotSecurityException for a system role");
+        } catch (final DotSecurityException e) {
+            // expected
+        }
+
+        assertNotNull(roleAPI.loadRoleById(systemRole.getId()));
+    }
+
+    /**
+     * Given Scenario: An admin attempts to delete a locked role.
+     * Expected Result: DotSecurityException (403); the role still exists. Legacy
+     * RoleAPIImpl.delete blocks locked roles with a DotStateException (~500); the pre-flight
+     * surfaces it as a clean 403.
+     */
+    @Test
+    public void testDeleteRole_lockedRole_forbidden() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+        roleAPI.lock(role);
+
+        try {
+            resource.deleteRole(adminRequest(), new MockHttpResponse().response(), role.getId());
+            fail("Should have thrown DotSecurityException for a locked role");
+        } catch (final DotSecurityException e) {
+            // expected
+        } finally {
+            roleAPI.unLock(role);
+        }
+
+        assertNotNull(roleAPI.loadRoleById(role.getId()));
+    }
+
+    /**
+     * Given Scenario: The roleId path parameter does not match any role.
+     * Expected Result: 404 DoesNotExistException (resource-wide convention).
+     */
+    @Test(expected = DoesNotExistException.class)
+    public void testDeleteRole_missingRole_notFound() throws Exception {
+        resource.deleteRole(adminRequest(), new MockHttpResponse().response(),
+                UUID.randomUUID().toString());
+    }
+
+    /**
+     * Given Scenario: An anonymous caller (no session user, no Authorization header) calls the
+     * endpoint.
+     * Expected Result: rejected by the InitBuilder's rejectWhenNoUser gate (401); the role
+     * still exists.
+     */
+    @Test
+    public void testDeleteRole_anonymous_unauthorized() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        try {
+            resource.deleteRole(anonymousRequest(),
+                    new MockHttpResponse().response(), role.getId());
+            fail("Should have thrown a security exception for an anonymous caller");
+        } catch (final com.dotcms.rest.exception.SecurityException e) {
+            // expected: rejectWhenNoUser → 401
+        }
+
+        assertNotNull(roleAPI.loadRoleById(role.getId()));
+    }
+
+    /**
+     * Given Scenario: A backend user without the roles portlet and without the CMS admin role
+     * calls the endpoint.
+     * Expected Result: rejected with a security exception (403); the role still exists.
+     */
+    @Test
+    public void testDeleteRole_nonAdmin_forbidden() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+
+        try {
+            resource.deleteRole(requestFor(limitedUser),
+                    new MockHttpResponse().response(), role.getId());
+            fail("Should have thrown a security exception");
+        } catch (final DotSecurityException | com.dotcms.rest.exception.SecurityException e) {
+            // expected: the InitBuilder portlet gate throws the REST SecurityException (→ 403),
+            // the CMS-admin check throws DotSecurityException (→ 403)
+        }
+
+        assertNotNull(roleAPI.loadRoleById(role.getId()));
+    }
+
+    /**
+     * Given Scenario: A backend user WITH access to the roles portlet but WITHOUT the CMS admin
+     * role calls the endpoint — exercises the CMS-admin gate specifically.
+     * Expected Result: rejected with a security exception (403); the role still exists.
+     */
+    @Test
+    public void testDeleteRole_rolesPortletUserWithoutAdmin_forbidden() throws Exception {
+        final Layout rolesLayout = new LayoutDataGen().portletIds("roles").nextPersisted();
+        final Role portletRole = new RoleDataGen().layout(rolesLayout).nextPersisted();
+        final User portletUser = UserTestUtil.getUser("rolesdeleteuser" + uniq(), false, true);
+        roleAPI.addRoleToUser(roleAPI.loadBackEndUserRole(), portletUser);
+        roleAPI.addRoleToUser(portletRole, portletUser);
+
+        final Role role = new RoleDataGen().nextPersisted();
+
+        try {
+            resource.deleteRole(requestFor(portletUser),
+                    new MockHttpResponse().response(), role.getId());
+            fail("Should have thrown a security exception for a non-admin caller");
+        } catch (final DotSecurityException | com.dotcms.rest.exception.SecurityException e) {
+            // expected: the CMS-admin check
+        }
+
+        assertNotNull(roleAPI.loadRoleById(role.getId()));
     }
 }


### PR DESCRIPTION
Adds `DELETE /v1/roles/{roleId}`, replacing DWR `RoleAjax#deleteRole` for the Angular portlet rewrite (#36909).

Delete cascades, same as legacy `RoleAPIImpl.delete`: role removed from all users, permissions deleted, layouts detached. Cascading (rather than the 409-on-users the issue suggested) keeps legacy behavior intact; the blast radius is returned as `usersAffected` (direct assignments) so the FE can warn before calling (#36930). Returns `{deleted, roleId, usersAffected}`.

Blocks: children → 409, workflow-action Assign To reference → 409 (pre-checked; inside `delete()` it degrades to a generic error), system/locked → 403. Auth: backend user + roles portlet + CMS admin (legacy gated on users-portlet only; tightened since this is destructive and token-scriptable — DWR path untouched until Dojo removal).

### Testing

10 new ITs in `RoleResourceIntegrationTest`, 26/26 green: happy path, cascade pinned (user/permission/layout rows verified gone), both 409s, 403 system/locked, 404, 401, both auth 403s.

resolved #36939 