### PR TITLE
fix(page): honor Expire Date in Future Time Machine on the Page JSON API (#36731)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -667,6 +667,16 @@ public class PageRenderUtil implements Serializable {
                 if(null != contentletMatchingTimeMachineDate){
                     return contentletMatchingTimeMachineDate;
                 }
+                // No version matched the Time Machine date. Falling back to the live version is only correct when
+                // the content has simply not been published *yet*; if it has already expired by the Time Machine
+                // date, the live version must NOT be brought back. This mirrors the expire-date guard that the
+                // traditional VTL path applies in ContainerLoader.
+                if (isExpiredAt(contentletIdentifier, timeMachineDate)) {
+                    Logger.debug(this, () -> String.format(
+                            "Contentlet '%s' has already expired by the Time Machine date. Excluding it",
+                            contentletIdentifier));
+                    return null;
+                }
                 //Now if no contentlet was found using time-machine Date, we'll try to find the latest live contentlet
                 return contentletAPI.findContentletByIdentifier(contentletIdentifier,true, resolveLanguageId, user, mode.respectAnonPerms);
             }
@@ -692,15 +702,47 @@ public class PageRenderUtil implements Serializable {
      * @return {@code true} if the Contentlet has a publish-date set, {@code false} otherwise.
      */
     boolean hasPublishOrExpireDateSet(final String identifier) {
+        return findIdentifier(identifier)
+                .filter(found -> null != found.getSysPublishDate() || null != found.getSysExpireDate())
+                .isPresent();
+    }
+
+    /**
+     * Determines whether the content behind the specified Identifier has already expired at the given
+     * Time Machine date; i.e., its {@code sysExpireDate} (Online To) is strictly before such a date.
+     * <p>Content with no expire date set never expires. The strict comparison keeps this check aligned
+     * with both the Time Machine SQL query -- which admits {@code tmDate <= sysexpire_date} -- and the
+     * VTL guard in {@code ContainerLoader}.</p>
+     *
+     * @param identifier      The Identifier of the Contentlet to check.
+     * @param timeMachineDate The Time Machine date the page is being previewed at.
+     *
+     * @return {@code true} if the content has expired at the specified date, {@code false} otherwise.
+     */
+    boolean isExpiredAt(final String identifier, final Date timeMachineDate) {
+        return findIdentifier(identifier)
+                .map(Identifier::getSysExpireDate)
+                .filter(timeMachineDate::after)
+                .isPresent();
+    }
+
+    /**
+     * Retrieves the {@link Identifier} object for the given Identifier ID, if it exists.
+     *
+     * @param identifier The Identifier ID to look up.
+     *
+     * @return The {@link Identifier}, or an empty Optional if it doesn't exist or cannot be read.
+     */
+    private Optional<Identifier> findIdentifier(final String identifier) {
         try {
-            final Identifier found = identifierAPI.find(identifier);
-            if (found != null && (found.getSysPublishDate() != null || found.getSysExpireDate() != null)) {
-                return true;
-            }
-        } catch (DotDataException e) {
+            final Identifier found = this.identifierAPI.find(identifier);
+            return null != found && UtilMethods.isSet(found.getId())
+                    ? Optional.of(found)
+                    : Optional.empty();
+        } catch (final DotDataException e) {
             Logger.error(this, "Error finding identifier: " + identifier, e);
+            return Optional.empty();
         }
-        return false;
     }
 
     /**
@@ -754,6 +796,15 @@ public class PageRenderUtil implements Serializable {
                         true);
                 if(contentlet.isPresent()) {
                      return contentlet.get();
+                }
+                // Same reasoning as in getSpecificContentlet: never let the live fallback bring back content
+                // that has already expired by the Time Machine date. Returning null here also prevents the
+                // mode.showLive lookup below from resurrecting it.
+                if (isExpiredAt(contentletIdentifier, timeMachineDate)) {
+                    Logger.debug(this, () -> String.format(
+                            "Contentlet '%s' has already expired by the Time Machine date. Excluding it",
+                            contentletIdentifier));
+                    return null;
                 }
                 final Optional<Contentlet> live = contentletAPI.findContentletByIdentifierOrFallback(
                         contentletIdentifier, true, languageId,

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/PageResourceTest.java
@@ -115,6 +115,7 @@ import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.Tuple;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -2721,6 +2722,81 @@ public class PageResourceTest {
             //When publish date is passed, we should still get only valid content since the base case only created expired content in the past, so we should only get valid content
             assertTrue("All content returned should be the valid - publish date provided",
                     validateAllContentletTitlesContaining(withFutureDatePassed, "Valid"));
+
+        } finally {
+            TimeZone.setDefault(defaultZone);
+        }
+    }
+
+    /**
+     * Method to test: {@link PageResource#loadJson}
+     * Given scenario: A headless page holds content that is live right now: one item expiring in 2 days,
+     *                 one expiring in 30 days, one that never expires, and one not published until day 20.
+     *                 The page is requested with a Time Machine date of now + 10 days.
+     * Expected result: The item whose Online To has passed at the Time Machine date is excluded, while the
+     *                 still-valid items are returned. Requesting now + 25 days additionally shows the
+     *                 not-yet-published item, proving the Online From fallback is preserved.
+     * @see <a href="https://github.com/dotCMS/core/issues/36731">#36731</a>
+     */
+    @Test
+    public void TestFutureTimeMachineExcludesLiveContentExpiredAtTimeMachineDate() throws Exception {
+        final TimeZone defaultZone = TimeZone.getDefault();
+        try {
+            final TimeZone utc = TimeZone.getTimeZone("UTC");
+            TimeZone.setDefault(utc);
+
+            // Reference date is NOW, so this content really is live at request time -- that is precisely the
+            // scenario in which the live fallback used to resurrect expired content.
+            final Date now = new Date();
+            final PageInfo pageInfo = createTestPageWithContentConfigs(List.of(
+                    ContentConfig.validWithExpiration("TM Live Expiring Soon", 1, 2),
+                    ContentConfig.validWithExpiration("TM Live Expiring Later", 1, 30),
+                    ContentConfig.neverExpires("TM Live Never Expires", 1),
+                    ContentConfig.neverExpires("TM Not Published Yet", -20)
+            ), now);
+
+            HttpServletResponseThreadLocal.INSTANCE.setResponse(this.response);
+            HttpServletRequestThreadLocal.INSTANCE.setRequest(this.request);
+            when(request.getAttribute(WebKeys.PAGE_MODE_PARAMETER)).thenReturn(PageMode.LIVE);
+            when(request.getAttribute(com.liferay.portal.util.WebKeys.USER)).thenReturn(user);
+            addPermission(host, user, PermissionAPI.INDIVIDUAL_PERMISSION_TYPE, PermissionAPI.PERMISSION_READ);
+
+            // Sanity check: with no Time Machine date the expiring content IS live and returned. Without this,
+            // the assertions below could pass simply because the content was never live to begin with.
+            final PageView livePageView = extractPageViewFromResponse(pageResource.loadJson(this.request,
+                    this.response, pageInfo.pageUri, PageMode.LIVE.name(), null, "1", null, null));
+            assertEquals("Content expiring in 2 days must be live right now", 1,
+                    validateContentletTitlesContainingInternal(livePageView, "TM Live Expiring Soon").matched);
+            assertEquals("Content with a future publish date must not be live yet", 0,
+                    validateContentletTitlesContainingInternal(livePageView, "TM Not Published Yet").matched);
+
+            // Time Machine 10 days ahead: past the Online To of "Expiring Soon", before the Online From of
+            // "Not Published Yet".
+            final String tenDaysAhead = now.toInstant().plus(Duration.ofDays(10)).toString();
+            final PageView tenDaysView = extractPageViewFromResponse(pageResource.loadJson(this.request,
+                    this.response, pageInfo.pageUri, PageMode.LIVE.name(), null, "1", null, tenDaysAhead));
+
+            assertEquals("Content expired at the Time Machine date must be excluded", 0,
+                    validateContentletTitlesContainingInternal(tenDaysView, "TM Live Expiring Soon").matched);
+            assertEquals("Content expiring after the Time Machine date must be included", 1,
+                    validateContentletTitlesContainingInternal(tenDaysView, "TM Live Expiring Later").matched);
+            assertEquals("Content with no expire date must be included", 1,
+                    validateContentletTitlesContainingInternal(tenDaysView, "TM Live Never Expires").matched);
+            assertEquals("Content not yet published at the Time Machine date must be excluded", 0,
+                    validateContentletTitlesContainingInternal(tenDaysView, "TM Not Published Yet").matched);
+
+            // Time Machine 25 days ahead: the scheduled content is now past its Online From, so the live
+            // fallback for the publish-date case must keep working.
+            final String twentyFiveDaysAhead = now.toInstant().plus(Duration.ofDays(25)).toString();
+            final PageView twentyFiveDaysView = extractPageViewFromResponse(pageResource.loadJson(this.request,
+                    this.response, pageInfo.pageUri, PageMode.LIVE.name(), null, "1", null, twentyFiveDaysAhead));
+
+            assertEquals("Content past its publish date must be included", 1,
+                    validateContentletTitlesContainingInternal(twentyFiveDaysView, "TM Not Published Yet").matched);
+            assertEquals("Expired content must stay excluded further into the future", 0,
+                    validateContentletTitlesContainingInternal(twentyFiveDaysView, "TM Live Expiring Soon").matched);
+            assertEquals("Content expiring after the Time Machine date must still be included", 1,
+                    validateContentletTitlesContainingInternal(twentyFiveDaysView, "TM Live Expiring Later").matched);
 
         } finally {
             TimeZone.setDefault(defaultZone);


### PR DESCRIPTION
### Proposed Changes
* **Fix the live fallback that resurrected expired content under Future Time Machine.** `PageRenderUtil` applies the Time Machine bounds correctly in its primary content query, but when that returned no match it fell back to a plain `findContentletByIdentifier(id, live=true, …)` — a lookup with no notion of publish/expire dates. Content that is live *today* but whose Online To has passed at the requested Time Machine date was therefore put straight back into the response. The fallback is now skipped when the content has already expired at that date, in both `getSpecificContentlet()` and `getContentletOrFallback()` (the `DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE` branch).
* **New `isExpiredAt()` / `findIdentifier()` helpers**, with `hasPublishOrExpireDateSet()` refactored onto the shared, null-safe Identifier lookup (cached via `IdentifierCache`).
* **Integration test** `PageResourceTest#TestFutureTimeMachineExcludesLiveContentExpiredAtTimeMachineDate` covering both boundaries on the JSON path.

### Why publish worked but expire failed
A not-yet-published contentlet never gets a live version — `VersionableAPIImpl.setLive()` returns early for a future publish date — so the `live=true` fallback returned `null` and it stayed excluded. An expiring contentlet *does* have a live version now, so the same fallback brought it back.

The traditional VTL path was unaffected because `ContainerLoader` re-checks `sysExpireDate` in Velocity (`ContainerLoader.java:300-302`); the JSON path serializes contentlets straight from `populateContainers()` and never runs that Velocity. The new check deliberately mirrors that guard's strict comparison, so both paths agree — and it matches the Time Machine SQL, which admits `tmDate <= sysexpire_date`.

### Checklist
- [x] Tests — new integration test passes (1/1); manually verified against a running instance
- [x] Translations — n/a, no user-facing strings
- [x] Security Implications Contemplated — none; the change only narrows what a Time Machine preview returns. No API signature, schema, permission or auth change.

### Additional Info

Existing expire-date tests did not catch this because they build all their content relative to `now + 365 days`, so it never has a live version and the faulty fallback returned `null` anyway. The new test uses a **now** reference date and asserts the content is live *before* the Time Machine request, so it cannot pass vacuously.

Verified end-to-end on a local instance with purpose-built fixtures (dates confirmed on the `identifier` rows):

| Fixture | Online From | Online To | live now |
|---|---|---|---|
| A | −1 h | **+6 h** | yes |
| B | −1 h | +30 d | yes |
| C | −1 h | — | yes |
| D | **+7 d** | — | no |

| Request | JSON path | VTL render path |
|---|---|---|
| No Time Machine date | `A, B, C` | `A, B, C` |
| `publishDate` = now + 12 h | `B, C` — **A excluded** | `B, C` |
| `publishDate` = now + 8 d | `B, C, D` — D past its Online From | `B, C, D` |

Both render paths agree at every point. Regression spot-checks: demo `/index` and `/store` unchanged with and without a Time Machine date; the LIVE front-end still shows A with Time Machine off; EDIT mode unaffected (it nullifies the Time Machine date by design, `PageRenderUtil.java:381-388`); PREVIEW mode drops expired content, consistent with LIVE and VTL; zero exceptions in the server log.

**Known gap:** `getContentletOrFallback()` only executes with `DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE=true`, which was `false` on the verification instance. That branch is covered by code symmetry with the fixed one, but is not exercised by a live run or the new test.

Fixes #36731

🤖 Generated with [Claude Code](https://claude.com/claude-code)
