### PR TITLE
chore(docker): bump OpenSearch 3.4 to 3.8 in migration example

### DIFF
--- a/docker/docker-compose-examples/single-node-os-migration/README.md
+++ b/docker/docker-compose-examples/single-node-os-migration/README.md
@@ -5,7 +5,7 @@ Runs two OpenSearch clusters side-by-side for ES → OpenSearch migration testin
 | Service | Version | URL |
 |---|---|---|
 | OpenSearch 1.x (primary) | 1.3.x | https://localhost:9200 |
-| OpenSearch 3.x (shadow) | 3.4.0 | https://localhost:9201 |
+| OpenSearch 3.x (shadow) | 3.8.0 | https://localhost:9201 |
 | OS 1.x Dashboards | 1.3.x | http://localhost:5601 |
 | OS 3.x Dashboards | 3.0.0 | http://localhost:5602 |
 | dotCMS | latest | http://localhost:8082 |

--- a/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
@@ -2,7 +2,7 @@
 #
 # Runs BOTH search backends side-by-side for the OS 1.x → OS 3.x migration:
 #   - OpenSearch 1.3.x  + OS Dashboards 1.3.x → http://localhost:5601
-#   - OpenSearch 3.4.0  + OS Dashboards 3.0.0  → http://localhost:5602
+#   - OpenSearch 3.8.0  + OS Dashboards 3.0.0  → http://localhost:5602
 #
 # dotCMS is configured to write to OpenSearch 1.x (primary) while OpenSearch 3.x
 # shadows the traffic. Flip DOT_ES_ENDPOINTS to the opensearch3 service URL
@@ -90,11 +90,11 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # OpenSearch 3.4.0  (shadow/target)
+  # OpenSearch 3.8.0  (shadow/target)
   # REST API → http://localhost:9201
   # ---------------------------------------------------------------------------
   opensearch3:
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.8.0
     environment:
       cluster.name: "opensearch3-cluster"
       discovery.type: "single-node"


### PR DESCRIPTION
## Summary
Updates single-node-os-migration compose stack to use OpenSearch 3.8.0 instead of 3.4.0.

## Changes
- `docker-compose.yml`: Updated opensearch3 service image tag from 3.4.0 to 3.8.0
- `README.md`: Updated version reference in service table

Closes #37047

🤖 Generated with Claude Code