### PR TITLE
fix(apps): stop silently wiping the App secrets store (#36724)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/app/ConfigService.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/ConfigService.java
@@ -1,11 +1,16 @@
 package com.dotcms.ai.app;
 
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.portal.model.User;
@@ -86,16 +91,33 @@ public class ConfigService {
     }
 
     private Optional<AppSecrets> getAiSecrets(final Host host, final User systemUser) {
-        // getOrElse, not get(): Try.get() unwraps by RETHROWING the failure, so the Try was doing
-        // nothing here. That went unnoticed while an unreadable App secrets store silently wiped
-        // itself and returned no secrets; since issue #36724 it raises instead, and this method
-        // would have propagated that into dotAI's config resolution rather than reporting the app
-        // as unconfigured -- unlike every other consumer, which degrades.
-        return Try
-                .of(() -> appsAPI.getSecrets(AppKeys.APP_KEY, false, host, systemUser))
-                .onFailure(e -> Logger.warnAndDebug(ConfigService.class,
-                        "Unable to read dotAI secrets; treating the app as unconfigured: "
-                                + e.getMessage(), e))
-                .getOrElse(Optional.empty());
+        // Only an unreadable secrets store degrades here; everything else keeps propagating.
+        //
+        // Try.get() rethrows the failure rather than swallowing it, and that is load-bearing:
+        // AppsAPIImpl raises InvalidLicenseException for dotAI on an unlicensed instance, and
+        // ConfigServiceTest.test_invalidLicense asserts it reaches the caller. An earlier revision of
+        // this PR replaced get() with getOrElse(Optional.empty()) on the mistaken reading that the
+        // Try was inert, which turned an invalid license into "the app is unconfigured".
+        //
+        // The reason for touching this at all: since issue #36724 an unreadable store raises where it
+        // previously wiped itself and returned nothing, so without the catch below that condition
+        // would propagate into dotAI's config resolution instead of reporting the app as
+        // unconfigured -- unlike every other consumer, which degrades.
+        try {
+            return appsAPI.getSecrets(AppKeys.APP_KEY, false, host, systemUser);
+        } catch (final DotRuntimeException e) {
+            if (!ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                throw e;
+            }
+            Logger.warnAndDebug(ConfigService.class,
+                    "App secrets store is unreadable; treating dotAI as unconfigured: "
+                            + e.getMessage(), e);
+            return Optional.empty();
+        } catch (final DotDataException | DotSecurityException e) {
+            Logger.warnAndDebug(ConfigService.class,
+                    "Unable to read dotAI secrets; treating the app as unconfigured: "
+                            + e.getMessage(), e);
+            return Optional.empty();
+        }
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/app/ConfigService.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/ConfigService.java
@@ -86,8 +86,16 @@ public class ConfigService {
     }
 
     private Optional<AppSecrets> getAiSecrets(final Host host, final User systemUser) {
+        // getOrElse, not get(): Try.get() unwraps by RETHROWING the failure, so the Try was doing
+        // nothing here. That went unnoticed while an unreadable App secrets store silently wiped
+        // itself and returned no secrets; since issue #36724 it raises instead, and this method
+        // would have propagated that into dotAI's config resolution rather than reporting the app
+        // as unconfigured -- unlike every other consumer, which degrades.
         return Try
                 .of(() -> appsAPI.getSecrets(AppKeys.APP_KEY, false, host, systemUser))
-                .get();
+                .onFailure(e -> Logger.warnAndDebug(ConfigService.class,
+                        "Unable to read dotAI secrets; treating the app as unconfigured: "
+                                + e.getMessage(), e))
+                .getOrElse(Optional.empty());
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
@@ -58,10 +58,18 @@ public class SiteAuthValidator implements AnalyticsValidator {
             } else {
                 Logger.warn(this, "HTTP Request object could not be retrieved");
             }
-            // Deliberately Exception, not just the checked DotDataException/DotSecurityException.
-            // Since issue #36724 the secrets store raises a DotRuntimeException when it cannot be
-            // read rather than silently wiping itself; that must surface as a normal validation
-            // failure on this analytics collection path, not as a raw runtime exception.
+            // An AnalyticsValidationException is this pipeline's own signal -- ContentAnalyticsUtil
+            // raises it when the site cannot be resolved from the Origin/Referer headers -- and it
+            // already carries the message the caller is meant to see. Rethrow it untouched; the
+            // broader catch below would otherwise re-wrap it as "Site Auth for Site 'null' could
+            // not be verified: <original>" and change that message.
+        } catch (final AnalyticsValidationException e) {
+            throw e;
+            // Otherwise deliberately Exception, not just the checked DotDataException /
+            // DotSecurityException. Since issue #36724 the secrets store raises a
+            // DotRuntimeException when it cannot be read rather than silently wiping itself; that
+            // must surface as a normal validation failure on this analytics collection path, not
+            // as a raw runtime exception escaping into the request.
         } catch (final Exception e) {
             final String errorMsg = String.format("Site Auth for Site '%s' could not be verified: %s",
                     null != currentSite ? currentSite.getHostname() : BLANK, ExceptionUtil.getErrorMessage(e));

--- a/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
@@ -6,6 +6,7 @@ import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
 import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.Secret;
 import com.dotcms.security.apps.SecretsStoreUnreadableException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.beans.Host;
@@ -61,18 +62,28 @@ public class SiteAuthValidator implements AnalyticsValidator {
             } else {
                 Logger.warn(this, "HTTP Request object could not be retrieved");
             }
-            // SecretsStoreUnreadableException is the addition to the original two. Since issue
-            // #36724 the secrets store raises when it cannot be read rather than silently wiping
-            // itself, and that must surface as an ordinary validation failure here rather than as a
-            // raw runtime exception escaping onto the analytics collection path.
+            // Matched on the CAUSE CHAIN rather than the thrown type. Since issue #36724 an
+            // unreadable secrets store raises instead of silently wiping itself, and that must
+            // surface as an ordinary validation failure here rather than escaping raw onto the
+            // analytics collection path. But SecretsStoreUnreadableException does not survive the
+            // journey: several `catch (Exception e) { throw new DotRuntimeException(e); }` layers
+            // sit between where it is raised and here -- SecretsKeyStoreHelper.loadValueFromStore
+            // being the one on this path -- so catching the specific type alone never matches in
+            // production.
             //
-            // Deliberately that exact type. Catching Exception also swallowed
-            // AnalyticsValidationException -- this pipeline's own signal, raised by
-            // ContentAnalyticsUtil when the site cannot be resolved from the Origin/Referer headers
-            // -- and re-wrapped it as "Site Auth for Site 'null' could not be verified: <original>",
-            // changing the message callers see. Naming the condition means that signal propagates
-            // on its own, with no rethrow clause needed to protect it.
-        } catch (final DotDataException | DotSecurityException | SecretsStoreUnreadableException e) {
+            // AnalyticsValidationException is deliberately NOT caught: it is this pipeline's own
+            // signal, raised by ContentAnalyticsUtil when the site cannot be resolved from the
+            // Origin/Referer headers, and already carries the message callers are meant to see.
+            // Catching Exception here swallowed it and re-wrapped it, which regressed
+            // AnalyticsValidatorUtilTest.
+        } catch (final DotDataException | DotSecurityException | DotRuntimeException e) {
+
+            if (e instanceof DotRuntimeException
+                    && !ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                // A database blip, a cache failure, a programming error -- stays loud rather than
+                // being reported as an invalid site auth.
+                throw (DotRuntimeException) e;
+            }
             final String errorMsg = String.format("Site Auth for Site '%s' could not be verified: %s",
                     null != currentSite ? currentSite.getHostname() : BLANK, ExceptionUtil.getErrorMessage(e));
             Logger.warnAndDebug(SiteAuthValidator.class, errorMsg, e);

--- a/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
@@ -5,6 +5,9 @@ import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
 import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.Secret;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.util.Logger;
@@ -58,19 +61,18 @@ public class SiteAuthValidator implements AnalyticsValidator {
             } else {
                 Logger.warn(this, "HTTP Request object could not be retrieved");
             }
-            // An AnalyticsValidationException is this pipeline's own signal -- ContentAnalyticsUtil
-            // raises it when the site cannot be resolved from the Origin/Referer headers -- and it
-            // already carries the message the caller is meant to see. Rethrow it untouched; the
-            // broader catch below would otherwise re-wrap it as "Site Auth for Site 'null' could
-            // not be verified: <original>" and change that message.
-        } catch (final AnalyticsValidationException e) {
-            throw e;
-            // Otherwise deliberately Exception, not just the checked DotDataException /
-            // DotSecurityException. Since issue #36724 the secrets store raises a
-            // DotRuntimeException when it cannot be read rather than silently wiping itself; that
-            // must surface as a normal validation failure on this analytics collection path, not
-            // as a raw runtime exception escaping into the request.
-        } catch (final Exception e) {
+            // SecretsStoreUnreadableException is the addition to the original two. Since issue
+            // #36724 the secrets store raises when it cannot be read rather than silently wiping
+            // itself, and that must surface as an ordinary validation failure here rather than as a
+            // raw runtime exception escaping onto the analytics collection path.
+            //
+            // Deliberately that exact type. Catching Exception also swallowed
+            // AnalyticsValidationException -- this pipeline's own signal, raised by
+            // ContentAnalyticsUtil when the site cannot be resolved from the Origin/Referer headers
+            // -- and re-wrapped it as "Site Auth for Site 'null' could not be verified: <original>",
+            // changing the message callers see. Naming the condition means that signal propagates
+            // on its own, with no rethrow clause needed to protect it.
+        } catch (final DotDataException | DotSecurityException | SecretsStoreUnreadableException e) {
             final String errorMsg = String.format("Site Auth for Site '%s' could not be verified: %s",
                     null != currentSite ? currentSite.getHostname() : BLANK, ExceptionUtil.getErrorMessage(e));
             Logger.warnAndDebug(SiteAuthValidator.class, errorMsg, e);

--- a/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteAuthValidator.java
@@ -7,8 +7,6 @@ import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.Secret;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.json.JSONObject;
@@ -60,7 +58,11 @@ public class SiteAuthValidator implements AnalyticsValidator {
             } else {
                 Logger.warn(this, "HTTP Request object could not be retrieved");
             }
-        } catch (final DotDataException | DotSecurityException e) {
+            // Deliberately Exception, not just the checked DotDataException/DotSecurityException.
+            // Since issue #36724 the secrets store raises a DotRuntimeException when it cannot be
+            // read rather than silently wiping itself; that must surface as a normal validation
+            // failure on this analytics collection path, not as a raw runtime exception.
+        } catch (final Exception e) {
             final String errorMsg = String.format("Site Auth for Site '%s' could not be verified: %s",
                     null != currentSite ? currentSite.getHostname() : BLANK, ExceptionUtil.getErrorMessage(e));
             Logger.warnAndDebug(SiteAuthValidator.class, errorMsg, e);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
@@ -12,10 +12,12 @@ import com.dotcms.jitsu.validators.AnalyticsValidatorUtil;
 import com.dotcms.jitsu.validators.SiteAuthValidator;
 import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.Secret;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.util.*;
@@ -267,6 +269,21 @@ public class ContentAnalyticsUtil {
             Logger.error(ContentAnalyticsUtil.class,
                     "Error retrieving app secrets for site: " + currentSite.getIdentifier(), e);
             return Collections.emptyMap();
+        } catch (final DotRuntimeException e) {
+            // An unreadable App secrets store raises since issue #36724, where it previously wiped
+            // itself and returned nothing. This method must keep degrading: it feeds
+            // EventAnalyticsProxyHelper.buildAuthHeader(), which is called outside proxy()'s try
+            // block, so propagating here turns every analytics proxy/ingest request into a 500.
+            // The exception arrives wrapped as a plain DotRuntimeException -- SecretCachedKeyStoreImpl
+            // and friends re-wrap it -- so recognise it through the cause chain, and let every other
+            // runtime failure (DB, cache) keep propagating rather than masquerading as "no secrets".
+            if (!ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                throw e;
+            }
+            Logger.debug(ContentAnalyticsUtil.class, () -> String.format(
+                    "App secrets store is unreadable; treating Content Analytics as unconfigured for site '%s'",
+                    currentSite.getIdentifier()));
+            return Collections.emptyMap();
         }
     }
 
@@ -306,6 +323,16 @@ public class ContentAnalyticsUtil {
         } catch (final DotDataException | DotSecurityException e) {
             Logger.error(ContentAnalyticsUtil.class,
                     "Error retrieving site key from app secrets for site: " + currentSite.getIdentifier(), e);
+            return Optional.empty();
+        } catch (final DotRuntimeException e) {
+            // Same reasoning as getAppSecrets() above: degrade on an unreadable store (see #36724),
+            // propagate anything else.
+            if (!ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                throw e;
+            }
+            Logger.debug(ContentAnalyticsUtil.class, () -> String.format(
+                    "App secrets store is unreadable; no Content Analytics site key available for site '%s'",
+                    currentSite.getIdentifier()));
             return Optional.empty();
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsHelper.java
@@ -2,6 +2,7 @@ package com.dotcms.rest.api.v1.apps;
 
 import static com.dotmarketing.util.UtilMethods.isNotSet;
 
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.rest.api.MultiPartUtils;
 import com.dotcms.rest.api.v1.apps.view.AppView;
 import com.dotcms.rest.api.v1.apps.view.SecretView;
@@ -14,6 +15,7 @@ import com.dotcms.security.apps.AppsAPI;
 import com.dotcms.security.apps.AppsUtil;
 import com.dotcms.security.apps.ParamDescriptor;
 import com.dotcms.security.apps.Secret;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
 import com.dotcms.security.apps.Type;
 import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.PaginationUtil;
@@ -25,6 +27,7 @@ import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.util.Logger;
@@ -63,6 +66,9 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
  * and forward it to AppsResource
  */
 class AppsHelper {
+
+    /** Reported as the "file" for an unreadable secrets store, mirroring the per-file YAML errors. */
+    private static final String SECRETS_STORE_FILE_NAME = "dotSecretsStore.p12";
 
     private final AppsAPI appsAPI;
     private final HostAPI hostAPI;
@@ -104,9 +110,11 @@ class AppsHelper {
     }
 
     /**
-     * Same as {@link #getAvailableDescriptorViews(User, String)} but also returns the list of
-     * YAML files that failed to load, so the REST layer can surface partial load failures via the
-     * response's {@code errors} field without preventing the successful apps from being listed.
+     * Same as {@link #getAvailableDescriptorViews(User, String)} but also returns the partial
+     * failures the REST layer should surface via the response's {@code errors} field without
+     * preventing the apps it could resolve from being listed: YAML descriptor files that failed to
+     * load, and -- since issue #36724 -- a secrets store this node cannot read, in which case the
+     * configuration counts are reported as zero rather than raising.
      */
     Tuple2<List<AppView>, List<AppDescriptorLoadError>> getAvailableDescriptorViewsWithErrors(
             final User user, final String filter) throws DotSecurityException, DotDataException {
@@ -118,7 +126,40 @@ class AppsHelper {
             appDescriptors = appDescriptors.stream().filter(appDescriptor -> appDescriptor.getName().matches(regexFilter)).collect(
                     Collectors.toList());
         }
-        final Set<String> siteIdentifiers = appsAPI.appKeysByHost().keySet();
+        final List<AppDescriptorLoadError> errors = new ArrayList<>(loadErrors);
+        // appKeysByHost() reads the secrets store, which raises when this node cannot open it
+        // (issue #36724, where it previously wiped the store and returned nothing). Note this is
+        // evaluated as the *argument* to the guarded filterSitesForAppKey below, so that method's
+        // own guard cannot help here -- the raise happens before it is entered.
+        //
+        // The listing degrades to zero counts rather than propagating, so the portlet still renders
+        // and the administrator can reach the rest of it. But it must not degrade *silently*: "0
+        // configurations" on the secrets screen reads as "your secrets are gone", which is the exact
+        // misreading that would prompt someone to re-enter them. So the condition rides this
+        // endpoint's existing partial-failure channel and is reported explicitly instead.
+        //
+        // Deliberately guarded here and not inside appKeysByHost(): removeApp(), removeSecretsForSite()
+        // and exportSecrets() all read it too, and an empty map would turn the removes into silent
+        // no-ops and make exportSecrets() write an empty backup that reports success -- worse than
+        // the bug this fixes. Those paths must keep raising.
+        Set<String> siteIdentifiers;
+        try {
+            siteIdentifiers = appsAPI.appKeysByHost().keySet();
+        } catch (final DotRuntimeException e) {
+            if (!ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                throw e;
+            }
+            Logger.warnAndDebug(AppsHelper.class,
+                    "App secrets store is unreadable on this node; listing apps with no configuration"
+                            + " counts. Stored secrets are intact.", e);
+            siteIdentifiers = Set.of();
+            errors.add(new AppDescriptorLoadError(SECRETS_STORE_FILE_NAME,
+                    "This node cannot read the App secrets store, so configuration counts are"
+                            + " unavailable. Existing secrets are intact and are not modified by this"
+                            + " condition; a node with the correct key still serves them. Check the"
+                            + " server log for the underlying cause.",
+                    AppDescriptorLoadError.SECRETS_STORE_UNREADABLE_ERROR_CODE));
+        }
         for (final AppDescriptor appDescriptor : appDescriptors) {
             final String appKey = appDescriptor.getKey();
             final int configurationsCount = appsAPI.filterSitesForAppKey(appKey, siteIdentifiers, user).size();
@@ -127,14 +168,15 @@ class AppsHelper {
         }
         final List<AppView> sorted = views.stream().sorted(compareByCountAndName)
                 .collect(CollectionsUtils.toImmutableList());
-        return Tuple.of(sorted, loadErrors);
+        return Tuple.of(sorted, List.copyOf(errors));
     }
 
     /**
      * Re-reads the app yaml directories to capture per-file load errors. Called from the list
      * endpoint only; the main descriptor path is still served from the cache in {@link AppsAPI}.
      */
-    private List<AppDescriptorLoadError> collectLoadErrors() {
+    @VisibleForTesting
+    List<AppDescriptorLoadError> collectLoadErrors() {
         try {
             return new AppDescriptorHelper().loadAppDescriptorsWithErrors()._2;
         } catch (Exception e) {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/apps/AppsResource.java
@@ -99,7 +99,7 @@ public class AppsResource {
                     helper.getAvailableDescriptorViewsWithErrors(user, filter);
             final List<ErrorEntity> errors = result._2.stream()
                     .map(error -> new ErrorEntity(
-                            "app-descriptor-load-error",
+                            error.getErrorCode(),
                             error.getMessage(),
                             error.getFileName()))
                     .collect(Collectors.toList());

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppDescriptorLoadError.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppDescriptorLoadError.java
@@ -3,20 +3,38 @@ package com.dotcms.security.apps;
 import java.io.Serializable;
 
 /**
- * Captures a per-file failure that occurred while {@link AppDescriptorHelper#loadAppDescriptors()}
- * was reading app YAML files. Used by the REST layer to report partial failures in the
- * {@code /api/v1/apps} response without preventing the successfully loaded apps from being listed.
+ * Captures a partial failure that the {@code /api/v1/apps} listing should report without preventing
+ * the apps it could resolve from being listed.
+ *
+ * <p>Originally this only carried per-file failures from {@link AppDescriptorHelper#loadAppDescriptors()}
+ * reading app YAML files, so the REST layer hardcoded a single error code. It now also carries the
+ * case where this node cannot read the App secrets store (issue #36724), which is a different
+ * condition an administrator needs to tell apart from a malformed descriptor — hence
+ * {@link #getErrorCode()}.
  */
 public class AppDescriptorLoadError implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /** Default code, kept for the YAML descriptor failures this class was introduced for. */
+    public static final String DESCRIPTOR_LOAD_ERROR_CODE = "app-descriptor-load-error";
+
+    /** The App secrets store exists but this node cannot read it. */
+    public static final String SECRETS_STORE_UNREADABLE_ERROR_CODE = "app-secrets-store-unreadable";
+
     private final String fileName;
     private final String message;
+    private final String errorCode;
 
     public AppDescriptorLoadError(final String fileName, final String message) {
+        this(fileName, message, DESCRIPTOR_LOAD_ERROR_CODE);
+    }
+
+    public AppDescriptorLoadError(final String fileName, final String message,
+            final String errorCode) {
         this.fileName = fileName;
         this.message = message;
+        this.errorCode = errorCode;
     }
 
     public String getFileName() {
@@ -25,5 +43,9 @@ public class AppDescriptorLoadError implements Serializable {
 
     public String getMessage() {
         return message;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -446,12 +446,16 @@ public class AppsAPIImpl implements AppsAPI {
                     // than reading as "0 configurations".
                     throw e;
                 }
-                // Deliberate consequence: against an unreadable store the Apps portlet LIST reports
-                // 0 configurations while opening an app's DETAIL raises, because getSecrets() is not
-                // swallowed. The list is a best-effort count, the detail view authoritative. It
-                // cannot be closed from here for the /api/* reason above; giving the list its own
-                // signal is tracked in issue #37061. The old wipe-then-recreate also reported 0, so
-                // this is not a regression.
+                // Deliberate consequence: against an unreadable store this method counts 0 for every
+                // site, while opening an app's DETAIL raises, because getSecrets() is not swallowed.
+                // The count is best-effort, the detail view authoritative.
+                //
+                // A bare 0 here would read as "your secrets are gone" on the Apps portlet, so the
+                // listing does not rely on it alone: AppsHelper.getAvailableDescriptorViewsWithErrors
+                // reports the condition explicitly through the endpoint's partial-failure channel
+                // (issue #37061, fixed in this PR). Note that guard has to live there rather than
+                // here, because appKeysByHost() raises while being evaluated as this method's own
+                // argument -- before this catch is ever reached.
                 // debug, not error, and deliberately so. This fires once per site per call, and
                 // EMAWebInterceptor.existsConfiguration reaches this method on every /api/* request
                 // -- measured at 32 ERROR lines from 16 requests on a two-site instance. Because the

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -423,8 +423,8 @@ public class AppsAPIImpl implements AppsAPI {
         return siteIdentifiers.stream().filter(id -> {
             try {
                 return hasAnySecrets(key, id, user);
-            } catch (Exception e) {
-                // Deliberately Exception, not just the checked DotDataException/DotSecurityException.
+            } catch (DotDataException | DotSecurityException | DotRuntimeException e) {
+                // DotRuntimeException is the addition, not a blanket catch (Exception).
                 // This method's contract is already "if the secrets cannot be determined for this
                 // site, treat it as having none" -- it logs and returns false. Since issue #36724 the
                 // secrets store raises a DotRuntimeException when it cannot be read rather than
@@ -444,6 +444,10 @@ public class AppsAPIImpl implements AppsAPI {
                 // tracked in issue #37061.
                 // Note the old wipe-then-recreate behaviour also reported 0, so this is not a
                 // regression.
+                //
+                // Deliberately these three types rather than Exception: a genuine programming error
+                // here -- an NPE inside hasAnySecrets, say -- should surface rather than be hidden
+                // as a wrong configuration count on a path this hot.
                 Logger.error(AppsAPIImpl.class,
                         String.format("Error getting secret from `%s` ", key), e);
             }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -12,6 +12,7 @@ import static com.dotmarketing.util.UtilMethods.isNotSet;
 import static com.dotmarketing.util.UtilMethods.isSet;
 import static java.util.Collections.emptyMap;
 
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.rest.api.v1.apps.view.SecretView.SecretViewSerializer;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
 import com.dotcms.util.LicenseValiditySupplier;
@@ -423,37 +424,36 @@ public class AppsAPIImpl implements AppsAPI {
         return siteIdentifiers.stream().filter(id -> {
             try {
                 return hasAnySecrets(key, id, user);
-            } catch (DotDataException | DotSecurityException | SecretsStoreUnreadableException e) {
-                // SecretsStoreUnreadableException is the addition, and deliberately that exact type
-                // rather than DotRuntimeException or Exception.
-                // This method's contract is already "if the secrets cannot be determined for this
-                // site, treat it as having none" -- it logs and returns false. Since issue #36724 the
-                // secrets store raises a DotRuntimeException when it cannot be read rather than
-                // silently wiping itself, and that slipped past the narrower catch: it escaped
-                // EMAWebInterceptor.intercept(), which the interceptor chain does not guard, turning
-                // an unreadable store into a 500 on every /api/* request. Every caller here
-                // (EMA, InitRunner, the Apps portlet counts, telemetry, SAML) expects a set, not a
-                // throw.
-                //
-                // One consequence is deliberate and worth knowing: against an unreadable store the
-                // Apps portlet LIST shows every app as 0 configurations, while opening an app's
-                // DETAIL still raises, because getSecrets() is not swallowed. The list is a
-                // best-effort count and the detail view is authoritative. The split cannot be
-                // closed from this side -- this same method is called by EMAWebInterceptor on every
-                // /api/* request, so raising here returns a 500 for the whole API. Surfacing the
-                // condition in the list needs its own signal path alongside AppDescriptorLoadError;
-                // tracked in issue #37061.
-                // Note the old wipe-then-recreate behaviour also reported 0, so this is not a
-                // regression.
-                //
-                // Deliberately these three types. Not Exception, because a genuine programming
-                // error -- an NPE inside hasAnySecrets, say -- should surface rather than hide as a
-                // wrong configuration count on a path this hot. And not DotRuntimeException either:
-                // that is dotCMS's general-purpose unchecked wrapper, so database blips and cache
-                // failures surface as one, and swallowing those here would report "0
-                // configurations" for what is really a transient infrastructure problem.
+            } catch (DotDataException | DotSecurityException e) {
+                // Pre-existing behaviour: this method's contract is "if the secrets for this site
+                // cannot be determined, treat it as having none".
                 Logger.error(AppsAPIImpl.class,
                         String.format("Error getting secret from `%s` ", key), e);
+            } catch (DotRuntimeException e) {
+                // Since issue #36724 an unreadable store raises instead of silently wiping itself.
+                // That must degrade here: EMAWebInterceptor reaches this method on every /api/*
+                // request and the interceptor chain does not guard it, so raising returns a 500 for
+                // the whole API.
+                //
+                // Matched on the CAUSE CHAIN rather than the thrown type. SecretsStoreUnreadableException
+                // does not survive the journey: there are nine `catch (Exception e) { throw new
+                // DotRuntimeException(e); }` re-wraps between where it is raised and here --
+                // SecretCachedKeyStoreImpl.containsKey is the one on this path -- so catching the
+                // specific type alone never matches in production. Matching the chain is robust to
+                // however many layers re-wrap it, and to a tenth being added later.
+                if (!ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                    // A database blip, a cache failure, a programming error. Those stay loud rather
+                    // than reading as "0 configurations".
+                    throw e;
+                }
+                // Deliberate consequence: against an unreadable store the Apps portlet LIST reports
+                // 0 configurations while opening an app's DETAIL raises, because getSecrets() is not
+                // swallowed. The list is a best-effort count, the detail view authoritative. It
+                // cannot be closed from here for the /api/* reason above; giving the list its own
+                // signal is tracked in issue #37061. The old wipe-then-recreate also reported 0, so
+                // this is not a regression.
+                Logger.error(AppsAPIImpl.class,
+                        String.format("App secrets store is unreadable; reporting no secrets for `%s` ", key), e);
             }
             return false;
         }).collect(Collectors.toCollection(LinkedHashSet::new));

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -423,7 +423,16 @@ public class AppsAPIImpl implements AppsAPI {
         return siteIdentifiers.stream().filter(id -> {
             try {
                 return hasAnySecrets(key, id, user);
-            } catch (DotDataException | DotSecurityException e) {
+            } catch (Exception e) {
+                // Deliberately Exception, not just the checked DotDataException/DotSecurityException.
+                // This method's contract is already "if the secrets cannot be determined for this
+                // site, treat it as having none" -- it logs and returns false. Since issue #36724 the
+                // secrets store raises a DotRuntimeException when it cannot be read rather than
+                // silently wiping itself, and that slipped past the narrower catch: it escaped
+                // EMAWebInterceptor.intercept(), which the interceptor chain does not guard, turning
+                // an unreadable store into a 500 on every /api/* request. Every caller here
+                // (EMA, InitRunner, the Apps portlet counts, telemetry, SAML) expects a set, not a
+                // throw.
                 Logger.error(AppsAPIImpl.class,
                         String.format("Error getting secret from `%s` ", key), e);
             }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -433,6 +433,16 @@ public class AppsAPIImpl implements AppsAPI {
                 // an unreadable store into a 500 on every /api/* request. Every caller here
                 // (EMA, InitRunner, the Apps portlet counts, telemetry, SAML) expects a set, not a
                 // throw.
+                //
+                // One consequence is deliberate and worth knowing: against an unreadable store the
+                // Apps portlet LIST shows every app as 0 configurations, while opening an app's
+                // DETAIL still raises, because getSecrets() is not swallowed. The list is a
+                // best-effort count and the detail view is authoritative. The split cannot be
+                // closed from this side -- this same method is called by EMAWebInterceptor on every
+                // /api/* request, so raising here returns a 500 for the whole API. Surfacing the
+                // condition in the list needs its own signal path alongside AppDescriptorLoadError.
+                // Note the old wipe-then-recreate behaviour also reported 0, so this is not a
+                // regression.
                 Logger.error(AppsAPIImpl.class,
                         String.format("Error getting secret from `%s` ", key), e);
             }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -452,8 +452,20 @@ public class AppsAPIImpl implements AppsAPI {
                 // cannot be closed from here for the /api/* reason above; giving the list its own
                 // signal is tracked in issue #37061. The old wipe-then-recreate also reported 0, so
                 // this is not a regression.
-                Logger.error(AppsAPIImpl.class,
-                        String.format("App secrets store is unreadable; reporting no secrets for `%s` ", key), e);
+                // debug, not error, and deliberately so. This fires once per site per call, and
+                // EMAWebInterceptor.existsConfiguration reaches this method on every /api/* request
+                // -- measured at 32 ERROR lines from 16 requests on a two-site instance. Because the
+                // condition persists until an operator fixes it, logging at ERROR here reproduces
+                // exactly the flood this PR throttles inside the helper: an actionable message
+                // repeated thousands of times stops being actionable.
+                //
+                // Nothing is lost. SecretsKeyStoreHelper.handleUnrecoverableLoad already logs the
+                // one ERROR that carries the diagnosis and the remediation, rate-limited to one per
+                // SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS. This line only restated that a
+                // particular app is being reported as unconfigured, which adds no new information.
+                Logger.debug(AppsAPIImpl.class, () -> String.format(
+                        "App secrets store is unreadable; reporting no secrets for `%s`: %s",
+                        key, e.getMessage()));
             }
             return false;
         }).collect(Collectors.toCollection(LinkedHashSet::new));

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -440,7 +440,8 @@ public class AppsAPIImpl implements AppsAPI {
                 // best-effort count and the detail view is authoritative. The split cannot be
                 // closed from this side -- this same method is called by EMAWebInterceptor on every
                 // /api/* request, so raising here returns a 500 for the whole API. Surfacing the
-                // condition in the list needs its own signal path alongside AppDescriptorLoadError.
+                // condition in the list needs its own signal path alongside AppDescriptorLoadError;
+                // tracked in issue #37061.
                 // Note the old wipe-then-recreate behaviour also reported 0, so this is not a
                 // regression.
                 Logger.error(AppsAPIImpl.class,

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -423,8 +423,9 @@ public class AppsAPIImpl implements AppsAPI {
         return siteIdentifiers.stream().filter(id -> {
             try {
                 return hasAnySecrets(key, id, user);
-            } catch (DotDataException | DotSecurityException | DotRuntimeException e) {
-                // DotRuntimeException is the addition, not a blanket catch (Exception).
+            } catch (DotDataException | DotSecurityException | SecretsStoreUnreadableException e) {
+                // SecretsStoreUnreadableException is the addition, and deliberately that exact type
+                // rather than DotRuntimeException or Exception.
                 // This method's contract is already "if the secrets cannot be determined for this
                 // site, treat it as having none" -- it logs and returns false. Since issue #36724 the
                 // secrets store raises a DotRuntimeException when it cannot be read rather than
@@ -445,9 +446,12 @@ public class AppsAPIImpl implements AppsAPI {
                 // Note the old wipe-then-recreate behaviour also reported 0, so this is not a
                 // regression.
                 //
-                // Deliberately these three types rather than Exception: a genuine programming error
-                // here -- an NPE inside hasAnySecrets, say -- should surface rather than be hidden
-                // as a wrong configuration count on a path this hot.
+                // Deliberately these three types. Not Exception, because a genuine programming
+                // error -- an NPE inside hasAnySecrets, say -- should surface rather than hide as a
+                // wrong configuration count on a path this hot. And not DotRuntimeException either:
+                // that is dotCMS's general-purpose unchecked wrapper, so database blips and cache
+                // failures surface as one, and swallowing those here would report "0
+                // configurations" for what is really a transient infrastructure problem.
                 Logger.error(AppsAPIImpl.class,
                         String.format("Error getting secret from `%s` ", key), e);
             }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -20,21 +20,26 @@ import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.liferay.portal.model.User;
-import com.liferay.util.FileUtil;
 import com.rainerhahnekamp.sneakythrow.Sneaky;
 import io.vavr.control.Try;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStore.PasswordProtection;
 import java.security.KeyStore.SecretKeyEntry;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Date;
 import java.util.List;
@@ -60,8 +65,24 @@ public class SecretsKeyStoreHelper {
     private static final String SECRETS_STORE_FILE = "dotSecretsStore.p12";
     private static final String SECRETS_STORE_KEYSTORE_TYPE = "pkcs12";
     private static final String SECRETS_STORE_SECRET_KEY_FACTORY_TYPE = "PBE";
-    private static final String SECRETS_STORE_LOAD_TRIES = "SECRETS_STORE_LOAD_TRIES";
-    private static final String SECRETS_KEYSTORE_FILE_PATH_KEY = "SECRETS_KEYSTORE_FILE_PATH_KEY";
+    static final String SECRETS_STORE_LOAD_TRIES = "SECRETS_STORE_LOAD_TRIES";
+
+    /**
+     * Whether an App secrets store that cannot be loaded may be backed up and replaced with an
+     * empty one. Defaults to {@code false}: the store on disk is the only copy of every App
+     * credential, and a backup taken at that point is encrypted with the password that just
+     * failed, so replacing it is not a recovery -- it is the data loss reported in issue #36724.
+     */
+    static final String SECRETS_STORE_AUTO_RECREATE = "SECRETS_STORE_AUTO_RECREATE";
+
+    /**
+     * Base delay between attempts to re-read the store. Multiplied by the attempt number, so the
+     * default rides out roughly 300ms of a concurrent write on another node.
+     */
+    private static final String SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS =
+            "SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS";
+
+    static final String SECRETS_KEYSTORE_FILE_PATH_KEY = "SECRETS_KEYSTORE_FILE_PATH_KEY";
     private static final String APPS_KEY_PROVIDER_CLASS = "APPS_KEY_PROVIDER_CLASS";
     private final String secretsKeyStorePath;
     private final List<StoreCreatedListener> storeCreatedListeners;
@@ -124,33 +145,124 @@ public class SecretsKeyStoreHelper {
     */
     @VisibleForTesting
     KeyStore getSecretsStore() {
-        try {
-            final KeyStore keyStore = KeyStore.getInstance(SECRETS_STORE_KEYSTORE_TYPE);
-            final int maxLoadTries = Config.getIntProperty(SECRETS_STORE_LOAD_TRIES, 2);
+        return loadSecretsStore(true);
+    }
 
-            int tryCount = 1;
-            while (tryCount <= maxLoadTries) {
-                final File secretStoreFile = createStoreIfNeeded();
-                try (InputStream inputStream = Files.newInputStream(secretStoreFile.toPath())) {
-                    keyStore.load(inputStream, passwordSupplier.get());
-                    Logger.info(SecretsKeyStoreHelper.class,
-                            String.format("KeyStore loaded successfully after `%d` tries.", tryCount));
-                    break;
-                } catch (IOException gse) {
-                    //IOException wraps the underlying UnrecoverableKeyException
-                    Try.of(() -> handleStorageLoadException(gse));
-                    tryCount++;
+    /**
+     * @param allowRecreate whether a terminal failure may fall back to
+     *        {@link #handleUnrecoverableLoad(IOException, boolean)}'s destructive path. False on the
+     *        single retry after a recreate, so a store that still cannot be loaded raises instead of
+     *        recursing forever.
+     */
+    private KeyStore loadSecretsStore(final boolean allowRecreate) {
+
+        // Created at most once per call, deliberately OUTSIDE the retry loop below. Calling
+        // createStoreIfNeeded() on every attempt is what allowed a transient failure to be
+        // "recovered" into a brand new empty store: the first attempt deleted the file, the second
+        // recreated it empty, loaded it cleanly and reported success (issue #36724).
+        final File secretStoreFile = createStoreIfNeeded();
+
+        final int maxLoadTries = Config.getIntProperty(SECRETS_STORE_LOAD_TRIES, 3);
+        final long backoffMillis = Config
+                .getLongProperty(SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS, 100);
+
+        IOException lastFailure = null;
+
+        for (int tryCount = 1; tryCount <= maxLoadTries; tryCount++) {
+            try (InputStream inputStream = Files.newInputStream(secretStoreFile.toPath())) {
+
+                final KeyStore keyStore = KeyStore.getInstance(SECRETS_STORE_KEYSTORE_TYPE);
+                keyStore.load(inputStream, passwordSupplier.get());
+
+                if (tryCount > 1) {
+                    Logger.info(SecretsKeyStoreHelper.class, String.format(
+                            "App secrets store recovered on attempt %d of %d.", tryCount,
+                            maxLoadTries));
                 }
+                return keyStore;
+
+            } catch (IOException e) {
+                lastFailure = e;
+
+                // An integrity failure is deterministic -- either the password is wrong or the
+                // bytes are genuinely corrupt. Re-reading cannot change the outcome, so stop
+                // rather than spend the remaining attempts on it.
+                if (isIntegrityFailure(e) || tryCount == maxLoadTries) {
+                    break;
+                }
+
+                Logger.warn(SecretsKeyStoreHelper.class, String.format(
+                        "Could not read the App secrets store on attempt %d of %d (%s); retrying."
+                                + " Another node may be writing it.",
+                        tryCount, maxLoadTries, e.getMessage()));
+
+                final long sleepMillis = backoffMillis * tryCount;
+                Try.run(() -> Thread.sleep(sleepMillis));
+
+            } catch (GeneralSecurityException e) {
+                Logger.error(this.getClass(),
+                        "Unable to load secrets store " + SECRETS_STORE_FILE + ": " + e.getMessage(), e);
+                throw new DotRuntimeException(e);
             }
-
-            return keyStore;
-
-        } catch (Exception e) {
-            Logger.debug(this.getClass(),
-                    "Unable to load secrets store " + SECRETS_STORE_FILE + ": " + e);
-            throw new DotRuntimeException(e);
         }
 
+        return handleUnrecoverableLoad(lastFailure, allowRecreate);
+    }
+
+    /**
+     * Distinguishes "cannot decrypt" from "cannot read".
+     *
+     * A PKCS12 integrity failure -- a wrong password, or corrupt content -- arrives as an
+     * {@link IOException} wrapping an {@link UnrecoverableKeyException}. A torn, truncated or
+     * missing file does not, and is worth retrying. Before issue #36724 both were handled
+     * identically, which is why a password mismatch destroyed the store just as readily as
+     * corruption did.
+     */
+    private static boolean isIntegrityFailure(final IOException e) {
+        return null != e && e.getCause() instanceof UnrecoverableKeyException;
+    }
+
+    /**
+     * Terminal handler for a store that could not be loaded after every attempt.
+     *
+     * It does not delete anything unless an operator has explicitly opted in via
+     * {@link #SECRETS_STORE_AUTO_RECREATE}. Because {@link #saveValue(String, char[])} loads the
+     * store before mutating it, throwing here also prevents a caller from writing a
+     * nearly-empty store over a file that is intact but merely unreadable by this node.
+     */
+    private KeyStore handleUnrecoverableLoad(final IOException cause, final boolean allowRecreate) {
+
+        final String diagnosis = isIntegrityFailure(cause)
+                ? "the store could not be decrypted. The password is derived from the cluster salt,"
+                        + " so this usually means the salt changed or SECRETS_KEYSTORE_PASSWORD_KEY"
+                        + " differs between nodes"
+                : "the store could not be read";
+
+        Try.run(this::sendFailureNotification);
+
+        if (!allowRecreate || !Config.getBooleanProperty(SECRETS_STORE_AUTO_RECREATE, false)) {
+            Logger.error(SecretsKeyStoreHelper.class, String.format(
+                    "Unable to load the App secrets store '%s': %s. The existing store has been LEFT"
+                            + " IN PLACE and no secrets were lost. Apps will not work until this is"
+                            + " resolved. Restore the correct salt/password, or set %s=true to back"
+                            + " it up and start over -- which DISCARDS every stored App credential.",
+                    secretsKeyStorePath, diagnosis, SECRETS_STORE_AUTO_RECREATE), cause);
+
+            throw new DotRuntimeException(
+                    "Unable to load the App secrets store: " + diagnosis, cause);
+        }
+
+        Logger.error(SecretsKeyStoreHelper.class, String.format(
+                "Unable to load the App secrets store '%s': %s. %s is enabled, so it will be backed"
+                        + " up and replaced with an EMPTY store. Every App credential must be"
+                        + " re-entered; note the backup is encrypted with the same password that"
+                        + " just failed.",
+                secretsKeyStorePath, diagnosis, SECRETS_STORE_AUTO_RECREATE), cause);
+
+        Sneaky.sneaked(this::backupAndRemoveKeyStore).run();
+        // allowRecreate=false: if the freshly created store also fails to load, raise rather than
+        // recurse into another backup-and-delete cycle.
+        return loadSecretsStore(false);
     }
 
 
@@ -163,18 +275,77 @@ public class SecretsKeyStoreHelper {
      */
     private KeyStore saveSecretsStore(final KeyStore keyStore) {
         final File secretStoreFile = new File(secretsKeyStorePath);
-        final File secretStoreFileTmp = new File(secretStoreFile.getParent(), "dotSecretsStore_" + System.currentTimeMillis() + ".p12.tmp");
+
+        // The tmp file must live in the destination's own directory: an atomic move is only
+        // available within a single filesystem.
+        final File secretStoreFileTmp = new File(secretStoreFile.getParent(),
+                SECRETS_STORE_FILE + "_" + System.currentTimeMillis() + ".tmp");
 
         secretStoreFileTmp.getParentFile().mkdirs();
-        try (OutputStream fos = Files.newOutputStream(secretStoreFileTmp.toPath())) {
-            keyStore.store(fos, passwordSupplier.get());
-            FileUtil.copyFile(secretStoreFileTmp, secretStoreFile);
-            secretStoreFileTmp.delete();
+        try {
+            try (FileOutputStream fos = new FileOutputStream(secretStoreFileTmp)) {
+                keyStore.store(fos, passwordSupplier.get());
+                fos.flush();
+                // The rename below must not publish bytes that are still buffered.
+                fos.getFD().sync();
+            }
+
+            restrictPermissions(secretStoreFileTmp);
+            publishAtomically(secretStoreFileTmp, secretStoreFile);
+
         } catch (Exception e) {
-            Logger.error(this.getClass(), "unable to save secrets store " + secretStoreFileTmp + ": " + e);
+            Logger.error(this.getClass(),
+                    "unable to save secrets store " + secretStoreFileTmp + ": " + e, e);
             throw new DotRuntimeException(e);
+        } finally {
+            // The old code only deleted the tmp file on the happy path, leaking a copy of every
+            // secret on any failure.
+            Try.run(() -> Files.deleteIfExists(secretStoreFileTmp.toPath()));
         }
         return keyStore;
+    }
+
+    /**
+     * Publishes the store by renaming the tmp file over it, so a concurrent reader -- including one
+     * on another cluster node sharing this file -- sees either the whole previous store or the whole
+     * new one. Never a partial write, and never a missing file.
+     *
+     * Deliberately not {@code FileUtil.copyFile}, which this method replaced. That utility exists
+     * for content versioning and either hard-links (deleting the destination first) or truncates the
+     * destination and streams the bytes back in. Both leave the shared store empty or partial for a
+     * window, which is defects B1 and B2 of issue #36724.
+     */
+    private static void publishAtomically(final File source, final File destination)
+            throws IOException {
+        try {
+            Files.move(source.toPath(), destination.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            Logger.warn(SecretsKeyStoreHelper.class, String.format(
+                    "The filesystem holding '%s' does not support atomic moves; falling back to a"
+                            + " non-atomic replace. Concurrent readers on other nodes may observe a"
+                            + " partial store on this filesystem.", destination), e);
+            Files.move(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    /**
+     * Restricts the file to owner read/write.
+     *
+     * Applied to the tmp file *before* it is moved into place, because the published store inherits
+     * the tmp file's permissions. Previously both the tmp file and the store were created with
+     * whatever the default umask allowed, in a directory shared across the cluster.
+     */
+    private static void restrictPermissions(final File file) {
+        try {
+            final Path path = file.toPath();
+            if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-------"));
+            }
+        } catch (Exception e) {
+            Logger.warn(SecretsKeyStoreHelper.class,
+                    "Unable to restrict permissions on the App secrets store: " + e.getMessage());
+        }
     }
 
     /**
@@ -375,22 +546,6 @@ public class SecretsKeyStoreHelper {
                 new I18NMessage("apps.fail.recover.secrets.notification", null), null, // no actions
                 NotificationLevel.WARNING, NotificationType.GENERIC, Visibility.ROLE, cmsAdminRole.getId(), systemUser.getUserId(),
                 systemUser.getLocale());
-    }
-
-    /**
-     * handles the any security exception when loading the keyStore
-     * on failure the p12 store is back-up and then gets removed.
-     * @param gse
-     * @throws DotDataException
-     * @throws IOException
-     */
-    private boolean handleStorageLoadException(final IOException gse) throws DotDataException, IOException {
-        Logger.warn(SecretsKeyStoreHelper.class,
-                "Failed to recover secrets from key/store. The keyStore will be backup and then removed. A new empty store will be generated.",
-                gse);
-        backupAndRemoveKeyStore();
-        sendFailureNotification();
-        return true;
     }
 
     @FunctionalInterface

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -202,9 +202,17 @@ public class SecretsKeyStoreHelper {
         // recreated it empty, loaded it cleanly and reported success (issue #36724).
         final File secretStoreFile = createStoreIfNeeded();
 
-        final int maxLoadTries = Config.getIntProperty(SECRETS_STORE_LOAD_TRIES, 3);
-        final long backoffMillis = Config
-                .getLongProperty(SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS, 100);
+        // Floored at one attempt. A configured 0 or a negative value would skip the loop entirely,
+        // leaving no failure to report, and the terminal handler would then declare a perfectly
+        // intact store permanently unreadable on this node -- with a diagnosis pointing at a
+        // password or corruption problem that does not exist. One attempt is the minimum that can
+        // answer the question the method was asked.
+        final int maxLoadTries = Math.max(1,
+                Config.getIntProperty(SECRETS_STORE_LOAD_TRIES, 3));
+        // Floored at zero: a negative backoff would make Thread.sleep throw
+        // IllegalArgumentException, which is not an IOException and would escape the retry loop.
+        final long backoffMillis = Math.max(0L,
+                Config.getLongProperty(SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS, 100));
 
         IOException lastFailure = null;
         boolean interrupted = false;

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -335,7 +335,7 @@ public class SecretsKeyStoreHelper {
 
             notifyLoadFailureOnce();
 
-            throw new DotRuntimeException(
+            throw new SecretsStoreUnreadableException(
                     "Unable to load the App secrets store: " + diagnosis, cause);
         }
 

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -293,6 +293,20 @@ public class SecretsKeyStoreHelper {
     }
 
     /**
+     * Clears the notification latch. Tests only.
+     *
+     * The latch is static and never resets in production, deliberately -- see
+     * {@link #LOAD_FAILURE_NOTIFIED}. Within one Surefire fork that means it stays set once any test
+     * trips it, so without this a test could only ever assert {@code true}, and asserting the
+     * false-to-true transition or "not notified yet" would silently depend on which siblings ran
+     * first. Call it in setup rather than teardown, so a test is unaffected by whatever ran before.
+     */
+    @VisibleForTesting
+    static void resetNotifiedLoadFailureLatch() {
+        LOAD_FAILURE_NOTIFIED.set(false);
+    }
+
+    /**
      * Whether the ERROR for an unreadable store should be logged now, rate-limited to one per
      * {@link #SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS}. The first failure always logs.
      *

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -364,14 +364,25 @@ public class SecretsKeyStoreHelper {
      */
     private KeyStore saveSecretsStore(final KeyStore keyStore) {
         final File secretStoreFile = new File(secretsKeyStorePath);
+        secretStoreFile.getParentFile().mkdirs();
 
-        // The tmp file must live in the destination's own directory: an atomic move is only
-        // available within a single filesystem.
-        final File secretStoreFileTmp = new File(secretStoreFile.getParent(),
-                SECRETS_STORE_FILE + "_" + System.currentTimeMillis() + ".tmp");
-
-        secretStoreFileTmp.getParentFile().mkdirs();
+        File secretStoreFileTmp = null;
         try {
+            // Unique per writer, and in the destination's own directory because an atomic move is
+            // only available within a single filesystem.
+            //
+            // The name used to be derived from currentTimeMillis() alone, so two saves on this node
+            // landing in the same millisecond resolved to the same path, both opened it, and
+            // interleaved -- and publishAtomically would then rename the interleaved result into
+            // place as the live store. That used to be self-correcting, because a store that failed
+            // to load was wiped and rebuilt; now that the store is preserved (issue #36724), such a
+            // collision would leave it corrupt until an operator intervened.
+            //
+            // createTempFile also creates the file with owner-only permissions on POSIX, so the tmp
+            // never exists world-readable in the window before restrictPermissions runs.
+            secretStoreFileTmp = Files.createTempFile(secretStoreFile.getParentFile().toPath(),
+                    SECRETS_STORE_FILE + "_", ".tmp").toFile();
+
             try (FileOutputStream fos = new FileOutputStream(secretStoreFileTmp)) {
                 keyStore.store(fos, passwordSupplier.get());
                 fos.flush();
@@ -389,7 +400,10 @@ public class SecretsKeyStoreHelper {
         } finally {
             // The old code only deleted the tmp file on the happy path, leaking a copy of every
             // secret on any failure.
-            Try.run(() -> Files.deleteIfExists(secretStoreFileTmp.toPath()));
+            final File tmpToClean = secretStoreFileTmp;
+            if (null != tmpToClean) {
+                Try.run(() -> Files.deleteIfExists(tmpToClean.toPath()));
+            }
         }
         return keyStore;
     }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -207,6 +207,7 @@ public class SecretsKeyStoreHelper {
                 .getLongProperty(SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS, 100);
 
         IOException lastFailure = null;
+        boolean interrupted = false;
 
         for (int tryCount = 1; tryCount <= maxLoadTries; tryCount++) {
             try (InputStream inputStream = Files.newInputStream(secretStoreFile.toPath())) {
@@ -245,6 +246,7 @@ public class SecretsKeyStoreHelper {
                     // thread that has been asked to stop; the loop falls through to the terminal
                     // handler, which preserves the store and raises.
                     Thread.currentThread().interrupt();
+                    interrupted = true;
                     break;
                 }
 
@@ -255,7 +257,7 @@ public class SecretsKeyStoreHelper {
             }
         }
 
-        return handleUnrecoverableLoad(lastFailure, allowRecreate);
+        return handleUnrecoverableLoad(lastFailure, allowRecreate, interrupted);
     }
 
     /**
@@ -316,15 +318,31 @@ public class SecretsKeyStoreHelper {
      * store before mutating it, throwing here also prevents a caller from writing a
      * nearly-empty store over a file that is intact but merely unreadable by this node.
      */
-    private KeyStore handleUnrecoverableLoad(final IOException cause, final boolean allowRecreate) {
+    private KeyStore handleUnrecoverableLoad(final IOException cause, final boolean allowRecreate,
+            final boolean interrupted) {
 
-        final String diagnosis = isIntegrityFailure(cause)
-                ? "the store could not be decrypted. The password is derived from the cluster salt,"
-                        + " so this usually means the salt changed or SECRETS_KEYSTORE_PASSWORD_KEY"
-                        + " differs between nodes"
-                : "the store could not be read";
+        // The interrupted case is reported for what it is. Falling through to "could not be read"
+        // would blame the store for a shutdown or a request timeout, sending an operator looking for
+        // a corrupt file or a salt mismatch that does not exist.
+        final String diagnosis;
+        if (interrupted) {
+            diagnosis = "the thread was interrupted while waiting to re-read it, so the read was"
+                    + " abandoned. The store itself may well be fine; this usually means a shutdown"
+                    + " or a request timeout, not a problem with the file";
+        } else if (isIntegrityFailure(cause)) {
+            diagnosis = "the store could not be decrypted. The password is derived from the cluster"
+                    + " salt, so this usually means the salt changed or SECRETS_KEYSTORE_PASSWORD_KEY"
+                    + " differs between nodes";
+        } else {
+            diagnosis = "the store could not be read";
+        }
 
-        if (!allowRecreate || !Config.getBooleanProperty(SECRETS_STORE_AUTO_RECREATE, false)) {
+        // An interrupt never justifies the destructive path, even with SECRETS_STORE_AUTO_RECREATE
+        // enabled. Nothing has been learned about the store: the read was abandoned before it could
+        // fail on its own merits. Backing it up and replacing it with an empty one here would let a
+        // shutdown or a request timeout discard every App credential.
+        if (interrupted || !allowRecreate
+                || !Config.getBooleanProperty(SECRETS_STORE_AUTO_RECREATE, false)) {
 
             // The store is preserved, so this state persists until an operator fixes it -- and every
             // read lands here again. Report it periodically instead of once per read; see

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -236,8 +236,17 @@ public class SecretsKeyStoreHelper {
                                 + " Another node may be writing it.",
                         tryCount, maxLoadTries, e.getMessage()));
 
-                final long sleepMillis = backoffMillis * tryCount;
-                Try.run(() -> Thread.sleep(sleepMillis));
+                try {
+                    Thread.sleep(backoffMillis * tryCount);
+                } catch (final InterruptedException ie) {
+                    // Thread.sleep clears the interrupt flag when it throws, so restore it: the
+                    // caller -- a shutdown hook, a request timeout -- is entitled to see that this
+                    // thread was interrupted. Stop retrying too, rather than sleeping again on a
+                    // thread that has been asked to stop; the loop falls through to the terminal
+                    // handler, which preserves the store and raises.
+                    Thread.currentThread().interrupt();
+                    break;
+                }
 
             } catch (GeneralSecurityException e) {
                 Logger.error(this.getClass(),

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -43,6 +43,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -82,11 +83,31 @@ public class SecretsKeyStoreHelper {
     private static final String SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS =
             "SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS";
 
+    /**
+     * How often a persistently unreadable store may be reported.
+     *
+     * Every consumer of a secret wraps its read defensively -- typically
+     * {@code Try.of(() -> getSecrets(...)).getOrElse(Optional.empty())} -- so a store this node
+     * cannot open degrades each App to "not configured" rather than raising into the request. The
+     * upside is that a mismatched store never takes an instance down; the downside is that the
+     * ERROR logged here is the only signal, and it would otherwise be emitted on every read: once
+     * per page render that touches a secret, per login attempt, per content save. An actionable
+     * message repeated thousands of times is not actionable, so it is reported once per interval.
+     */
+    private static final String SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS =
+            "SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS";
+
     static final String SECRETS_KEYSTORE_FILE_PATH_KEY = "SECRETS_KEYSTORE_FILE_PATH_KEY";
     private static final String APPS_KEY_PROVIDER_CLASS = "APPS_KEY_PROVIDER_CLASS";
     private final String secretsKeyStorePath;
     private final List<StoreCreatedListener> storeCreatedListeners;
     private final Supplier<char[]> passwordSupplier;
+
+    /**
+     * When this instance last reported an unreadable store. Per-instance rather than static so that
+     * two helpers pointed at different stores cannot silence each other.
+     */
+    private final AtomicLong lastLoadFailureReportAt = new AtomicLong(0);
 
     @VisibleForTesting
     public static String getSecretStorePath() {
@@ -223,6 +244,24 @@ public class SecretsKeyStoreHelper {
     }
 
     /**
+     * Whether an unreadable store should be reported now, rate-limited to one report per
+     * {@link #SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS}. The first failure always reports.
+     *
+     * Gates the admin notification as well as the log line: {@code sendFailureNotification()} writes
+     * a notification row, so firing it per read would turn a mismatched store into a steady write
+     * load against the database on top of the log noise.
+     */
+    @VisibleForTesting
+    boolean shouldReportLoadFailure() {
+        final long interval = Config
+                .getLongProperty(SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS, 60000);
+        final long now = System.currentTimeMillis();
+        final long last = lastLoadFailureReportAt.get();
+
+        return now - last > interval && lastLoadFailureReportAt.compareAndSet(last, now);
+    }
+
+    /**
      * Terminal handler for a store that could not be loaded after every attempt.
      *
      * It does not delete anything unless an operator has explicitly opted in via
@@ -238,20 +277,31 @@ public class SecretsKeyStoreHelper {
                         + " differs between nodes"
                 : "the store could not be read";
 
-        Try.run(this::sendFailureNotification);
-
         if (!allowRecreate || !Config.getBooleanProperty(SECRETS_STORE_AUTO_RECREATE, false)) {
-            Logger.error(SecretsKeyStoreHelper.class, String.format(
-                    "Unable to load the App secrets store '%s': %s. The existing store has been LEFT"
-                            + " IN PLACE and no secrets were lost. Apps will not work until this is"
-                            + " resolved. Restore the correct salt/password, or set %s=true to back"
-                            + " it up and start over -- which DISCARDS every stored App credential.",
-                    secretsKeyStorePath, diagnosis, SECRETS_STORE_AUTO_RECREATE), cause);
+
+            // The store is preserved, so this state persists until an operator fixes it -- and every
+            // read lands here again. Report it periodically instead of once per read; see
+            // SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS.
+            if (shouldReportLoadFailure()) {
+                Logger.error(SecretsKeyStoreHelper.class, String.format(
+                        "Unable to load the App secrets store '%s': %s. The existing store has been"
+                                + " LEFT IN PLACE and no secrets were lost. Apps will not work until"
+                                + " this is resolved. Restore the correct salt/password, or set"
+                                + " %s=true to back it up and start over -- which DISCARDS every"
+                                + " stored App credential.",
+                        secretsKeyStorePath, diagnosis, SECRETS_STORE_AUTO_RECREATE), cause);
+                Try.run(this::sendFailureNotification);
+            } else {
+                Logger.debug(SecretsKeyStoreHelper.class,
+                        () -> "App secrets store is still unreadable: " + diagnosis);
+            }
 
             throw new DotRuntimeException(
                     "Unable to load the App secrets store: " + diagnosis, cause);
         }
 
+        // The destructive path runs once and then succeeds, so it is never throttled.
+        Try.run(this::sendFailureNotification);
         Logger.error(SecretsKeyStoreHelper.class, String.format(
                 "Unable to load the App secrets store '%s': %s. %s is enabled, so it will be backed"
                         + " up and replaced with an EMPTY store. Every App credential must be"

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -26,11 +26,13 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.GeneralSecurityException;
 import java.security.Key;
@@ -327,8 +329,18 @@ public class SecretsKeyStoreHelper {
      * See {@link #LOAD_FAILURE_NOTIFIED}.
      */
     private void notifyLoadFailureOnce() {
-        if (LOAD_FAILURE_NOTIFIED.compareAndSet(false, true)) {
-            Try.run(this::sendFailureNotification);
+        // Claim the latch first so only one thread sends, then release it again if the send failed.
+        // Latching unconditionally would lose the notification for the life of the JVM whenever
+        // sendFailureNotification() throws -- and it is most likely to throw during exactly the
+        // outage that made the store unreadable, since it needs a role lookup and a database write.
+        // Releasing lets the next read try again; the throttled ERROR keeps reporting meanwhile.
+        if (LOAD_FAILURE_NOTIFIED.compareAndSet(false, true)
+                && Try.run(this::sendFailureNotification)
+                        .onFailure(e -> Logger.warnAndDebug(SecretsKeyStoreHelper.class,
+                                "Could not notify administrators that the App secrets store is"
+                                        + " unreadable; will retry on a later read: " + e.getMessage(), e))
+                        .isFailure()) {
+            LOAD_FAILURE_NOTIFIED.set(false);
         }
     }
 
@@ -526,6 +538,37 @@ public class SecretsKeyStoreHelper {
                             + " non-atomic replace. Concurrent readers on other nodes may observe a"
                             + " partial store on this filesystem.", destination), e);
             Files.move(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        syncDirectory(destination.toPath().getParent());
+    }
+
+    /**
+     * Flushes the directory entry created by the rename, so the new name survives a crash.
+     *
+     * The tmp file's own contents are fsynced before the move, but that only guarantees the bytes.
+     * Without this, a crash in the window right after the rename can leave the directory entry
+     * unpersisted and the store reverts to its previous version. That is a much smaller exposure
+     * than the bug this class was changed to fix -- the previous version is a complete, readable
+     * store, so what is lost is the most recent save rather than every credential -- and it is
+     * strictly better than the truncate-and-stream it replaced, which could leave a partial file.
+     * Given the goal is not to lose the store, it is worth closing.
+     *
+     * Never fatal. Opening a directory as a channel works on Linux and macOS (verified on both, JDK
+     * 25) but is not guaranteed across every filesystem, and a save that reached this point has
+     * already been published successfully.
+     */
+    private static void syncDirectory(final Path directory) {
+        if (null == directory) {
+            return;
+        }
+        try (FileChannel channel = FileChannel.open(directory, StandardOpenOption.READ)) {
+            channel.force(true);
+        } catch (Exception e) {
+            Logger.debug(SecretsKeyStoreHelper.class, () -> String.format(
+                    "Could not flush the directory entry for '%s' (%s). The store is published; only"
+                            + " crash durability of the rename is affected.",
+                    directory, e.getMessage()));
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -43,6 +43,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import javax.crypto.SecretKey;
@@ -108,6 +109,24 @@ public class SecretsKeyStoreHelper {
      * two helpers pointed at different stores cannot silence each other.
      */
     private final AtomicLong lastLoadFailureReportAt = new AtomicLong(0);
+
+    /**
+     * Whether the admin notification for an unreadable store has already been raised in this JVM.
+     *
+     * Separate from {@link #lastLoadFailureReportAt}, and deliberately a one-shot latch rather than
+     * an interval: a log line is a stream, but a notification is a persisted row and a permanent
+     * item in an administrator's tray. Repeating it says nothing new. Measured on a container with
+     * the report interval shortened to 10s, a store left unreadable for five minutes produced 20
+     * notification rows; at the 60s default that is still thousands a day for a store nobody has
+     * got round to fixing. The recurring signal belongs in the log; the notification only has to
+     * say "go and look" once.
+     *
+     * Static, so it is one notification per JVM rather than per helper instance -- an operator does
+     * not need the same instruction twice because two components each hold a helper. A store that
+     * breaks again after being fixed re-notifies on the next restart, which in practice is how a
+     * salt or password change arrives anyway.
+     */
+    private static final AtomicBoolean LOAD_FAILURE_NOTIFIED = new AtomicBoolean(false);
 
     @VisibleForTesting
     public static String getSecretStorePath() {
@@ -244,12 +263,31 @@ public class SecretsKeyStoreHelper {
     }
 
     /**
-     * Whether an unreadable store should be reported now, rate-limited to one report per
-     * {@link #SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS}. The first failure always reports.
+     * Raises the admin notification for an unreadable store at most once per JVM.
+     * See {@link #LOAD_FAILURE_NOTIFIED}.
+     */
+    private void notifyLoadFailureOnce() {
+        if (LOAD_FAILURE_NOTIFIED.compareAndSet(false, true)) {
+            Try.run(this::sendFailureNotification);
+        }
+    }
+
+    /**
+     * Whether the admin notification has yet been raised in this JVM. Only for tests to assert the
+     * one-shot behaviour without generating notification rows.
+     */
+    @VisibleForTesting
+    static boolean hasNotifiedLoadFailure() {
+        return LOAD_FAILURE_NOTIFIED.get();
+    }
+
+    /**
+     * Whether the ERROR for an unreadable store should be logged now, rate-limited to one per
+     * {@link #SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS}. The first failure always logs.
      *
-     * Gates the admin notification as well as the log line: {@code sendFailureNotification()} writes
-     * a notification row, so firing it per read would turn a mismatched store into a steady write
-     * load against the database on top of the log noise.
+     * Covers the log line only. The admin notification is a separate one-shot latch --
+     * {@link #notifyLoadFailureOnce()} -- because a persisted notification row should not repeat on
+     * an interval the way a log line can.
      */
     @VisibleForTesting
     boolean shouldReportLoadFailure() {
@@ -290,11 +328,12 @@ public class SecretsKeyStoreHelper {
                                 + " %s=true to back it up and start over -- which DISCARDS every"
                                 + " stored App credential.",
                         secretsKeyStorePath, diagnosis, SECRETS_STORE_AUTO_RECREATE), cause);
-                Try.run(this::sendFailureNotification);
             } else {
                 Logger.debug(SecretsKeyStoreHelper.class,
                         () -> "App secrets store is still unreadable: " + diagnosis);
             }
+
+            notifyLoadFailureOnce();
 
             throw new DotRuntimeException(
                     "Unable to load the App secrets store: " + diagnosis, cause);

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -111,6 +111,20 @@ public class SecretsKeyStoreHelper {
     private final AtomicLong lastLoadFailureReportAt = new AtomicLong(0);
 
     /**
+     * When this instance last exhausted its attempts and gave up, or 0 if the last read succeeded.
+     *
+     * Used to stop paying the retry backoff over and over for a failure already known to be
+     * persistent. The wrong-password case never retries -- an integrity failure is deterministic and
+     * breaks immediately -- but a truncated or zero-byte store raises an IOException with no
+     * UnrecoverableKeyException cause, which is indistinguishable from a torn read mid-write and so
+     * is retried. Verified against the JDK: a half-truncated store gives EOFException and a
+     * zero-byte one a bare IOException, neither with that cause. Now that a store is preserved
+     * rather than wiped and rebuilt, that state persists, and every read -- page render, login,
+     * content save -- would burn the full backoff (300ms at defaults) before degrading.
+     */
+    private final AtomicLong lastTerminalFailureAt = new AtomicLong(0);
+
+    /**
      * Whether the admin notification for an unreadable store has already been raised in this JVM.
      *
      * Separate from {@link #lastLoadFailureReportAt}, and deliberately a one-shot latch rather than
@@ -207,8 +221,13 @@ public class SecretsKeyStoreHelper {
         // intact store permanently unreadable on this node -- with a diagnosis pointing at a
         // password or corruption problem that does not exist. One attempt is the minimum that can
         // answer the question the method was asked.
-        final int maxLoadTries = Math.max(1,
+        final int configuredTries = Math.max(1,
                 Config.getIntProperty(SECRETS_STORE_LOAD_TRIES, 3));
+        // Retrying only helps a genuinely transient failure. If this instance already exhausted its
+        // attempts recently, the condition is persistent, so try once and degrade instead of
+        // sleeping through the backoff on every read. The window is the report interval: once it
+        // lapses the full retry budget returns, so a store that has since been fixed is picked up.
+        final int maxLoadTries = recentlyFailedTerminally() ? 1 : configuredTries;
         // Floored at zero: a negative backoff would make Thread.sleep throw
         // IllegalArgumentException, which is not an IOException and would escape the retry loop.
         final long backoffMillis = Math.max(0L,
@@ -222,6 +241,8 @@ public class SecretsKeyStoreHelper {
 
                 final KeyStore keyStore = KeyStore.getInstance(SECRETS_STORE_KEYSTORE_TYPE);
                 keyStore.load(inputStream, passwordSupplier.get());
+
+                lastTerminalFailureAt.set(0);
 
                 if (tryCount > 1) {
                     Logger.info(SecretsKeyStoreHelper.class, String.format(
@@ -265,6 +286,12 @@ public class SecretsKeyStoreHelper {
             }
         }
 
+        // An interrupt says nothing about the store, so it must not suppress the retry budget for
+        // the next caller.
+        if (!interrupted) {
+            lastTerminalFailureAt.set(System.currentTimeMillis());
+        }
+
         return handleUnrecoverableLoad(lastFailure, allowRecreate, interrupted);
     }
 
@@ -279,6 +306,20 @@ public class SecretsKeyStoreHelper {
      */
     private static boolean isIntegrityFailure(final IOException e) {
         return null != e && e.getCause() instanceof UnrecoverableKeyException;
+    }
+
+    /**
+     * Whether this instance gave up on a read within the report interval, meaning the failure is
+     * already known to be persistent and retrying would only add latency.
+     */
+    private boolean recentlyFailedTerminally() {
+        final long last = lastTerminalFailureAt.get();
+        if (0 == last) {
+            return false;
+        }
+        final long interval = Config
+                .getLongProperty(SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS, 60000);
+        return System.currentTimeMillis() - last < interval;
     }
 
     /**
@@ -382,7 +423,14 @@ public class SecretsKeyStoreHelper {
                         () -> "App secrets store is still unreadable: " + diagnosis);
             }
 
-            notifyLoadFailureOnce();
+            // Not on the interrupted path. The notification latch is one-shot for the life of the
+            // JVM, so spending it here -- on a read that was abandoned, where the diagnosis above
+            // says the store may well be fine -- would silently suppress the notification for a
+            // genuinely unreadable store failing later in the same JVM. The throttled ERROR still
+            // fires either way, so the signal is not lost, only the one-time "go and look".
+            if (!interrupted) {
+                notifyLoadFailureOnce();
+            }
 
             throw new SecretsStoreUnreadableException(
                     "Unable to load the App secrets store: " + diagnosis, cause);

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsKeyStoreHelper.java
@@ -6,6 +6,7 @@ import static com.dotcms.security.apps.AppsUtil.digest;
 import com.dotcms.api.system.event.Visibility;
 import com.dotcms.auth.providers.jwt.factories.SigningKeyFactory;
 import com.dotcms.enterprise.cluster.ClusterFactory;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.notifications.bean.NotificationLevel;
 import com.dotcms.notifications.bean.NotificationType;
 import com.dotcms.notifications.business.NotificationAPI;
@@ -622,8 +623,27 @@ public class SecretsKeyStoreHelper {
                 return null;
             }
 
-        } catch (Exception e) {
-            Logger.error(SecretsKeyStoreHelper.class,e);
+        } catch (final Exception e) {
+            // An unreadable store has already been diagnosed and reported by handleUnrecoverableLoad,
+            // at ERROR and throttled to once per SECRETS_STORE_LOAD_FAILURE_REPORT_INTERVAL_MILLIS.
+            // Logging a second, un-throttled stack trace here would undo that: since issue #36724 the
+            // store is preserved rather than wiped, so the condition persists until an operator fixes
+            // it, and nothing caches a failed read -- SecretCachedKeyStoreImpl.getValue only caches
+            // what the supplier returns, so every getSecrets() on every request re-enters this method
+            // and would re-log. That is exactly the per-read flood this PR removes elsewhere, and the
+            // sibling containsKey() path already avoids it by logging at debug
+            // (SecretCachedKeyStoreImpl:59).
+            //
+            // Anything else reaching this catch is genuinely unexpected and still logs loudly.
+            if (ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                Logger.debug(SecretsKeyStoreHelper.class, () -> String.format(
+                        "Secrets store is unreadable; failing the read for key '%s'. Already reported.",
+                        variableKey));
+            } else {
+                Logger.error(SecretsKeyStoreHelper.class, e);
+            }
+            // Wrapped exactly as before: callers match this condition on the cause chain, so the
+            // shape they see must not change.
             throw new DotRuntimeException(e);
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreUnreadableException.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreUnreadableException.java
@@ -18,8 +18,14 @@ import com.dotmarketing.exception.DotRuntimeException;
  *
  * Extends {@link DotRuntimeException} so existing handlers, and the write paths that must never
  * overwrite a store they could not read, keep working unchanged. See issue #36724.
+ *
+ * {@code final} on purpose. Both callers recognise this condition with
+ * {@code ExceptionUtil.causedBy}, which matches on {@code getClass().equals(...)} rather than
+ * {@code isInstance}, so a subclass would silently stop matching -- and silently restore the 500 on
+ * every {@code /api/*} request. Sealing the type makes the exact-class comparison correct by
+ * construction instead of by convention.
  */
-public class SecretsStoreUnreadableException extends DotRuntimeException {
+public final class SecretsStoreUnreadableException extends DotRuntimeException {
 
     public SecretsStoreUnreadableException(final String message, final Throwable cause) {
         super(message, cause);

--- a/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreUnreadableException.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/SecretsStoreUnreadableException.java
@@ -1,0 +1,27 @@
+package com.dotcms.security.apps;
+
+import com.dotmarketing.exception.DotRuntimeException;
+
+/**
+ * Raised when the App secrets store exists but this node cannot load it -- a wrong password
+ * (usually a changed cluster salt or a per-node {@code SECRETS_KEYSTORE_PASSWORD_KEY}), or content
+ * that will not parse.
+ *
+ * Exists so callers can recognise <em>this</em> condition specifically rather than catching
+ * {@link DotRuntimeException}, which is dotCMS's general-purpose unchecked wrapper: database blips,
+ * cache failures and plenty else surface as one. Two callers on request paths must degrade rather
+ * than propagate, because raising there returns a 500 for every {@code /api/*} request
+ * ({@code AppsAPIImpl.filterSitesForAppKey}, reached from {@code EMAWebInterceptor}) or escapes onto
+ * the analytics collection path ({@code SiteAuthValidator}). Catching the broad type there would
+ * have silently degraded unrelated infrastructure failures into "no secrets configured" too; this
+ * type keeps that narrow.
+ *
+ * Extends {@link DotRuntimeException} so existing handlers, and the write paths that must never
+ * overwrite a store they could not read, keep working unchanged. See issue #36724.
+ */
+public class SecretsStoreUnreadableException extends DotRuntimeException {
+
+    public SecretsStoreUnreadableException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/translate/GoogleTranslationService.java
+++ b/dotCMS/src/main/java/com/dotcms/translate/GoogleTranslationService.java
@@ -13,12 +13,15 @@ import com.dotcms.rendering.velocity.viewtools.JSONTool;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.security.apps.AppSecrets;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.ApiProvider;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.Config;
@@ -160,6 +163,18 @@ public class GoogleTranslationService extends AbstractTranslationService {
 
         } catch (DotDataException | DotSecurityException e) {
             Logger.error(this, "Error getting the API Key from the Apps Service: " + e.getMessage());
+            return Config.getStringProperty(GOOGLE_TRANSLATE_SERVICE_API_KEY_PROPERTY, StringPool.BLANK);
+        } catch (DotRuntimeException e) {
+            // An unreadable App secrets store raises since issue #36724, where it previously wiped
+            // itself and returned nothing. This method's whole purpose is to fall back to the
+            // configured property, so it must keep degrading rather than propagate. The exception
+            // arrives wrapped as a plain DotRuntimeException by the layers between here and the
+            // store, hence the cause-chain match; anything else still propagates.
+            if (!ExceptionUtil.causedBy(e, SecretsStoreUnreadableException.class)) {
+                throw e;
+            }
+            Logger.debug(this, () -> "App secrets store is unreadable; falling back to the configured "
+                    + "Google Translate API key");
             return Config.getStringProperty(GOOGLE_TRANSLATE_SERVICE_API_KEY_PROPERTY, StringPool.BLANK);
         } finally {
             if(UtilMethods.isSet(appSecrets) && appSecrets.isPresent()){

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00050LoadAppsSecrets.java
@@ -27,6 +27,7 @@ import com.dotmarketing.startup.runonce.Task04355SystemEventAddServerIdColumn;
 import com.dotmarketing.startup.runonce.Task05350AddDotSaltClusterColumn;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import io.vavr.control.Try;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
@@ -85,7 +86,16 @@ public class Task00050LoadAppsSecrets implements StartupTask {
     @Override
     public boolean forceRun() {
         addDotSaltClusterColumnIfNeeded();
-        return keyStoreHelper.size() == 0 && isSet(Config.getStringProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD, BLANK)) ;
+        // An App secrets store that cannot be read now raises instead of being silently backed up
+        // and replaced with an empty one. That must not take startup down with it: skip the import,
+        // leave the store untouched, and let the ERROR the helper already logged drive the fix.
+        final boolean storeIsEmpty = Try.of(() -> keyStoreHelper.size() == 0)
+                .onFailure(e -> Logger.error(this,
+                        "Unable to read the App secrets store, so the secrets import task will be"
+                                + " skipped. Apps will not work until this is resolved.", e))
+                .getOrElse(false);
+
+        return storeIsEmpty && isSet(Config.getStringProperty(APPS_IMPORT_EXPORT_DEFAULT_PASSWORD, BLANK));
     }
 
     @Override

--- a/dotCMS/src/test/java/com/dotcms/ai/app/ConfigServiceUnreadableStoreTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/app/ConfigServiceUnreadableStoreTest.java
@@ -1,0 +1,150 @@
+package com.dotcms.ai.app;
+
+import com.dotcms.security.apps.AppSecrets;
+import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.exception.InvalidLicenseException;
+import com.liferay.portal.model.User;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers how {@link ConfigService} resolves dotAI configuration when the App secrets store cannot be
+ * read, and — just as importantly — what it must <em>not</em> swallow while doing so.
+ *
+ * <p>Since issue #36724 an unreadable store raises where it previously wiped itself and returned
+ * nothing, so this lookup has to degrade to "the app is unconfigured" on that condition alone.
+ *
+ * <p>The second half of that contract is the one that broke. An earlier revision of this PR degraded
+ * <em>every</em> failure by replacing {@code Try.of(...).get()} with
+ * {@code getOrElse(Optional.empty())}, on the mistaken reading that the {@code Try} was inert.
+ * {@code Try.get()} rethrows, and that was what carried {@link InvalidLicenseException} out to the
+ * caller; swallowing it turned an unlicensed instance into a silent "dotAI is unconfigured". CI
+ * caught it in {@code ConfigServiceTest.test_invalidLicense}, an integration test. These unit cases
+ * pin both halves at unit speed so the same mistake cannot be reintroduced without a fast failure.
+ *
+ * <p>The store failure is thrown in its <em>wrapped</em> production shape,
+ * {@code DotRuntimeException(SecretsStoreUnreadableException(...))} — the intermediate layers re-wrap
+ * it, so a test asserting against the unwrapped type would pass while production still returned 500.
+ */
+public class ConfigServiceUnreadableStoreTest {
+
+    private static final String HOST_NAME = "demo.dotcms.com";
+
+    private MockedStatic<APILocator> apiLocator;
+    private AppsAPI appsAPI;
+    private ConfigService configService;
+    private Host host;
+
+    /** The shape production actually produces: re-wrapped as a bare DotRuntimeException. */
+    private static DotRuntimeException wrappedStoreFailure() {
+        return new DotRuntimeException(new SecretsStoreUnreadableException(
+                "cannot read dotSecretsStore.p12", new IOException("wrong password")));
+    }
+
+    @Before
+    public void setUp() {
+        appsAPI = mock(AppsAPI.class);
+
+        host = mock(Host.class);
+        when(host.getHostname()).thenReturn(HOST_NAME);
+        // System host short-circuits the SYSTEM_HOST fallback lookup in config(), keeping each case
+        // to a single call against the mocked AppsAPI.
+        when(host.isSystemHost()).thenReturn(true);
+
+        apiLocator = mockStatic(APILocator.class);
+        apiLocator.when(APILocator::getAppsAPI).thenReturn(appsAPI);
+        apiLocator.when(APILocator::systemUser).thenReturn(mock(User.class));
+        apiLocator.when(APILocator::systemHost).thenReturn(host);
+
+        // Constructed only AFTER APILocator is stubbed, and the order matters more than it looks:
+        // ConfigService's static INSTANCE field runs on first touch of the class and calls the
+        // no-arg constructor, which resolves the real AppsAPI -> AppsAPIImpl -> DataSource. With no
+        // database present that reaches DbConnectionFactory, whose SYSTEM_EXIT_ON_STARTUP_FAILURE
+        // path (default true) calls System.exit and takes the surefire fork down with it -- the run
+        // then reports "Tests run: 0" rather than a test failure. Stubbing getAppsAPI() first keeps
+        // the static initializer away from the database.
+        configService = new ConfigService(appsAPI);
+    }
+
+    @After
+    public void tearDown() {
+        apiLocator.close();
+    }
+
+    private void storeRaises(final Throwable toThrow) throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any(User.class)))
+                .thenThrow(toThrow);
+    }
+
+    /**
+     * Given an unreadable store, when dotAI resolves its config, then it reports the app as
+     * unconfigured rather than propagating.
+     */
+    @Test
+    public void unreadableStore_reportsAppAsUnconfigured() throws Exception {
+        storeRaises(wrappedStoreFailure());
+
+        final AppConfig config = configService.config(host);
+
+        assertEquals(HOST_NAME, config.getHost());
+        assertNull("No secrets should have been resolved from an unreadable store",
+                config.getApiKey());
+    }
+
+    /**
+     * The regression CI caught. An unlicensed instance must still fail loudly: degrading it would
+     * report dotAI as merely unconfigured and hide the licensing problem.
+     */
+    @Test
+    public void invalidLicense_stillPropagates() throws Exception {
+        storeRaises(new InvalidLicenseException("valid license required"));
+
+        assertThrows(InvalidLicenseException.class, () -> configService.config(host));
+    }
+
+    /**
+     * An unrelated infrastructure failure (a database blip surfaces as a plain DotRuntimeException
+     * too) must propagate — degrading it would hide a real outage behind "unconfigured".
+     */
+    @Test
+    public void unrelatedRuntimeFailure_isNotMasked() throws Exception {
+        storeRaises(new DotRuntimeException("the database went away"));
+
+        final DotRuntimeException thrown = assertThrows(DotRuntimeException.class,
+                () -> configService.config(host));
+        assertEquals("the database went away", thrown.getMessage());
+    }
+
+    /**
+     * Guards the happy path against an over-broad catch: a readable store still yields its secrets.
+     */
+    @Test
+    public void readableStore_returnsSecrets() throws Exception {
+        final AppSecrets secrets = new AppSecrets.Builder()
+                .withKey(AppKeys.APP_KEY)
+                .withHiddenSecret(AppKeys.API_KEY.key, "a-real-key")
+                .build();
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any(User.class)))
+                .thenReturn(Optional.of(secrets));
+
+        assertEquals("a-real-key", configService.config(host).getApiKey());
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/jitsu/validators/SiteAuthValidatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/jitsu/validators/SiteAuthValidatorTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
 import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotRuntimeException;
@@ -26,8 +27,8 @@ import org.mockito.MockedStatic;
 /**
  * Unit tests for {@link SiteAuthValidator}'s exception handling, added for issue #36724.
  *
- * Since that issue the App secrets store raises a {@link DotRuntimeException} when it cannot be
- * read, instead of silently wiping itself and returning an empty store. This validator sits on the
+ * Since that issue the App secrets store raises a {@link SecretsStoreUnreadableException} when it
+ * cannot be read, instead of silently wiping itself and returning an empty store. This validator sits on the
  * analytics collection request path, so that must surface as an ordinary validation failure rather
  * than a raw runtime exception escaping into the response.
  *
@@ -70,16 +71,17 @@ public class SiteAuthValidatorTest {
 
     /**
      * Method to test: {@link SiteAuthValidator#validate(Object)}
-     * Given Scenario: the App secrets store cannot be read, so getSecrets raises the
-     * DotRuntimeException introduced by issue #36724.
+     * Given Scenario: the App secrets store cannot be read, so getSecrets raises
+     * SecretsStoreUnreadableException.
      * Expected Result: an ordinary AnalyticsValidationException carrying INVALID_SITE_AUTH -- never
      * the raw DotRuntimeException, which on this request path would escape into the response.
      */
     @Test
     public void test_unreadableSecretsStore_becomesValidationFailure() throws Exception {
         when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any()))
-                .thenThrow(new DotRuntimeException(
-                        "Unable to load the App secrets store: the store could not be decrypted"));
+                .thenThrow(new SecretsStoreUnreadableException(
+                        "Unable to load the App secrets store: the store could not be decrypted",
+                        new java.io.IOException("Integrity check failed")));
 
         try {
             new SiteAuthValidator().validate("any-site-auth");
@@ -115,6 +117,29 @@ public class SiteAuthValidatorTest {
             assertSame("the domain exception must be rethrown, not re-wrapped", raised, e);
             assertEquals("Site could not be retrieved from Origin or Referer HTTP Headers",
                     e.getMessage());
+        }
+    }
+
+    /**
+     * Method to test: {@link SiteAuthValidator#validate(Object)}
+     * Given Scenario: an unrelated runtime failure -- a database blip or cache error, which dotCMS
+     * surfaces as a plain DotRuntimeException.
+     * Expected Result: it propagates. The catch names SecretsStoreUnreadableException specifically
+     * so a transient infrastructure problem is not quietly converted into "invalid site auth",
+     * which is what catching the general wrapper would have done.
+     */
+    @Test
+    public void test_unrelatedRuntimeFailure_isNotMasked() throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any()))
+                .thenThrow(new DotRuntimeException("the database went away"));
+
+        try {
+            new SiteAuthValidator().validate("any-site-auth");
+            fail("expected the unrelated failure to propagate");
+        } catch (AnalyticsValidator.AnalyticsValidationException e) {
+            fail("an unrelated infrastructure failure must not be reported as invalid site auth");
+        } catch (DotRuntimeException expected) {
+            assertEquals("the database went away", expected.getMessage());
         }
     }
 

--- a/dotCMS/src/test/java/com/dotcms/jitsu/validators/SiteAuthValidatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/jitsu/validators/SiteAuthValidatorTest.java
@@ -122,6 +122,35 @@ public class SiteAuthValidatorTest {
 
     /**
      * Method to test: {@link SiteAuthValidator#validate(Object)}
+     * Given Scenario: the store failure as it actually arrives in production -- wrapped. The
+     * exception is raised deep in the store and several {@code catch (Exception e) { throw new
+     * DotRuntimeException(e); }} layers sit between there and this validator
+     * ({@code SecretsKeyStoreHelper.loadValueFromStore} being the one on this path), so what
+     * reaches the catch is a bare DotRuntimeException with the real cause underneath.
+     * Expected Result: still an ordinary validation failure. Matching only the thrown type never
+     * fires in production -- that mistake silently reinstated the raw-exception-on-the-request-path
+     * bug, and the earlier version of this test missed it by mocking the throw at the boundary
+     * instead of through the re-wrap.
+     */
+    @Test
+    public void test_unreadableStoreWrappedByIntermediateLayers_stillDegrades() throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any()))
+                .thenThrow(new DotRuntimeException(new SecretsStoreUnreadableException(
+                        "Unable to load the App secrets store: the store could not be decrypted",
+                        new java.io.IOException("Integrity check failed"))));
+
+        try {
+            new SiteAuthValidator().validate("any-site-auth");
+            fail("a wrapped unreadable-store failure must fail validation");
+        } catch (AnalyticsValidator.AnalyticsValidationException e) {
+            assertEquals(ValidationErrorCode.INVALID_SITE_AUTH, e.getCode());
+        } catch (DotRuntimeException e) {
+            fail("the wrapped store failure must not escape onto the request path: " + e);
+        }
+    }
+
+    /**
+     * Method to test: {@link SiteAuthValidator#validate(Object)}
      * Given Scenario: an unrelated runtime failure -- a database blip or cache error, which dotCMS
      * surfaces as a plain DotRuntimeException.
      * Expected Result: it propagates. The catch names SecretsStoreUnreadableException specifically

--- a/dotCMS/src/test/java/com/dotcms/jitsu/validators/SiteAuthValidatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/jitsu/validators/SiteAuthValidatorTest.java
@@ -1,0 +1,138 @@
+package com.dotcms.jitsu.validators;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.api.web.HttpServletRequestThreadLocal;
+import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
+import com.dotcms.security.apps.AppsAPI;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotRuntimeException;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Unit tests for {@link SiteAuthValidator}'s exception handling, added for issue #36724.
+ *
+ * Since that issue the App secrets store raises a {@link DotRuntimeException} when it cannot be
+ * read, instead of silently wiping itself and returning an empty store. This validator sits on the
+ * analytics collection request path, so that must surface as an ordinary validation failure rather
+ * than a raw runtime exception escaping into the response.
+ *
+ * The first attempt at that widened the catch to {@code Exception}, which also swallowed
+ * {@link AnalyticsValidator.AnalyticsValidationException} -- the pipeline's own signal, raised by
+ * {@code ContentAnalyticsUtil} when the site cannot be resolved from the Origin/Referer headers --
+ * and re-wrapped it, changing the message callers see. That broke
+ * {@code AnalyticsValidatorUtilTest} in CI. Both halves are pinned below.
+ *
+ * Deliberately a unit test with static mocks rather than an integration test: making the real
+ * secrets store unreadable would mean mutating global Config and the SecretsStore singleton, which
+ * is exactly the kind of cross-test pollution this PR has already had to clean up.
+ */
+public class SiteAuthValidatorTest {
+
+    private MockedStatic<APILocator> apiLocator;
+    private MockedStatic<ContentAnalyticsUtil> analyticsUtil;
+    private AppsAPI appsAPI;
+
+    @Before
+    public void setUp() {
+        HttpServletRequestThreadLocal.INSTANCE.setRequest(mock(HttpServletRequest.class));
+
+        appsAPI = mock(AppsAPI.class);
+        apiLocator = mockStatic(APILocator.class);
+        apiLocator.when(APILocator::getAppsAPI).thenReturn(appsAPI);
+        apiLocator.when(APILocator::systemUser).thenReturn(null);
+
+        analyticsUtil = mockStatic(ContentAnalyticsUtil.class);
+        analyticsUtil.when(() -> ContentAnalyticsUtil.getSiteFromRequest(any()))
+                .thenReturn(new Host());
+    }
+
+    @After
+    public void tearDown() {
+        analyticsUtil.close();
+        apiLocator.close();
+        HttpServletRequestThreadLocal.INSTANCE.setRequest(null);
+    }
+
+    /**
+     * Method to test: {@link SiteAuthValidator#validate(Object)}
+     * Given Scenario: the App secrets store cannot be read, so getSecrets raises the
+     * DotRuntimeException introduced by issue #36724.
+     * Expected Result: an ordinary AnalyticsValidationException carrying INVALID_SITE_AUTH -- never
+     * the raw DotRuntimeException, which on this request path would escape into the response.
+     */
+    @Test
+    public void test_unreadableSecretsStore_becomesValidationFailure() throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any()))
+                .thenThrow(new DotRuntimeException(
+                        "Unable to load the App secrets store: the store could not be decrypted"));
+
+        try {
+            new SiteAuthValidator().validate("any-site-auth");
+            fail("an unreadable secrets store must fail validation");
+        } catch (AnalyticsValidator.AnalyticsValidationException e) {
+            assertEquals(ValidationErrorCode.INVALID_SITE_AUTH, e.getCode());
+        } catch (DotRuntimeException e) {
+            fail("the raw store failure must not escape onto the request path: " + e);
+        }
+    }
+
+    /**
+     * Method to test: {@link SiteAuthValidator#validate(Object)}
+     * Given Scenario: the site cannot be resolved from the Origin/Referer headers, which
+     * ContentAnalyticsUtil signals with its own AnalyticsValidationException.
+     * Expected Result: that exception passes through untouched -- same instance, same message. The
+     * broad catch must not re-wrap it as "Site Auth for Site 'null' could not be verified: ...",
+     * which is the regression that failed AnalyticsValidatorUtilTest in CI.
+     */
+    @Test
+    public void test_siteResolutionFailure_passesThroughUnwrapped() {
+        final AnalyticsValidator.AnalyticsValidationException raised =
+                new AnalyticsValidator.AnalyticsValidationException(
+                        "Site could not be retrieved from Origin or Referer HTTP Headers",
+                        ValidationErrorCode.INVALID_SITE_AUTH);
+
+        analyticsUtil.when(() -> ContentAnalyticsUtil.getSiteFromRequest(any())).thenThrow(raised);
+
+        try {
+            new SiteAuthValidator().validate("any-site-auth");
+            fail("an unresolvable site must fail validation");
+        } catch (AnalyticsValidator.AnalyticsValidationException e) {
+            assertSame("the domain exception must be rethrown, not re-wrapped", raised, e);
+            assertEquals("Site could not be retrieved from Origin or Referer HTTP Headers",
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Method to test: {@link SiteAuthValidator#validate(Object)}
+     * Given Scenario: the store is readable but holds no matching siteAuth.
+     * Expected Result: the ordinary "Invalid Site Auth" failure, unchanged by this PR.
+     */
+    @Test
+    public void test_noMatchingSecret_stillFailsValidation() throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any()))
+                .thenReturn(Optional.empty());
+
+        try {
+            new SiteAuthValidator().validate("any-site-auth");
+            fail("a site auth with no matching secret must fail validation");
+        } catch (AnalyticsValidator.AnalyticsValidationException e) {
+            assertEquals(ValidationErrorCode.INVALID_SITE_AUTH, e.getCode());
+        }
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtilUnreadableStoreTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtilUnreadableStoreTest.java
@@ -1,0 +1,149 @@
+package com.dotcms.rest.api.v1.analytics.content.util;
+
+import com.dotcms.security.apps.AppSecrets;
+import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.liferay.portal.model.User;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers how {@link ContentAnalyticsUtil} behaves when the App secrets store cannot be read.
+ *
+ * <p>Context: before issue #36724 an unreadable store silently recreated itself and returned no
+ * secrets, so these lookups degraded by accident. Since the fix it raises instead, and these methods
+ * have to degrade on purpose -- {@code getBearerTokenFromAppSecrets} feeds
+ * {@code EventAnalyticsProxyHelper.buildAuthHeader()}, which is invoked outside {@code proxy()}'s try
+ * block, so anything escaping here becomes a 500 on every analytics proxy and ingest request.
+ *
+ * <p>The exception never arrives as a {@link SecretsStoreUnreadableException}: several
+ * {@code catch (Exception e) { throw new DotRuntimeException(e); }} layers sit between the store and
+ * this class, so what actually reaches the catch is a bare {@link DotRuntimeException} with the real
+ * cause underneath. These tests therefore throw the <em>wrapped</em> shape, which is what production
+ * produces -- asserting against an unwrapped exception would pass while the production path still
+ * returned 500. The existing {@code SiteAuthValidatorTest} and {@code EventAnalyticsProxyHelperTest}
+ * both {@code mockStatic(ContentAnalyticsUtil.class)}, so neither could observe this class's own
+ * exception handling; that is the gap these tests close.
+ */
+public class ContentAnalyticsUtilUnreadableStoreTest {
+
+    private MockedStatic<APILocator> apiLocator;
+    private AppsAPI appsAPI;
+    private Host site;
+
+    @BeforeEach
+    public void setUp() {
+        appsAPI = mock(AppsAPI.class);
+        site = mock(Host.class);
+        when(site.getIdentifier()).thenReturn("site-id-1");
+
+        apiLocator = mockStatic(APILocator.class);
+        apiLocator.when(APILocator::getAppsAPI).thenReturn(appsAPI);
+        apiLocator.when(APILocator::systemUser).thenReturn(mock(User.class));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        apiLocator.close();
+    }
+
+    private void storeRaises(final Throwable toThrow) throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any(User.class)))
+                .thenThrow(toThrow);
+    }
+
+    /**
+     * The production shape: an unreadable store re-wrapped by the intermediate layers.
+     * Expected result: an empty map, not a propagated exception.
+     */
+    @Test
+    public void getAppSecrets_unreadableStoreWrappedByIntermediateLayers_degradesToEmptyMap()
+            throws Exception {
+        storeRaises(new DotRuntimeException(new SecretsStoreUnreadableException(
+                "cannot read dotSecretsStore.p12", new IOException("wrong password"))));
+
+        final Map<String, com.dotcms.security.apps.Secret> secrets =
+                ContentAnalyticsUtil.getAppSecrets(site);
+
+        assertTrue(secrets.isEmpty(), "An unreadable store must degrade to no secrets, not raise");
+    }
+
+    /**
+     * An unrelated infrastructure failure (a database blip surfaces as a plain
+     * DotRuntimeException too). Expected result: it propagates -- degrading it into "no secrets
+     * configured" would hide real outages behind an unconfigured-app response.
+     */
+    @Test
+    public void getAppSecrets_unrelatedRuntimeFailure_isNotMasked() throws Exception {
+        storeRaises(new DotRuntimeException("the database went away"));
+
+        final DotRuntimeException thrown = assertThrows(DotRuntimeException.class,
+                () -> ContentAnalyticsUtil.getAppSecrets(site));
+        assertEquals("the database went away", thrown.getMessage());
+    }
+
+    /**
+     * The path that produced the 500: {@code buildAuthHeader()} asks for the bearer token before the
+     * proxy's try block opens. Expected result: an empty token, letting the caller fall back.
+     */
+    @Test
+    public void getBearerTokenFromAppSecrets_unreadableStore_degradesToEmpty() throws Exception {
+        storeRaises(new DotRuntimeException(new SecretsStoreUnreadableException(
+                "cannot read dotSecretsStore.p12", new IOException("wrong password"))));
+
+        final Optional<String> token = ContentAnalyticsUtil.getBearerTokenFromAppSecrets(site);
+
+        assertTrue(token.isEmpty(), "An unreadable store must yield no token, not raise");
+    }
+
+    @Test
+    public void getSiteKeyFromAppSecrets_unreadableStore_degradesToEmpty() throws Exception {
+        storeRaises(new DotRuntimeException(new SecretsStoreUnreadableException(
+                "cannot read dotSecretsStore.p12", new IOException("wrong password"))));
+
+        final Optional<String> siteKey = ContentAnalyticsUtil.getSiteKeyFromAppSecrets(site);
+
+        assertTrue(siteKey.isEmpty(), "An unreadable store must yield no site key, not raise");
+    }
+
+    @Test
+    public void getSiteKeyFromAppSecrets_unrelatedRuntimeFailure_isNotMasked() throws Exception {
+        storeRaises(new DotRuntimeException("the database went away"));
+
+        assertThrows(DotRuntimeException.class,
+                () -> ContentAnalyticsUtil.getSiteKeyFromAppSecrets(site));
+    }
+
+    /**
+     * Guards the happy path against over-broad catching: a readable store still returns its secrets.
+     */
+    @Test
+    public void getAppSecrets_readableStore_returnsSecrets() throws Exception {
+        final AppSecrets appSecrets = new AppSecrets.Builder()
+                .withKey("dotAnalytics")
+                .withHiddenSecret("bearerToken", "a-token")
+                .build();
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any(User.class)))
+                .thenReturn(Optional.of(appSecrets));
+
+        assertTrue(ContentAnalyticsUtil.getAppSecrets(site).containsKey("bearerToken"));
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/apps/AppsHelperUnreadableStoreTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/apps/AppsHelperUnreadableStoreTest.java
@@ -1,0 +1,148 @@
+package com.dotcms.rest.api.v1.apps;
+
+import com.dotcms.security.apps.AppDescriptor;
+import com.dotcms.security.apps.AppDescriptorLoadError;
+import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
+import com.dotcms.util.SecurityLoggerServiceAPI;
+import com.dotcms.rest.api.v1.apps.view.AppView;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.portlets.contentlet.business.HostAPI;
+import com.liferay.portal.model.User;
+import io.vavr.Tuple2;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the Apps portlet listing when this node cannot read the App secrets store.
+ *
+ * <p>Context: the listing calls {@code filterSitesForAppKey(appKey, appsAPI.appKeysByHost().keySet(), user)}.
+ * {@code appKeysByHost()} is evaluated as the *argument*, so the cause-chain guard inside
+ * {@code filterSitesForAppKey} never sees the failure -- it is raised before that method is entered.
+ * Before this guard the listing returned a 500, which contradicted the documented behaviour that it
+ * "reports 0 configurations".
+ *
+ * <p>The contract asserted here is that the listing degrades to zero counts <em>and says so</em>: a
+ * silent zero on the secrets screen reads as "your secrets are gone", which is the misreading that
+ * would prompt an administrator to re-enter them.
+ *
+ * <p>Note the guard lives at this call site rather than inside {@code appKeysByHost()} on purpose.
+ * {@code removeApp()}, {@code removeSecretsForSite()} and {@code exportSecrets()} read it too, and an
+ * empty map there would turn the removes into silent no-ops and make {@code exportSecrets()} write an
+ * empty backup that reports success.
+ */
+public class AppsHelperUnreadableStoreTest {
+
+    private AppsAPI appsAPI;
+    private AppsHelper helper;
+    private User user;
+
+    /** The shape production actually produces: re-wrapped as a bare DotRuntimeException. */
+    private static DotRuntimeException wrappedStoreFailure() {
+        return new DotRuntimeException(new SecretsStoreUnreadableException(
+                "cannot read dotSecretsStore.p12", new IOException("wrong password")));
+    }
+
+    private static AppDescriptor descriptor(final String key, final String name) {
+        final AppDescriptor descriptor = mock(AppDescriptor.class);
+        when(descriptor.getKey()).thenReturn(key);
+        when(descriptor.getName()).thenReturn(name);
+        return descriptor;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        appsAPI = mock(AppsAPI.class);
+        user = mock(User.class);
+        // collectLoadErrors() re-reads the app YAML directories, which pulls in ES infrastructure
+        // that cannot initialize in a unit test (and fails with an Error, which its own
+        // catch (Exception) does not stop). Stubbed out: YAML descriptor errors are a separate
+        // concern from the store condition under test here.
+        helper = new AppsHelper(appsAPI, mock(HostAPI.class), mock(PermissionAPI.class),
+                mock(SecurityLoggerServiceAPI.class)) {
+            @Override
+            List<AppDescriptorLoadError> collectLoadErrors() {
+                return List.of();
+            }
+        };
+        // Built before the when(...) below: creating mocks inside thenReturn(...) interrupts
+        // Mockito's ongoing stubbing and fails with UnfinishedStubbing.
+        final List<AppDescriptor> descriptors = List.of(
+                descriptor("dotAnalytics", "Analytics"), descriptor("dotEMA", "EMA"));
+        when(appsAPI.getAppDescriptors(any(User.class))).thenReturn(descriptors);
+    }
+
+    /**
+     * Given an unreadable store, when the apps are listed, then every app is still returned with a
+     * count of zero and a dedicated error entry explains why.
+     */
+    @Test
+    public void unreadableStore_listsAppsWithZeroCountsAndReportsTheCondition() throws Exception {
+        when(appsAPI.appKeysByHost()).thenThrow(wrappedStoreFailure());
+
+        final Tuple2<List<AppView>, List<AppDescriptorLoadError>> result =
+                helper.getAvailableDescriptorViewsWithErrors(user, null);
+
+        assertEquals("Every app should still be listed", 2, result._1.size());
+        result._1.forEach(view -> assertEquals(
+                "An unreadable store must not invent a configuration count",
+                0, view.getConfigurationsCount()));
+
+        assertEquals("The condition must be reported, not degraded silently", 1, result._2.size());
+        final AppDescriptorLoadError error = result._2.get(0);
+        assertEquals(AppDescriptorLoadError.SECRETS_STORE_UNREADABLE_ERROR_CODE,
+                error.getErrorCode());
+        assertEquals("dotSecretsStore.p12", error.getFileName());
+        assertTrue("The message should reassure that nothing was lost",
+                error.getMessage().contains("intact"));
+    }
+
+    /**
+     * An unrelated runtime failure (a database blip surfaces as a plain DotRuntimeException too)
+     * must still propagate -- degrading it would hide a real outage behind "0 configurations".
+     */
+    @Test
+    public void unrelatedRuntimeFailure_isNotMasked() throws Exception {
+        when(appsAPI.appKeysByHost()).thenThrow(new DotRuntimeException("the database went away"));
+
+        final DotRuntimeException thrown = assertThrows(DotRuntimeException.class,
+                () -> helper.getAvailableDescriptorViewsWithErrors(user, null));
+        assertEquals("the database went away", thrown.getMessage());
+    }
+
+    /**
+     * The happy path must keep its real counts, guarding against an over-broad catch: two sites
+     * configured for one app, none for the other.
+     */
+    @Test
+    public void readableStore_keepsRealCountsAndReportsNoError() throws Exception {
+        when(appsAPI.appKeysByHost()).thenReturn(Map.of(
+                "site-1", Set.of("dotAnalytics"), "site-2", Set.of("dotAnalytics")));
+        when(appsAPI.filterSitesForAppKey(anyString(), any(), any(User.class)))
+                .thenAnswer(inv -> "dotAnalytics".equals(inv.getArgument(0))
+                        ? Set.of("site-1", "site-2") : Set.of());
+        when(appsAPI.computeWarningsBySite(any(AppDescriptor.class), any(), any(User.class)))
+                .thenReturn(Map.of());
+
+        final Tuple2<List<AppView>, List<AppDescriptorLoadError>> result =
+                helper.getAvailableDescriptorViewsWithErrors(user, null);
+
+        assertTrue("A readable store must report no store error", result._2.isEmpty());
+        // Sorted by count descending, so the configured app comes first.
+        assertEquals(2, result._1.get(0).getConfigurationsCount());
+        assertEquals(0, result._1.get(1).getConfigurationsCount());
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/security/apps/AppsAPIImplUnreadableStoreTest.java
+++ b/dotCMS/src/test/java/com/dotcms/security/apps/AppsAPIImplUnreadableStoreTest.java
@@ -1,0 +1,132 @@
+package com.dotcms.security.apps;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
+import com.dotcms.util.LicenseValiditySupplier;
+import com.dotmarketing.business.LayoutAPI;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.portlets.contentlet.business.HostAPI;
+import com.liferay.portal.model.User;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Guards how {@link AppsAPIImpl#filterSitesForAppKey} behaves when the App secrets store cannot be
+ * read (issue #36724).
+ *
+ * This is the highest-consequence path of that change: {@code EMAWebInterceptor.existsConfiguration}
+ * reaches this method on every {@code /api/*} request and the interceptor chain does not guard it, so
+ * raising here returns a 500 for the entire API.
+ *
+ * The reason this class exists is that the fix regressed once already. The store raises
+ * {@link SecretsStoreUnreadableException} deep inside itself, but
+ * {@code catch (Exception e) { throw new DotRuntimeException(e); }} layers sit between there and here
+ * -- {@code SecretCachedKeyStoreImpl.containsKey} is the one on this path -- so what actually arrives
+ * is a bare {@link DotRuntimeException} wrapping the real cause. Matching on the thrown type
+ * compiled, read as the cleanest option, passed every test, and never fired in production. These
+ * cases therefore throw the failure **wrapped**, the way it really arrives.
+ *
+ * Every case makes {@code containsKey} throw, which deliberately keeps the test out of
+ * {@code hasAnySecrets}' env-var branch: that reaches descriptor and config lookups which, with no
+ * database present, take {@code DbConnectionFactory}'s {@code System.exit} path
+ * ({@code SYSTEM_EXIT_ON_STARTUP_FAILURE} defaults to true) and kill the surefire fork.
+ */
+public class AppsAPIImplUnreadableStoreTest {
+
+    private static final String APP_KEY = "dotcms-app";
+    private static final String SITE_ID = "48190c8c-42c4-46af-8d1a-0cd5db894797";
+
+    private AppsAPIImpl newApi(final SecretsStore secretsStore) {
+        final LayoutAPI layoutAPI = mock(LayoutAPI.class);
+        try {
+            // Grant portlet access, so the check in hasAnySecrets passes and the store is reached.
+            when(layoutAPI.doesUserHaveAccessToPortlet(anyString(), any(User.class)))
+                    .thenReturn(true);
+        } catch (final Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return new AppsAPIImpl(
+                layoutAPI,
+                mock(HostAPI.class),
+                secretsStore,
+                mock(AppsCache.class),
+                mock(LocalSystemEventsAPI.class),
+                mock(AppDescriptorHelper.class),
+                new LicenseValiditySupplier() {
+                    @Override
+                    public boolean hasValidLicense() {
+                        return true;
+                    }
+                });
+    }
+
+    private SecretsStore storeThatThrows(final RuntimeException failure) {
+        final SecretsStore secretsStore = mock(SecretsStore.class);
+        when(secretsStore.containsKey(anyString())).thenThrow(failure);
+        return secretsStore;
+    }
+
+    private static SecretsStoreUnreadableException unreadable() {
+        return new SecretsStoreUnreadableException(
+                "Unable to load the App secrets store: the store could not be decrypted",
+                new java.io.IOException("Integrity check failed"));
+    }
+
+    /**
+     * Method to test: {@link AppsAPIImpl#filterSitesForAppKey(String, java.util.Collection, User)}
+     * Given Scenario: the store cannot be read, and the failure arrives wrapped in a bare
+     * DotRuntimeException by the intermediate cache layer — exactly as it does in production.
+     * Expected Result: the site reports no secrets. It must not raise: EMAWebInterceptor calls this
+     * on every /api/* request, so raising returns a 500 for the whole API.
+     */
+    @Test
+    public void test_unreadableStoreWrapped_degradesInsteadOfRaising() {
+        final Set<String> configured = newApi(storeThatThrows(new DotRuntimeException(unreadable())))
+                .filterSitesForAppKey(APP_KEY, List.of(SITE_ID), mock(User.class));
+
+        assertTrue("a wrapped unreadable-store failure must report no configured sites, not raise",
+                configured.isEmpty());
+    }
+
+    /**
+     * Method to test: {@link AppsAPIImpl#filterSitesForAppKey(String, java.util.Collection, User)}
+     * Given Scenario: two layers of wrapping, as happens when listKeys re-wraps before containsKey
+     * re-wraps again.
+     * Expected Result: still degrades. The number of wrapping layers is not this method's business,
+     * which is why the guard walks the cause chain instead of matching the thrown type.
+     */
+    @Test
+    public void test_unreadableStoreDoubleWrapped_stillDegrades() {
+        final Set<String> configured = newApi(
+                storeThatThrows(new DotRuntimeException(new DotRuntimeException(unreadable()))))
+                .filterSitesForAppKey(APP_KEY, List.of(SITE_ID), mock(User.class));
+
+        assertTrue("depth of wrapping must not matter", configured.isEmpty());
+    }
+
+    /**
+     * Method to test: {@link AppsAPIImpl#filterSitesForAppKey(String, java.util.Collection, User)}
+     * Given Scenario: an unrelated runtime failure — a database blip or cache error, which dotCMS
+     * surfaces as a plain DotRuntimeException with nothing store-related in its cause chain.
+     * Expected Result: it propagates. Swallowing it would report "0 configurations" for a transient
+     * infrastructure problem and would hide genuine bugs on a very hot path.
+     */
+    @Test
+    public void test_unrelatedRuntimeFailure_propagates() {
+        try {
+            newApi(storeThatThrows(new DotRuntimeException("the database went away")))
+                    .filterSitesForAppKey(APP_KEY, List.of(SITE_ID), mock(User.class));
+            fail("an unrelated infrastructure failure must not be reported as 'no secrets'");
+        } catch (DotRuntimeException expected) {
+            assertEquals("the database went away", expected.getMessage());
+        }
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/translate/GoogleTranslationServiceUnreadableStoreTest.java
+++ b/dotCMS/src/test/java/com/dotcms/translate/GoogleTranslationServiceUnreadableStoreTest.java
@@ -1,0 +1,155 @@
+package com.dotcms.translate;
+
+import com.dotcms.rendering.velocity.viewtools.JSONTool;
+import com.dotcms.security.apps.AppSecrets;
+import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.SecretsStoreUnreadableException;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.ApiProvider;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.portlets.contentlet.business.HostAPI;
+import com.dotmarketing.util.Config;
+import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static com.dotcms.translate.GoogleTranslationService.API_KEY_VAR;
+import static com.dotcms.translate.GoogleTranslationService.GOOGLE_TRANSLATE_SERVICE_API_KEY_PROPERTY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@code GoogleTranslationService.getFallbackAPIKey()} when the App secrets store cannot be
+ * read.
+ *
+ * <p>That method exists precisely to fall back to the configured
+ * {@code GOOGLE_TRANSLATE_SERVICE_API_KEY} property, but its catch named only
+ * {@code DotDataException | DotSecurityException}. Since issue #36724 an unreadable store raises --
+ * where it previously wiped itself and returned nothing -- and the raise walked straight past that
+ * catch, so the fallback never happened.
+ *
+ * <p>The failure is thrown in its <em>wrapped</em> production shape,
+ * {@code DotRuntimeException(SecretsStoreUnreadableException(...))}: the layers between the store and
+ * here re-wrap it, so a test asserting on the unwrapped type would pass while production still broke.
+ *
+ * <p>Reached through {@code setServiceParameters} with a blank API key, which is the only path to the
+ * private fallback method.
+ */
+public class GoogleTranslationServiceUnreadableStoreTest {
+
+    private static final String CONFIGURED_KEY = "configured-fallback-key";
+    private static final String HOST_ID = "48190c8c-42c4-46af-8d1a-0cd5db894797";
+
+    private MockedStatic<APILocator> apiLocator;
+    private MockedStatic<Config> config;
+    private AppsAPI appsAPI;
+    private GoogleTranslationService service;
+
+    /** The shape production actually produces: re-wrapped as a bare DotRuntimeException. */
+    private static DotRuntimeException wrappedStoreFailure() {
+        return new DotRuntimeException(new SecretsStoreUnreadableException(
+                "cannot read dotSecretsStore.p12", new IOException("wrong password")));
+    }
+
+    /** A blank key is what sends setServiceParameters into the fallback lookup. */
+    private static List<ServiceParameter> blankApiKeyParam() {
+        return List.of(new ServiceParameter(API_KEY_VAR, "Service API Key", StringPool.BLANK));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        appsAPI = mock(AppsAPI.class);
+
+        // find() must be stubbed to a real (mock) Host, not left to return null. getFallbackAPIKey
+        // wraps it in Try.of(...).getOrElse(systemHost), and a null RESULT is a Success -- getOrElse
+        // only fires on failure -- so the host stays null, and Mockito's any(Host.class) does not
+        // match null. The getSecrets stub below would then never apply, Mockito would hand back its
+        // default Optional.empty(), and every case would take the "no secrets" branch: the
+        // unreadable-store test would pass without the exception ever being thrown.
+        final HostAPI hostAPI = mock(HostAPI.class);
+        when(hostAPI.find(anyString(), any(User.class), anyBoolean())).thenReturn(mock(Host.class));
+
+        apiLocator = mockStatic(APILocator.class);
+        apiLocator.when(APILocator::getAppsAPI).thenReturn(appsAPI);
+        apiLocator.when(APILocator::getHostAPI).thenReturn(hostAPI);
+        apiLocator.when(APILocator::systemUser).thenReturn(mock(User.class));
+        apiLocator.when(APILocator::systemHost).thenReturn(mock(Host.class));
+
+        config = mockStatic(Config.class);
+        config.when(() -> Config.getStringProperty(
+                        eq(GOOGLE_TRANSLATE_SERVICE_API_KEY_PROPERTY), anyString()))
+                .thenReturn(CONFIGURED_KEY);
+        config.when(() -> Config.getStringProperty(
+                        eq("GOOGLE_TRANSLATE_SERVICE_BASE_URL"), anyString()))
+                .thenReturn(GoogleTranslationService.BASE_URL);
+
+        service = new GoogleTranslationService(
+                StringPool.BLANK, mock(JSONTool.class), mock(ApiProvider.class));
+    }
+
+    @After
+    public void tearDown() {
+        config.close();
+        apiLocator.close();
+    }
+
+    /**
+     * Given an unreadable store, when the service resolves its API key, then it falls back to the
+     * configured property instead of propagating.
+     */
+    @Test
+    public void unreadableStore_fallsBackToConfiguredKey() throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any(User.class)))
+                .thenThrow(wrappedStoreFailure());
+
+        service.setServiceParameters(blankApiKeyParam(), HOST_ID);
+
+        assertEquals(CONFIGURED_KEY, service.getApiKey());
+    }
+
+    /**
+     * An unrelated infrastructure failure must still propagate -- silently falling back would hide a
+     * real outage behind a working-looking configuration.
+     */
+    @Test
+    public void unrelatedRuntimeFailure_isNotMasked() throws Exception {
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any(User.class)))
+                .thenThrow(new DotRuntimeException("the database went away"));
+
+        final DotRuntimeException thrown = assertThrows(DotRuntimeException.class,
+                () -> service.setServiceParameters(blankApiKeyParam(), HOST_ID));
+        assertEquals("the database went away", thrown.getMessage());
+    }
+
+    /**
+     * Guards the happy path against an over-broad catch: a readable store's secret still wins over
+     * the configured property.
+     */
+    @Test
+    public void readableStore_prefersTheStoredSecret() throws Exception {
+        final AppSecrets secrets = new AppSecrets.Builder()
+                .withKey(GoogleTranslationService.GOOGLE_TRANSLATE_APP_CONFIG_KEY)
+                .withHiddenSecret(API_KEY_VAR, "stored-key")
+                .build();
+        when(appsAPI.getSecrets(anyString(), anyBoolean(), any(Host.class), any(User.class)))
+                .thenReturn(Optional.of(secrets));
+
+        service.setServiceParameters(blankApiKeyParam(), HOST_ID);
+
+        assertEquals("stored-key", service.getApiKey());
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -15,6 +15,8 @@ import com.dotcms.rest.api.v1.drive.ContentDriveWorkflowArchiveStepTest;
 import com.dotcms.rest.api.v1.drive.ContentDriveWorkflowFilterTest;
 import com.dotcms.rest.api.v1.system.cache.CacheResourceIntegrationTest;
 import com.dotcms.security.apps.AppsAPIImplTest;
+import com.dotcms.security.apps.SecretsStoreConcurrentWriteRaceTest;
+import com.dotcms.security.apps.SecretsStoreWipeRegressionTest;
 import com.dotcms.telemetry.collectors.MetricTimeoutTest;
 import com.dotcms.telemetry.collectors.experiment.CountPagesWithAllEndedExperimentsMetricTypeTest;
 import com.dotcms.telemetry.collectors.experiment.CountPagesWithArchivedExperimentsMetricTypeTest;
@@ -102,6 +104,8 @@ import org.junit.runners.Suite;
         ContentToStringUtilTest.class,
         CacheResourceIntegrationTest.class,
         InodeExistenceCheckIntegrationTest.class,
+        SecretsStoreWipeRegressionTest.class,
+        SecretsStoreConcurrentWriteRaceTest.class,
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreConcurrentWriteRaceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreConcurrentWriteRaceTest.java
@@ -1,0 +1,132 @@
+package com.dotcms.security.apps;
+
+import static com.dotcms.security.apps.SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY;
+import static org.junit.Assert.assertFalse;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.util.Config;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Reproduction harness for issue #35592 — "App configurations silently wiped out
+ * (dotSecretsStore.p12 integrity failure -&gt; empty store regenerated)".
+ *
+ * <p>In a multi-node cluster every node reads and writes the SAME
+ * {@code dotSecretsStore.p12} living on shared assets storage, with no lock. When two nodes
+ * touch it concurrently:
+ * <ul>
+ *   <li>{@code SecretsKeyStoreHelper.saveSecretsStore()} writes a tmp file then
+ *       {@code FileUtil.copyFile(tmp, dest)}. On shared network storage (NFS/EFS) hard links
+ *       are unavailable, so {@code copyFile} truncates the destination to zero and streams the
+ *       bytes back in — a reader on another node can observe a torn / empty PKCS12.</li>
+ *   <li>A torn read throws {@code Failed PKCS12 integrity checking}, which
+ *       {@code getSecretsStore()} "recovers" from by backing up, deleting, and regenerating an
+ *       EMPTY store — silently wiping every previously stored App secret.</li>
+ * </ul>
+ *
+ * <p>This test seeds a canary secret and then hammers the shared store with concurrent writes
+ * and reads, asserting the canary can never disappear. It failed on {@code master} when it was
+ * written, reproducing #35592. It is retained as the concurrent stress companion to the
+ * deterministic {@code SecretsStoreWipeRegressionTest}, and passes with the fix for #36724 (atomic
+ * publish plus no wipe-on-transient-error).
+ *
+ * <p>Everything is isolated to a temp file via {@code SECRETS_KEYSTORE_FILE_PATH_KEY}, so the
+ * real store is never touched, and both Config overrides are restored in {@code finally}.
+ */
+public class SecretsStoreConcurrentWriteRaceTest {
+
+    private static final String CONTENT_VERSION_HARD_LINK = "CONTENT_VERSION_HARD_LINK";
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Test
+    public void concurrent_writes_silently_wipe_previously_stored_secret() throws Exception {
+
+        final Path tmpDir = Files.createTempDirectory("secrets-race-35592");
+        final String storePath = tmpDir.resolve("dotSecretsStore.p12").toString();
+        final String priorPath = Config.getStringProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, null);
+        final boolean priorHardLink = Config.getBooleanProperty(CONTENT_VERSION_HARD_LINK, true);
+
+        // Point the store at an isolated temp file, and simulate shared network storage
+        // (NFS/EFS) where hard links are unavailable -> FileUtil.copyFile truncates + streams.
+        Config.setProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, storePath);
+        Config.setProperty(CONTENT_VERSION_HARD_LINK, false);
+
+        final ExecutorService pool = Executors.newFixedThreadPool(3);
+        try {
+            // A fixed password shared by both "nodes" (deterministic, like a shared cluster_salt).
+            final Supplier<char[]> pwd = () -> "shared-cluster-salt-digest".toCharArray();
+            final SecretsKeyStoreHelper nodeA = new SecretsKeyStoreHelper(pwd, ImmutableList.of());
+            final SecretsKeyStoreHelper nodeB = new SecretsKeyStoreHelper(pwd, ImmutableList.of());
+
+            final String canaryKey = "canary-app-config";
+            final char[] canaryVal = "must-survive".toCharArray();
+            nodeA.saveValue(canaryKey, canaryVal);
+
+            final int iterations = 800;
+            final AtomicReference<String> lostReason = new AtomicReference<>(null);
+
+            // Writer "node": continuously rewrites the whole shared store with new keys.
+            final Future<?> writer = pool.submit(() -> {
+                for (int i = 0; i < iterations; i++) {
+                    nodeA.saveValue("k-" + i, ("v-" + i).toCharArray());
+                }
+            });
+
+            // Two reader "nodes" checking the canary is still present on every read.
+            final Runnable readerTask = () -> {
+                for (int i = 0; i < iterations && lostReason.get() == null; i++) {
+                    try {
+                        // getValue returns the value still encrypted -- decryption is the caching
+                        // wrapper's job -- so it must be decrypted before comparing against the
+                        // plaintext canary. Comparing the raw result would never match.
+                        final char[] stored = nodeB.getValue(canaryKey);
+                        if (Arrays.equals(stored, AppsCache.CACHE_404)) {
+                            lostReason.compareAndSet(null,
+                                    "canary secret disappeared (store wiped / regenerated empty)");
+                        } else if (!Arrays.equals(nodeB.decrypt(stored), canaryVal)) {
+                            lostReason.compareAndSet(null,
+                                    "canary secret changed value under concurrent writes");
+                        }
+                    } catch (Exception e) {
+                        lostReason.compareAndSet(null,
+                                "read threw during concurrent write: " + e);
+                    }
+                }
+            };
+            final Future<?> reader1 = pool.submit(readerTask);
+            final Future<?> reader2 = pool.submit(readerTask);
+
+            writer.get(60, TimeUnit.SECONDS);
+            reader1.get(60, TimeUnit.SECONDS);
+            reader2.get(60, TimeUnit.SECONDS);
+
+            assertFalse("Regression #35592/#36724 — a durably stored App secret was lost under a "
+                            + "concurrent multi-node write: " + lostReason.get(),
+                    lostReason.get() != null);
+        } finally {
+            pool.shutdownNow();
+            Config.setProperty(CONTENT_VERSION_HARD_LINK, priorHardLink);
+            Config.setProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, priorPath == null ? "" : priorPath);
+            try (var paths = Files.walk(tmpDir)) {
+                paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+        }
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreKeyStoreImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreKeyStoreImplTest.java
@@ -4,12 +4,18 @@ import static com.dotcms.security.apps.SecretsKeyStoreHelper.SECRETS_KEYSTORE_PA
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertTrue;
 
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.util.Config;
+import com.google.common.collect.ImmutableList;
 import com.dotmarketing.util.UUIDGenerator;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import org.apache.commons.lang.RandomStringUtils;
@@ -216,30 +222,102 @@ public class SecretsStoreKeyStoreImplTest {
     }
 
     /**
-     * Given scenario: We ensure there's a storage file out there created on top of a password. Then
-     * we set a new password to simulate a conflict loading the existing file
-     * Expected Result: After changing password we should still be able to interact with the store
-     * without getting the UnrecoverableKeyException.
-     * But as the previous file just got wiped-out no secret previously stored will be available now.
+     * Given scenario: a store is created under one password, then read with a different one — the
+     * cluster-salt rotation / per-node override drift from issue #36724.
+     * Expected Result: the load fails and the store is PRESERVED.
+     *
+     * This method previously asserted the opposite: that the store was silently wiped and
+     * reading simply returned nothing ("as the previous file just got wiped-out no secret
+     * previously stored will be available now"). That behaviour was the data loss reported in
+     * #36724 — the wiped file held every App credential, and the backup it left behind was
+     * encrypted with the password that had just failed, so it could not be restored either.
+     * Recreating the store is now opt-in; see
+     * {@link #Test_Recovery_On_Load_Failure_When_Auto_Recreate_Enabled()}.
+     *
+     * Deliberately isolated to its own temp file and its own password supplier rather than
+     * mutating the shared SECRETS_KEYSTORE_PASSWORD_KEY and the SecretsStore singleton. The old
+     * version left a random password in Config -- restoring it did nothing, because the property is
+     * normally unset and so the "original value" it saved was null -- and relied on the auto-wipe to
+     * rebuild a usable store for whatever test ran next.
      */
     @Test
-    public void Test_Recovery_On_Load_Failure() {
-        final String password = Config.getStringProperty(SECRETS_KEYSTORE_PASSWORD_KEY);
+    public void Test_Recovery_On_Load_Failure() throws Exception {
+        final Path tmpDir = Files.createTempDirectory("secrets-load-failure-");
+        final Path storePath = tmpDir.resolve("dotSecretsStore.p12");
+        final String priorPath = Config
+                .getStringProperty(SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY, null);
+        Config.setProperty(SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY,
+                storePath.toString());
         try {
-            final SecretCachedKeyStoreImpl secretsStore = (SecretCachedKeyStoreImpl) SecretsStore.INSTANCE.get();
+            final SecretsKeyStoreHelper nodeA = new SecretsKeyStoreHelper(
+                    () -> "password-one".toCharArray(), ImmutableList.of());
             final String anyKey = "anyKey-" + System.currentTimeMillis();
-            final String anyValue = "anyValue";
-            // Save something to ensure there's a file in use.
-            secretsStore.saveValue(anyKey, anyValue.toCharArray());
-            //Now we change the password.
-            Config.setProperty(SECRETS_KEYSTORE_PASSWORD_KEY,
-                    RandomStringUtils.randomAlphanumeric(10));
-            secretsStore.flushCache();
-            //it's a brand new store so do not expect the old key to be there.
-            final Optional<char[]> valueInStore = secretsStore.getValue(anyKey);
-            assertFalse(valueInStore.isPresent());
+            nodeA.saveValue(anyKey, "anyValue".toCharArray());
+            final long lengthBefore = Files.size(storePath);
+
+            final SecretsKeyStoreHelper nodeB = new SecretsKeyStoreHelper(
+                    () -> RandomStringUtils.randomAlphanumeric(10).toCharArray(),
+                    ImmutableList.of());
+            try {
+                nodeB.getValue(anyKey);
+                fail("a store that cannot be decrypted must raise rather than be replaced");
+            } catch (DotRuntimeException expected) {
+                // correct: this password cannot open the store
+            }
+
+            assertTrue("the store must not be deleted", Files.exists(storePath));
+            assertEquals("the store must be left untouched", lengthBefore, Files.size(storePath));
+            assertEquals("the secret must still be readable with the correct password", "anyValue",
+                    new String(nodeA.decrypt(nodeA.getValue(anyKey))));
         } finally {
-            Config.setProperty(SECRETS_KEYSTORE_PASSWORD_KEY, password);
+            Config.setProperty(SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY,
+                    priorPath == null ? "" : priorPath);
+            try (java.util.stream.Stream<Path> paths = Files.walk(tmpDir)) {
+                paths.sorted(java.util.Comparator.reverseOrder()).map(Path::toFile)
+                        .forEach(java.io.File::delete);
+            }
+        }
+    }
+
+    /**
+     * Given scenario: the same password mismatch, but with SECRETS_STORE_AUTO_RECREATE enabled —
+     * an operator explicitly accepting the loss of the secrets to get a working store back.
+     * Expected Result: the pre-#36724 behaviour, i.e. the store is backed up, replaced with an empty
+     * one, and the read returns nothing instead of raising. Pins the escape hatch.
+     */
+    @Test
+    public void Test_Recovery_On_Load_Failure_When_Auto_Recreate_Enabled() throws Exception {
+        final Path tmpDir = Files.createTempDirectory("secrets-auto-recreate-");
+        final Path storePath = tmpDir.resolve("dotSecretsStore.p12");
+        final String priorPath = Config
+                .getStringProperty(SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY, null);
+        final String priorAutoRecreate = Config
+                .getStringProperty(SecretsKeyStoreHelper.SECRETS_STORE_AUTO_RECREATE, null);
+        Config.setProperty(SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY,
+                storePath.toString());
+        try {
+            final SecretsKeyStoreHelper nodeA = new SecretsKeyStoreHelper(
+                    () -> "password-one".toCharArray(), ImmutableList.of());
+            final String anyKey = "anyKey-" + System.currentTimeMillis();
+            nodeA.saveValue(anyKey, "anyValue".toCharArray());
+
+            Config.setProperty(SecretsKeyStoreHelper.SECRETS_STORE_AUTO_RECREATE, "true");
+
+            final SecretsKeyStoreHelper nodeB = new SecretsKeyStoreHelper(
+                    () -> "a-different-password".toCharArray(), ImmutableList.of());
+
+            assertTrue("the recreated store is empty, so the old secret is gone",
+                    Arrays.equals(AppsCache.CACHE_404, nodeB.getValue(anyKey)));
+            assertTrue("a fresh store must exist", Files.exists(storePath));
+        } finally {
+            Config.setProperty(SecretsKeyStoreHelper.SECRETS_STORE_AUTO_RECREATE,
+                    priorAutoRecreate == null ? "false" : priorAutoRecreate);
+            Config.setProperty(SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY,
+                    priorPath == null ? "" : priorPath);
+            try (java.util.stream.Stream<Path> paths = Files.walk(tmpDir)) {
+                paths.sorted(java.util.Comparator.reverseOrder()).map(Path::toFile)
+                        .forEach(java.io.File::delete);
+            }
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -239,6 +239,42 @@ public class SecretsStoreWipeRegressionTest {
     }
 
     /**
+     * Method to test: {@link SecretsKeyStoreHelper#shouldReportLoadFailure()}
+     * Given Scenario: a store this node cannot open. Every consumer wraps its read defensively, so
+     * the state persists and every subsequent read reaches the same failure handler.
+     * Expected Result: the failure is reported once, then suppressed until the interval elapses —
+     * while every read still raises. Without this the actionable ERROR (and the admin notification,
+     * which writes a row) would be emitted on every page render, login and content save.
+     */
+    @Test
+    public void test_repeatedLoadFailures_areReportedOnceButAlwaysRaise() throws Exception {
+        final SecretsKeyStoreHelper nodeA = helperWithPassword(PASSWORD_A);
+        nodeA.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+
+        final SecretsKeyStoreHelper nodeB = helperWithPassword(PASSWORD_B);
+
+        assertTrue("the first failure must always be reported", nodeB.shouldReportLoadFailure());
+        assertFalse("an immediately following failure must be suppressed",
+                nodeB.shouldReportLoadFailure());
+        assertFalse(nodeB.shouldReportLoadFailure());
+
+        // Suppressing the report must not suppress the failure itself.
+        for (int i = 0; i < 3; i++) {
+            try {
+                nodeB.getValue(CANARY_KEY);
+                fail("every read of an unreadable store must raise, reported or not");
+            } catch (DotRuntimeException expected) {
+                // correct
+            }
+        }
+
+        assertTrue("the store must survive every one of those attempts", Files.exists(storePath));
+        assertEquals("and must never be backed up or replaced", 0, countBackups());
+        assertEquals("the owning node must still read its secret", CANARY_VALUE,
+                readSecret(nodeA, CANARY_KEY));
+    }
+
+    /**
      * Method to test: file permissions on the published store.
      * Given Scenario: the store is written into a directory shared across the cluster.
      * Expected Result: it is readable only by its owner. Previously both the temp file and the store

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -279,6 +279,25 @@ public class SecretsStoreWipeRegressionTest {
         assertEquals("and must never be backed up or replaced", 0, countBackups());
         assertEquals("the owning node must still read its secret", CANARY_VALUE,
                 readSecret(nodeA, CANARY_KEY));
+
+        // The admin notification is a persisted row, so unlike the log line it must not repeat on
+        // an interval. A container run with the interval shortened to 10s produced 20 notification
+        // rows in five minutes before this was separated out.
+        assertTrue("the notification latch must be set after the first failure",
+                SecretsKeyStoreHelper.hasNotifiedLoadFailure());
+
+        // A second helper on the same broken store must not raise another notification: the latch
+        // is per JVM, not per instance, because an operator does not need the same instruction
+        // twice just because two components each hold a helper.
+        final SecretsKeyStoreHelper nodeC = helperWithPassword("yet-another-wrong-password");
+        try {
+            nodeC.getValue(CANARY_KEY);
+            fail("still unreadable for this password");
+        } catch (DotRuntimeException expected) {
+            // correct
+        }
+        assertTrue("latch stays set; no second notification",
+                SecretsKeyStoreHelper.hasNotifiedLoadFailure());
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -69,6 +69,11 @@ public class SecretsStoreWipeRegressionTest {
         Config.setProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, storePath.toString());
         // Keep the retry budget small so a deliberately unreadable store fails fast.
         Config.setProperty(SECRETS_STORE_LOAD_TRIES, "2");
+
+        // The notification latch is static and never resets in production, so within one Surefire
+        // fork it stays set once any test trips it. Clearing it here makes the transition assertion
+        // below independent of whichever sibling test ran first.
+        SecretsKeyStoreHelper.resetNotifiedLoadFailureLatch();
     }
 
     @After
@@ -255,6 +260,9 @@ public class SecretsStoreWipeRegressionTest {
      */
     @Test
     public void test_repeatedLoadFailures_areReportedOnceButAlwaysRaise() throws Exception {
+        assertFalse("setUp cleared the latch, so this test can assert the transition",
+                SecretsKeyStoreHelper.hasNotifiedLoadFailure());
+
         final SecretsKeyStoreHelper nodeA = helperWithPassword(PASSWORD_A);
         nodeA.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
 

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -309,6 +309,52 @@ public class SecretsStoreWipeRegressionTest {
     }
 
     /**
+     * Method to test: the retry cap after a terminal failure, in {@code loadSecretsStore}.
+     * Given Scenario: a persistently truncated store — an IOException with no
+     * UnrecoverableKeyException cause, so it is classified transient and retried with backoff. The
+     * store is now preserved rather than wiped, so that state persists and every read re-enters the
+     * loop.
+     * Expected Result: the first read pays the backoff, subsequent reads within the report interval
+     * do not. Without the cap every page render, login and content save would burn the full backoff
+     * (300ms at defaults) before degrading, indefinitely.
+     */
+    @Test
+    public void test_persistentNonIntegrityFailure_stopsPayingTheBackoff() throws Exception {
+        final SecretsKeyStoreHelper helper = helperWithPassword(PASSWORD_A);
+        helper.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+
+        // Truncation, not a bad password: this is the branch that retries.
+        final byte[] intact = Files.readAllBytes(storePath);
+        Files.write(storePath, Arrays.copyOf(intact, intact.length / 2));
+        Config.setProperty(SECRETS_STORE_LOAD_TRIES, "3");
+        Config.setProperty("SECRETS_STORE_LOAD_RETRY_BACKOFF_MILLIS", "200");
+
+        final long firstReadMillis = timeFailedRead(helper);
+        final long secondReadMillis = timeFailedRead(helper);
+
+        // First read: 200ms + 400ms of backoff across three attempts. Second: none.
+        assertTrue("the first read should retry with backoff, took " + firstReadMillis + "ms",
+                firstReadMillis >= 200);
+        assertTrue("a read after a known-persistent failure must not sleep again, took "
+                        + secondReadMillis + "ms", secondReadMillis < 200);
+
+        assertTrue("the store must still be intact", Files.exists(storePath));
+        assertEquals("and nothing may be backed up", 0, countBackups());
+    }
+
+    /** Times a read that is expected to fail, returning elapsed milliseconds. */
+    private long timeFailedRead(final SecretsKeyStoreHelper helper) {
+        final long start = System.currentTimeMillis();
+        try {
+            helper.getValue(CANARY_KEY);
+            fail("the truncated store must not read successfully");
+        } catch (DotRuntimeException expected) {
+            // expected
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    /**
      * Method to test: the retry-count floor in {@code loadSecretsStore}.
      * Given Scenario: SECRETS_STORE_LOAD_TRIES misconfigured to 0, with a perfectly readable store.
      * Expected Result: the secret still reads. Without a floor the loop never runs, no failure is

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -1,0 +1,263 @@
+package com.dotcms.security.apps;
+
+import static com.dotcms.security.apps.SecretsKeyStoreHelper.SECRETS_KEYSTORE_FILE_PATH_KEY;
+import static com.dotcms.security.apps.SecretsKeyStoreHelper.SECRETS_STORE_AUTO_RECREATE;
+import static com.dotcms.security.apps.SecretsKeyStoreHelper.SECRETS_STORE_LOAD_TRIES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.UUIDGenerator;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.function.Supplier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Deterministic regression tests for issue #36724 — a multi-node race that silently wiped the App
+ * secrets store.
+ *
+ * These deliberately contain no threads, sleeps or timing assumptions. The failure the issue
+ * describes is a race, but the *damage* was done by a single-threaded code path: any load failure
+ * caused {@code getSecretsStore()} to back up and delete the store, and its retry loop then
+ * recreated an empty one, loaded it cleanly and logged "KeyStore loaded successfully". Each test
+ * below simulates one way of provoking that load failure and asserts the store survives.
+ *
+ * The concurrent stress test that originally reproduced the race lives alongside this class in
+ * {@code SecretsStoreConcurrentWriteRaceTest}; this one is the deterministic guard required by the
+ * issue's acceptance criteria.
+ */
+public class SecretsStoreWipeRegressionTest {
+
+    private static final String CANARY_KEY = "issue36724-canary";
+    private static final String CANARY_VALUE = "do-not-lose-me";
+
+    private static final String PASSWORD_A = "correct-horse-battery-staple-A";
+    private static final String PASSWORD_B = "a-completely-different-password-B";
+
+    private Path storeDir;
+    private Path storePath;
+    private String previousPath;
+    private String previousAutoRecreate;
+    private String previousLoadTries;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        storeDir = Files.createTempDirectory("issue36724-secrets-");
+        storePath = storeDir.resolve("dotSecretsStore.p12");
+
+        previousPath = Config.getStringProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, null);
+        previousAutoRecreate = Config.getStringProperty(SECRETS_STORE_AUTO_RECREATE, null);
+        previousLoadTries = Config.getStringProperty(SECRETS_STORE_LOAD_TRIES, null);
+
+        Config.setProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, storePath.toString());
+        // Keep the retry budget small so a deliberately unreadable store fails fast.
+        Config.setProperty(SECRETS_STORE_LOAD_TRIES, "2");
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        Config.setProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, previousPath);
+        Config.setProperty(SECRETS_STORE_AUTO_RECREATE, previousAutoRecreate);
+        Config.setProperty(SECRETS_STORE_LOAD_TRIES, previousLoadTries);
+
+        if (null != storeDir && Files.exists(storeDir)) {
+            try (java.util.stream.Stream<Path> paths = Files.walk(storeDir)) {
+                paths.sorted(java.util.Comparator.reverseOrder()).forEach(
+                        path -> path.toFile().delete());
+            }
+        }
+    }
+
+    /**
+     * Reads a secret as plaintext. {@link SecretsKeyStoreHelper#getValue(String)} returns the value
+     * still encrypted -- decryption is normally done by the caching wrapper -- so a test comparing
+     * its result directly against the plaintext it stored would never match.
+     */
+    private String readSecret(final SecretsKeyStoreHelper helper, final String key) {
+        final char[] stored = helper.getValue(key);
+        assertFalse("the secret must be present in the store",
+                Arrays.equals(AppsCache.CACHE_404, stored));
+        return new String(helper.decrypt(stored));
+    }
+
+    private SecretsKeyStoreHelper helperWithPassword(final String password) {
+        final Supplier<char[]> supplier = password::toCharArray;
+        return new SecretsKeyStoreHelper(supplier, ImmutableList.of());
+    }
+
+    /**
+     * Any file in the store's directory whose name ends in the store's name is a backup created by
+     * {@code backupAndRemoveKeyStore()} (it prefixes a yyyyMMddHHmmss stamp).
+     */
+    private long countBackups() throws IOException {
+        try (java.util.stream.Stream<Path> paths = Files.list(storeDir)) {
+            return paths.filter(path -> path.getFileName().toString().endsWith("-dotSecretsStore.p12"))
+                    .count();
+        }
+    }
+
+    private long countTempFiles() throws IOException {
+        try (java.util.stream.Stream<Path> paths = Files.list(storeDir)) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".tmp")).count();
+        }
+    }
+
+    /**
+     * Method to test: {@link SecretsKeyStoreHelper#getValue(String)} against a torn store.
+     * Given Scenario: a canary secret is stored, then the file is truncated to half its length —
+     * exactly what a concurrent reader observed while another node streamed the store back over the
+     * destination (defect B1).
+     * Expected Result: the failure is raised, and the store file is still on disk, untouched. Before
+     * this fix the truncated read triggered backup + delete + regenerate-empty, and the canary was
+     * gone for good with only a WARN and an INFO claiming success.
+     */
+    @Test
+    public void test_tornStore_isNotWipedAndFailsLoudly() throws Exception {
+        final SecretsKeyStoreHelper helper = helperWithPassword(PASSWORD_A);
+        helper.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+
+        assertTrue("the store must exist after a save", Files.exists(storePath));
+        final byte[] intact = Files.readAllBytes(storePath);
+        assertTrue("a store holding a secret cannot be empty", intact.length > 0);
+
+        // Simulate the torn read: a partial store, as a reader on another node would have seen.
+        Files.write(storePath, Arrays.copyOf(intact, intact.length / 2));
+        final long tornLength = Files.size(storePath);
+
+        try {
+            helper.getValue(CANARY_KEY);
+            fail("an unreadable store must raise rather than silently return an empty one");
+        } catch (DotRuntimeException expected) {
+            // the store could not be read, which is the honest outcome
+        }
+
+        assertTrue("the store must NOT be deleted when it cannot be read", Files.exists(storePath));
+        assertEquals("the store must be left exactly as it was found",
+                tornLength, Files.size(storePath));
+        assertEquals("nothing may be backed up and removed by default", 0, countBackups());
+    }
+
+    /**
+     * Method to test: {@link SecretsKeyStoreHelper#getValue(String)} with a mismatched password.
+     * Given Scenario: the store is written by one node and read by another that derives a different
+     * password — the cluster-salt rotation / per-node SECRETS_KEYSTORE_PASSWORD_KEY drift described
+     * in the issue. This needs no concurrency at all.
+     * Expected Result: the store survives intact and the node that owns the correct password can
+     * still read the canary. Before this fix the mismatch wiped the store, and the backup it left
+     * behind was encrypted with the very password that had just failed — which is why customers
+     * reported that restoring the backup did not restore access.
+     */
+    @Test
+    public void test_wrongPassword_preservesStoreAndOtherNodeStillReads() throws Exception {
+        final SecretsKeyStoreHelper nodeA = helperWithPassword(PASSWORD_A);
+        nodeA.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+        final byte[] intact = Files.readAllBytes(storePath);
+
+        final SecretsKeyStoreHelper nodeB = helperWithPassword(PASSWORD_B);
+        try {
+            nodeB.getValue(CANARY_KEY);
+            fail("a store that cannot be decrypted must raise, not be silently replaced");
+        } catch (DotRuntimeException expected) {
+            // correct: this node cannot decrypt the shared store
+        }
+
+        assertTrue("the store must survive a password mismatch", Files.exists(storePath));
+        assertTrue("the store bytes must be untouched",
+                Arrays.equals(intact, Files.readAllBytes(storePath)));
+        assertEquals("no backup may be taken by default", 0, countBackups());
+
+        // The decisive assertion: the data was never at risk.
+        assertEquals("the node with the correct password must still read the canary",
+                CANARY_VALUE, readSecret(nodeA, CANARY_KEY));
+    }
+
+    /**
+     * Method to test: the {@code SECRETS_STORE_AUTO_RECREATE} opt-in.
+     * Given Scenario: an operator explicitly accepts losing the secrets to get a working store back,
+     * which is the pre-fix behaviour.
+     * Expected Result: the store is backed up and replaced with an empty one, and the read returns
+     * empty instead of raising. This pins the escape hatch so the destructive path stays available
+     * to anyone who genuinely wants it.
+     */
+    @Test
+    public void test_autoRecreateOptIn_restoresLegacyBehaviour() throws Exception {
+        final SecretsKeyStoreHelper nodeA = helperWithPassword(PASSWORD_A);
+        nodeA.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+
+        Config.setProperty(SECRETS_STORE_AUTO_RECREATE, "true");
+
+        final SecretsKeyStoreHelper nodeB = helperWithPassword(PASSWORD_B);
+
+        assertTrue("the recreated store is empty, so the canary is gone",
+                Arrays.equals(AppsCache.CACHE_404, nodeB.getValue(CANARY_KEY)));
+        assertEquals("the old store must have been backed up before being replaced",
+                1, countBackups());
+        assertTrue("a fresh store must have been created", Files.exists(storePath));
+    }
+
+    /**
+     * Method to test: {@link SecretsKeyStoreHelper#saveValue(String, char[])} publishing.
+     * Given Scenario: repeated saves, the operation that previously truncated the destination and
+     * streamed the bytes back in.
+     * Expected Result: the store is never observed at zero length between saves, every save is
+     * immediately readable, and no .tmp file is left behind. The old code only deleted its temp file
+     * on the happy path, leaving a copy of every secret on any failure.
+     */
+    @Test
+    public void test_savesPublishAtomicallyAndLeaveNoTempFiles() throws Exception {
+        final SecretsKeyStoreHelper helper = helperWithPassword(PASSWORD_A);
+
+        for (int i = 0; i < 25; i++) {
+            final String key = "key-" + i;
+            final String value = UUIDGenerator.generateUuid();
+            helper.saveValue(key, value.toCharArray());
+
+            assertTrue("the store must never be truncated to nothing", Files.size(storePath) > 0);
+            assertEquals("every published value must be immediately readable",
+                    value, readSecret(helper, key));
+        }
+
+        assertEquals("no temp file may survive a save", 0, countTempFiles());
+        assertEquals("saving must never back anything up", 0, countBackups());
+    }
+
+    /**
+     * Method to test: file permissions on the published store.
+     * Given Scenario: the store is written into a directory shared across the cluster.
+     * Expected Result: it is readable only by its owner. Previously both the temp file and the store
+     * were created with whatever the default umask allowed, for a file that holds every App
+     * credential in plain reach of anything that can read the assets volume.
+     */
+    @Test
+    public void test_publishedStoreIsNotWorldReadable() throws Exception {
+        final SecretsKeyStoreHelper helper = helperWithPassword(PASSWORD_A);
+        helper.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+
+        final File storeFile = storePath.toFile();
+        if (!storePath.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            return; // permission model does not apply
+        }
+
+        assertFalse("the secrets store must not be readable by other users",
+                storeFile.canRead() && Files.getPosixFilePermissions(storePath).stream()
+                        .anyMatch(perm -> perm.name().startsWith("OTHERS")
+                                || perm.name().startsWith("GROUP")));
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -309,6 +309,27 @@ public class SecretsStoreWipeRegressionTest {
     }
 
     /**
+     * Method to test: the retry-count floor in {@code loadSecretsStore}.
+     * Given Scenario: SECRETS_STORE_LOAD_TRIES misconfigured to 0, with a perfectly readable store.
+     * Expected Result: the secret still reads. Without a floor the loop never runs, no failure is
+     * recorded, and the terminal handler declares an intact store permanently unreadable on this
+     * node -- blaming a password or corruption problem that does not exist.
+     */
+    @Test
+    public void test_zeroConfiguredTries_stillReadsAReadableStore() throws Exception {
+        final SecretsKeyStoreHelper helper = helperWithPassword(PASSWORD_A);
+        helper.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+
+        Config.setProperty(SECRETS_STORE_LOAD_TRIES, "0");
+
+        assertEquals("a misconfigured retry count must not make a good store unreadable",
+                CANARY_VALUE, readSecret(helper, CANARY_KEY));
+
+        Config.setProperty(SECRETS_STORE_LOAD_TRIES, "-5");
+        assertEquals("negative is floored too", CANARY_VALUE, readSecret(helper, CANARY_KEY));
+    }
+
+    /**
      * Method to test: the retry backoff in {@code loadSecretsStore}.
      * Given Scenario: a torn store, so the read retries with backoff, on a thread that is already
      * interrupted.

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -73,9 +73,16 @@ public class SecretsStoreWipeRegressionTest {
 
     @After
     public void tearDown() throws IOException {
-        Config.setProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, previousPath);
-        Config.setProperty(SECRETS_STORE_AUTO_RECREATE, previousAutoRecreate);
-        Config.setProperty(SECRETS_STORE_LOAD_TRIES, previousLoadTries);
+        // Each of these is null when the property was unset before the test, and
+        // Config.setProperty(key, null) does not reliably clear it -- it can leave the test's own
+        // value in place. Restore an explicit safe value instead, matching the guarded pattern in
+        // SecretsStoreKeyStoreImplTest. Both classes run in MainSuite3a, so leaking this temp path
+        // would point a sibling secrets test at a directory this method then deletes.
+        Config.setProperty(SECRETS_KEYSTORE_FILE_PATH_KEY, previousPath == null ? "" : previousPath);
+        Config.setProperty(SECRETS_STORE_AUTO_RECREATE,
+                previousAutoRecreate == null ? "false" : previousAutoRecreate);
+        Config.setProperty(SECRETS_STORE_LOAD_TRIES,
+                previousLoadTries == null ? "3" : previousLoadTries);
 
         if (null != storeDir && Files.exists(storeDir)) {
             try (java.util.stream.Stream<Path> paths = Files.walk(storeDir)) {

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreWipeRegressionTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
  * Deterministic regression tests for issue #36724 — a multi-node race that silently wiped the App
  * secrets store.
  *
- * These deliberately contain no threads, sleeps or timing assumptions. The failure the issue
+ * These deliberately contain no concurrency and no timing assumptions. The failure the issue
  * describes is a race, but the *damage* was done by a single-threaded code path: any load failure
  * caused {@code getSecretsStore()} to back up and delete the store, and its retry loop then
  * recreated an empty one, loaded it cleanly and logged "KeyStore loaded successfully". Each test
@@ -298,6 +298,41 @@ public class SecretsStoreWipeRegressionTest {
         }
         assertTrue("latch stays set; no second notification",
                 SecretsKeyStoreHelper.hasNotifiedLoadFailure());
+    }
+
+    /**
+     * Method to test: the retry backoff in {@code loadSecretsStore}.
+     * Given Scenario: a torn store, so the read retries with backoff, on a thread that is already
+     * interrupted.
+     * Expected Result: the failure still raises, and the thread's interrupt flag survives.
+     * Thread.sleep clears the flag when it throws, so swallowing InterruptedException would lose a
+     * shutdown or timeout signal and leave the loop sleeping on a thread asked to stop.
+     */
+    @Test
+    public void test_interruptDuringRetryBackoff_isNotSwallowed() throws Exception {
+        final SecretsKeyStoreHelper helper = helperWithPassword(PASSWORD_A);
+        helper.saveValue(CANARY_KEY, CANARY_VALUE.toCharArray());
+
+        // Force the retrying (non-integrity) path: a truncated store, not a bad password.
+        final byte[] intact = Files.readAllBytes(storePath);
+        Files.write(storePath, Arrays.copyOf(intact, intact.length / 2));
+        Config.setProperty(SECRETS_STORE_LOAD_TRIES, "3");
+
+        Thread.currentThread().interrupt();
+        try {
+            helper.getValue(CANARY_KEY);
+            fail("a torn store must still raise");
+        } catch (DotRuntimeException expected) {
+            // correct
+        } finally {
+            // Read and clear, so the assertion below is about what the helper left behind and this
+            // test cannot leak an interrupt into whatever runs next in the suite.
+            final boolean stillInterrupted = Thread.interrupted();
+            assertTrue("the interrupt flag must survive the retry backoff", stillInterrupted);
+        }
+
+        assertTrue("and the store must still be intact", Files.exists(storePath));
+        assertEquals("with nothing backed up or replaced", 0, countBackups());
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

Fixes #36724 (implementation of spike #35592). Also fixes #37061, filed from this PR's own review and closed here.

The shared `dotSecretsStore.p12` lives on cluster assets storage and every node reads and writes the same physical file with no lock — but **the concurrency was only the trigger. The data loss was done by a single-threaded path.** `getSecretsStore()` treated every `IOException` from `KeyStore.load` as unrecoverable corruption, so it backed up and **deleted** the store; the retry loop then recreated it empty, loaded it cleanly, and logged *"KeyStore loaded successfully after 2 tries."*

There are three ways in, and the third needs no concurrency at all: a torn read, the hard-link delete window, or simply a wrong password — the password is `digest(cluster_salt)`, so a salt rotation or a per-node `SECRETS_KEYSTORE_PASSWORD_KEY` override wiped the store on the next read. The backup left behind was encrypted with the password that had just failed, which is why customers report that restoring it does not restore access.

**Four changes:**

1. **Never destroy on read failure.** The retry now retries the **read** with backoff instead of retrying after a delete, and the store is created at most once per call so the loop cannot manufacture an empty one. Integrity failures (wrong password → stop and preserve) are distinguished from torn reads (retry), verified against the JDK rather than assumed. Recreating is opt-in via `SECRETS_STORE_AUTO_RECREATE`, default **false**.
2. **Atomic publish.** Write-temp → fsync → `ATOMIC_MOVE`, replacing `FileUtil.copyFile`, which truncates the destination and streams the bytes back. The tmp file is restricted to **0600** before the move and always removed in a `finally`.
3. **Startup cannot be taken down by the new raise.** `Task00050LoadAppsSecrets.forceRun()` tolerates an unreadable store and skips the import — booting with Apps broken and the credentials intact beats booting with them destroyed.
4. **A node that cannot open the store still works.** Four read paths that previously degraded only *by accident* — because the old code wiped the store and returned nothing — now degrade on purpose, matching the cause chain with `ExceptionUtil.causedBy` since the failure arrives re-wrapped as a bare `DotRuntimeException`. Writes and the App detail views still raise, so nobody saves a blank form over a store that is intact but merely unreadable by this node.

The Apps portlet **list** degrades to zero counts and says why — a dedicated `app-secrets-store-unreadable` entry in the 200 response's `errors` field — rather than showing a bare zero that reads as "your secrets are gone". The guard sits at that call site and deliberately not inside `appKeysByHost()`, because `removeApp()`, `removeSecretsForSite()` and `exportSecrets()` read it too, and an empty map there would make `exportSecrets()` write an **empty backup that reports success**.

Net effect: **reads degrade, writes are protected.** The instance stays usable, the encrypted data survives, and the configuration returns once the salt is corrected.

📋 **[Root cause, the four changes in full, container verification, testing and known gaps →](https://github.com/dotCMS/core/pull/37053#issuecomment-5296013552)**
📋 **[Review round 8: the High fix and both Mediums verified →](https://github.com/dotCMS/core/pull/37053#issuecomment-5295936589)**

### Deliberately not included: cluster-wide locking

With atomic publish a reader can no longer observe a torn file, so a lock is **not** needed to prevent corruption. What it would add is protection against **lost updates** — two nodes each adding a different secret, last writer wins. That is a distinct bug, it puts the database in the secrets write path, and reusing the existing `ClusterLockManager` requires handling ShedLock's skip-if-locked semantics first: `ClusterLockManagerImpl.tryLock` never checks `wasExecuted()`, so a contended lock silently returns `null`. For a save that means "we didn't persist your secret and told you nothing" — worse than the bug being fixed. Filed as #37054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36724