### PR TITLE
fix(push-publish): stop letting a stale index document block unique-field content (#36898)

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
@@ -1059,12 +1059,15 @@ public class ContentHandler implements IHandler {
      *                             the receiving dotCMS instance.
      *
      * @return If the "correspondent" content is found such a content will be returned. Otherwise, the original content
-     * in the bundle will be returned.
+     * in the bundle will be returned. Index matches that can no longer be resolved from the database -- i.e., stale
+     * documents left behind by an index/database desynchronization -- are logged and skipped, so that they cannot
+     * block this bundle and every retry of it indefinitely.
      *
      * @throws DotDataException     An error occurred when retrieving the data.
      * @throws DotSecurityException A user permission error has occurred.
      */
-    private Contentlet findUniqueContentMatch(final Contentlet content, final List<Field> fields, final Pair<Long,Long> remoteLocalLanguages)
+    @VisibleForTesting
+    Contentlet findUniqueContentMatch(final Contentlet content, final List<Field> fields, final Pair<Long,Long> remoteLocalLanguages)
 			throws DotDataException, DotSecurityException {
 		final Identifier contentIdentifier = this.identifierAPI.find(content);
 		if (null != contentIdentifier && !UtilMethods.isSet(contentIdentifier.getId())) {
@@ -1095,6 +1098,10 @@ public class ContentHandler implements IHandler {
 							.append(" ");
 				}
 				luceneQuery.append(")");
+				// Only the working version of a contentlet is relevant for this check. Restricting the
+				// query here keeps stale documents left behind by an ES/DB desynchronization -- old live
+				// versions of destroyed content, for instance -- from ever being matched.
+				luceneQuery.append(" +working:true");
 				final int limit = 0;
 				final int offset = -1;
 				final String sortBy = "score";
@@ -1105,15 +1112,16 @@ public class ContentHandler implements IHandler {
 				if (null != contentlets && !contentlets.isEmpty()) {
 					// A contentlet with different Identifier but same unique value has been found. Update the local
                     // one WITHOUT CHANGING the local Identifier and Inode
-					final Contentlet matchingContent =
-							this.contentletAPI.find(contentlets.get(0).getInode(), systemUser,
-									!RESPECT_FRONTEND_ROLES);
+					final Optional<Contentlet> matchingContentOpt =
+							this.resolveUniqueContentMatch(contentlets, uniqueFields, luceneQuery.toString());
 
-                    if (null == matchingContent || !UtilMethods.isSet(matchingContent.getIdentifier())) {
-                        // It might be that the matching content doesn't exist in the DB anymore, or is archived
-                        throw new DotDataException(getUniqueMatchErrorMsg(uniqueFields, luceneQuery.toString(),
-                                contentlets.get(0)));
+                    if (matchingContentOpt.isEmpty()) {
+                        // Every match is a ghost: present in the index, but gone from the database. Failing here
+                        // would block this bundle -- and every retry of it -- forever, so the conflict is ignored
+                        // and the content is imported as new. Every stale entry was already logged as a warning.
+                        return content;
                     }
+                    final Contentlet matchingContent = matchingContentOpt.get();
                     existingContentMap.addExistingContent(
 							Pair.of(content.getIdentifier(), remoteLocalLanguages.getLeft()),
 							Pair.of(matchingContent.getIdentifier(), remoteLocalLanguages.getRight()));
@@ -1131,23 +1139,56 @@ public class ContentHandler implements IHandler {
 	}
 
     /**
-     * Utility method to generate the appropriate error message when {@link #findUniqueContentMatch(Contentlet, List,
-     * Pair)} method fails to retrieve a result.
+     * Takes the results matched by the unique-value Lucene query and returns the first one that can actually be
+     * loaded from the database. Any result that cannot be resolved is a "ghost": a document that lives in the
+     * index but whose contentlet is no longer in the {@code contentlet} table, usually the leftover of an
+     * ES/database desynchronization. Ghosts are logged as warnings and skipped instead of aborting the bundle.
+     *
+     * @param matches      The {@link ContentletSearch} results matched by the Lucene query.
+     * @param uniqueFields The list of unique {@link Field} objects in the contentlet that is being pushed.
+     * @param luceneQuery  The Lucene query used to find the contentlet that matches the unique value.
+     *
+     * @return The first matching {@link Contentlet} that exists in the database, or an empty {@link Optional} if
+     * every match is a ghost.
+     *
+     * @throws DotDataException     An error occurred when retrieving the data.
+     * @throws DotSecurityException A user permission error has occurred.
+     */
+    private Optional<Contentlet> resolveUniqueContentMatch(final List<ContentletSearch> matches,
+			final List<Field> uniqueFields, final String luceneQuery)
+			throws DotDataException, DotSecurityException {
+		final User systemUser = this.userAPI.getSystemUser();
+		for (final ContentletSearch match : matches) {
+			final Contentlet matchingContent =
+					this.contentletAPI.find(match.getInode(), systemUser, !RESPECT_FRONTEND_ROLES);
+			if (null != matchingContent && UtilMethods.isSet(matchingContent.getIdentifier())) {
+				return Optional.of(matchingContent);
+			}
+			Logger.warn(this, getUniqueMatchWarnMsg(uniqueFields, luceneQuery, match));
+		}
+		return Optional.empty();
+	}
+
+    /**
+     * Utility method to generate the appropriate warning message when {@link #findUniqueContentMatch(Contentlet, List,
+     * Pair)} matches a document in the index whose contentlet cannot be resolved via API.
      *
      * @param uniqueFields   The list of unique {@link Field} objects in the contentlet that is being pushed.
      * @param luceneQuery    The Lucene query used to find the contentlet that matches the unique value.
-     * @param matchedContent The first {@link ContentletSearch} result matched by the Lucene query.
+     * @param matchedContent The {@link ContentletSearch} result matched by the Lucene query.
      *
-     * @return The error message to display in the log.
+     * @return The warning message to display in the log.
      */
-    private String getUniqueMatchErrorMsg(final List<Field> uniqueFields, final String luceneQuery, final
+    private String getUniqueMatchWarnMsg(final List<Field> uniqueFields, final String luceneQuery, final
 	ContentletSearch matchedContent) {
 		final StringBuilder fieldsInfo = new StringBuilder();
 		for (final Field field : uniqueFields) {
 			fieldsInfo.append(field.getVelocityVarName()).append(" [").append(field.getInode()).append("], ");
 		}
-        return String.format("Lucene query [ %s ] matched existing content with ID '%s' / inode '%s' in ES Index, but" +
-                " it was not found via API. Unique fields: %s", luceneQuery, matchedContent.getIdentifier(),
+        return String.format("Stale index document detected during the unique-field check: Lucene query [ %s ] matched" +
+                " content with ID '%s' / inode '%s', but it was not found via API. Skipping it and treating it as no" +
+                " conflict. This points to an index/database desynchronization on this server, and a reindex of the" +
+                " affected content is recommended. Unique fields: %s", luceneQuery, matchedContent.getIdentifier(),
                 matchedContent.getInode(), fieldsInfo);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -3119,9 +3119,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
         // Delete all the versions of the contentlets to delete
         this.contentFactory.delete(contentletsVersion);
-        // Remove the contentlets from the Elastic index and cache
+        // Remove the contentlets from the search index and cache
+        final Set<String> removedFromIndex = new HashSet<>();
         for (final Contentlet contentlet : contentletsVersion) {
 
+            // The index document ID is per identifier/language/variant, so removing it once per version
+            // would be pure repetition. Relying on forceUnpublishArchive() alone is not enough either:
+            // it only removes live content, leaving working-only versions behind as stale documents.
+            final String documentKey = contentlet.getIdentifier() + StringPool.UNDERLINE
+                    + contentlet.getLanguageId() + StringPool.UNDERLINE + contentlet.getVariantId();
+            if (removedFromIndex.add(documentKey)) {
+                this.indexAPI.removeContentFromIndex(contentlet);
+            }
             CacheLocator.getIdentifierCache().removeFromCacheByVersionable(contentlet);
         }
 

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandlerTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandlerTest.java
@@ -2,14 +2,18 @@ package com.dotcms.enterprise.publishing.remote.handler;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.TagField;
+import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.FieldDataGen;
 import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.publisher.pusher.wrapper.ContentWrapper;
 import com.dotcms.publishing.PublisherConfig;
@@ -19,9 +23,14 @@ import com.dotcms.util.xstream.XStreamHandler;
 import com.dotcms.util.xstream.XStreamHandler.TrustedListMatcher;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
+import com.dotmarketing.cache.FieldsCache;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.util.UUIDGenerator;
+import org.apache.commons.lang3.tuple.Pair;
 import com.thoughtworks.xstream.XStream;
 import java.io.File;
 import java.io.IOException;
@@ -129,6 +138,59 @@ public class ContentHandlerTest {
         assertNotNull(savedTag);
         assertEquals(savedTag.getTagName(), tags[1]);
         assertEquals(Host.SYSTEM_HOST, savedTag.getHostId());
+    }
+
+    /**
+     * Method to test: {@link ContentHandler#findUniqueContentMatch(Contentlet, List, Pair)}
+     * When: The receiver's index still holds a document for a unique value whose contentlet is gone from the
+     * database -- the "ghost" left behind by an index/database desynchronization -- and a bundle arrives carrying
+     * that same unique value.
+     * Should: Skip the stale match and hand back the incoming content untouched, so the bundle is imported as new
+     * content instead of failing on this -- and on every single retry.
+     */
+    @Test
+    public void TEST_STALE_INDEX_DOCUMENT_DOES_NOT_BLOCK_UNIQUE_FIELD_MATCH() throws Exception {
+        final long languageId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+        final String uniqueVarName = "uniqueField" + UUIDGenerator.shorty().replace("-", "");
+        final ContentType contentType = new ContentTypeDataGen()
+                .field(new FieldDataGen().type(TextField.class).velocityVarName(uniqueVarName).unique(true).next())
+                .nextPersisted();
+        final String uniqueValue = "ghost-" + UUIDGenerator.shorty();
+
+        // A contentlet that gets indexed the regular way...
+        final Contentlet ghost = new ContentletDataGen(contentType)
+                .languageId(languageId)
+                .setProperty(uniqueVarName, uniqueValue)
+                .nextPersisted();
+
+        // ...and is then wiped from the database behind the API's back, leaving its index document orphaned
+        new DotConnect().setSQL("delete from contentlet_version_info where identifier = ?")
+                .addParam(ghost.getIdentifier()).loadResult();
+        new DotConnect().setSQL("delete from contentlet where identifier = ?")
+                .addParam(ghost.getIdentifier()).loadResult();
+        CacheLocator.getContentletCache().remove(ghost.getInode());
+        CacheLocator.getIdentifierCache().removeFromCacheByVersionable(ghost);
+
+        // The ghost must really be there, otherwise this test would pass for the wrong reason
+        final List<ContentletSearch> staleMatches = APILocator.getContentletAPI().searchIndex(
+                "+structureInode:" + contentType.id() + " +working:true", 0, -1, "score",
+                APILocator.systemUser(), false);
+        assertFalse("The stale index document was not created; the scenario under test is not in place",
+                staleMatches.isEmpty());
+        assertNull("The ghost must no longer be resolvable from the database",
+                APILocator.getContentletAPI().find(ghost.getInode(), APILocator.systemUser(), false));
+
+        final Contentlet fromBundle = new Contentlet();
+        fromBundle.setContentTypeId(contentType.id());
+        fromBundle.setIdentifier(UUIDGenerator.generateUuid());
+        fromBundle.setInode(UUIDGenerator.generateUuid());
+        fromBundle.setLanguageId(languageId);
+        fromBundle.setStringProperty(uniqueVarName, uniqueValue);
+
+        final Contentlet result = new ContentHandler(new PublisherConfig()).findUniqueContentMatch(fromBundle,
+                FieldsCache.getFieldsByStructureInode(contentType.id()), Pair.of(languageId, languageId));
+
+        assertSame("The stale index document must be ignored, not matched", fromBundle, result);
     }
 
 


### PR DESCRIPTION
## Proposed Changes

Fixes #36898

Push-publish was permanently blocked for unique-field content whenever the receiver's search index held a **ghost**: a document whose contentlet no longer exists in the `contentlet` table. `findUniqueContentMatch()` matched the ghost in the index, failed to resolve it via API, and threw a `DotDataException` that aborted the whole bundle. Because nothing ever cleaned the ghost up, **every retry failed identically** — the only workaround was toggling the unique flag off, force-pushing, and toggling it back on (T3 intervention).

This has been confirmed in a customer Cloud environment and is reported across multiple customers.

### 1. Self-healing on ghost matches — `ContentHandler.java`

`findUniqueContentMatch()` no longer throws. A new `resolveUniqueContentMatch()` helper walks **every** result the Lucene query returned (previously only `contentlets.get(0)` was ever considered) and returns the first one that actually resolves from the database. Any match that does not resolve is logged at `WARN` with the ghost inode, identifier, the Lucene query used and the unique fields involved, plus a note that a reindex of the affected content is recommended — then skipped.

If every match turns out to be a ghost, the incoming `content` is returned untouched, so the bundle is imported as new content and unblocks itself.

### 2. State filter on the Lucene query — `ContentHandler.java`

The query now appends `+working:true`, so stale live documents from older versions never reach the resolution step.

`+deleted:false` was deliberately **not** added: matching archived content is intentional here — `handleContent()` calls `unarchive()` on a matched archived contentlet before check-in, so excluding archived documents would be a behavior regression.

### 3. Closing one ghost-creation path — `ESContentletAPIImpl.java`

`destroyContentlets()` relied solely on `forceUnpublishArchive()` for index removal, and that path is gated on `contentlet.isLive()`. Working-only content that was never published had its index document left behind when destroyed — one of the ways a ghost is born. The method now calls `indexAPI.removeContentFromIndex()` explicitly, deduplicated per `identifier`/`language`/`variant`, which is the granularity of the index document ID (removing once per version would be pure repetition).

This mirrors what the sibling delete path already does.

## Checklist

- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

## Additional Info

**Why the ES query change is safe for the ghost path.** Fix 2 alone does not close the issue: a ghost whose *working* document is the stale one still matches. That is precisely why Fix 1 is the required part and Fix 2 is defense in depth.

**Existing blocked content unblocks with no reindex and no flag toggling** — the very next push-publish attempt succeeds and leaves a `WARN` trail pointing at the desynchronization.

## Screenshots

N/A — backend only.

This PR fixes: #36898