### PR TITLE
fix(search): recover exact-name and mid-token matches in the legacy relationship dialog (#37052)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjax.java
@@ -950,14 +950,29 @@ public class ContentletAjax {
 
 									fieldValueStr = fieldValueStr.replaceAll(specialCharsToEscape, "\\\\$1");
 
-							        if(fieldName.equals("languageId") || fieldValueStr.contains("-")){
+							        if("catchall".equals(fieldName)) {
+										// Mandatory gate: match either a catchall token PREFIX (fast, existing
+										// behavior) OR the raw title via wildcard. Unlike catchall (which
+										// aggregates every field of the document), title_dotraw is scoped to a
+										// single field, so this alternative recovers mid-token and
+										// exact-full-value matches -- e.g. a file named "IMG_0004.jpeg"
+										// tokenizes to "img_0004"+"jpeg", so "0004" or a full-name search never
+										// satisfies a catchall-only prefix gate -- without reintroducing an
+										// unscoped, whole-document wildcard like the old broad catchall:*value*.
+										// Boosts are deliberately asymmetric: catchall (a real token-prefix hit)
+										// outranks title_dotraw (a raw substring hit that can land anywhere,
+										// including mid-word). Mirrors GlobalSearchAttributeStrategy, which is
+										// the equivalent gate for the new Content Search / Content Drive path.
+										luceneQuery.append("+(catchall:" + fieldValueStr + "*^10 OR title_dotraw:*"
+												+ fieldValueStr + "*^2) ");
+									} else if(fieldName.equals("languageId") || fieldValueStr.contains("-")){
 										luceneQuery.append("+" + fieldName +":" + fieldValueStr + " ");
 									}else{
 										luceneQuery.append("+" + fieldName +":" + fieldValueStr + "* ");
 									}
-							        
+
 							        if("catchall".equals(fieldName)) {
-							           
+
 							            luceneQuery.append(" title:'" + fieldValueStr + "'^15 ");
                                         final String[] titleSplit = fieldValueStr.split("[,|\\s+]");
                                         if (titleSplit.length > 1) {
@@ -965,7 +980,6 @@ public class ContentletAjax {
                                                 luceneQuery.append(" title:" + term + "^5 ");
                                             }
                                         }
-							            luceneQuery.append(" title_dotraw:*" + fieldValueStr + "*^5 ");
 							        }
 							        
 							        

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjaxTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/ajax/ContentletAjaxTest.java
@@ -17,6 +17,8 @@ import com.dotcms.contenttype.model.type.SimpleContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.FieldDataGen;
+import com.dotcms.datagen.FileAssetDataGen;
+import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.LanguageDataGen;
 import com.dotcms.languagevariable.business.LanguageVariableAPI;
 import com.dotcms.repackage.org.directwebremoting.WebContext;
@@ -33,6 +35,7 @@ import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
+import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
@@ -42,6 +45,7 @@ import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.google.common.collect.ImmutableList;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.WebKeys;
+import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
 import com.liferay.util.servlet.SessionMessages;
 import com.tngtech.java.junit.dataprovider.DataProvider;
@@ -56,6 +60,8 @@ import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -533,6 +539,75 @@ public class ContentletAjaxTest {
 		final long contentletTwo_Language = Long.parseLong(((Map<String,String>)results.get(4)).get("languageId"));
 		assertTrue(contentletTwo_Language!=contentletOne_Language);
 
+	}
+
+	/**
+	 * <b>Method to Test:</b> {@link ContentletAjax#searchContentletsByUser(List, String, List, List,
+	 * boolean, boolean, boolean, boolean, int, String, int, User, HttpSession, String, String)}<p>
+	 * <b>When:</b> the legacy Relationships search dialog performs a global ({@code catchall})
+	 * search for a term that lands mid-token, or that spans a tokenizer boundary such as the exact
+	 * full file name<p>
+	 * <b>Should:</b> Find the content anyway, while a term present in no field still returns
+	 * nothing — i.e. the broad, unscoped {@code catchall:*value*} is not reintroduced. See issue
+	 * #37052.
+	 */
+	@Test
+	public void test_searchContentletsByUser_globalSearch_matchesMidTokenAndExactFullName()
+			throws Exception {
+
+		final String uniqueToken = "qa" + System.currentTimeMillis();
+		// Tokenizes to "img_<uniqueToken>_0004" + "jpeg", so <uniqueToken> sits mid-token and the
+		// full name spans the "." boundary
+		final String fileName = "IMG_" + uniqueToken + "_0004.jpeg";
+
+		final Host host = APILocator.getHostAPI().findDefaultHost(systemUser, false);
+		final Folder folder = new FolderDataGen().site(host).nextPersisted();
+
+		final File tempDir = Files.createTempDirectory(uniqueToken).toFile();
+		final File file = new File(tempDir, fileName);
+		FileUtil.write(file, "helloworld");
+
+		final Contentlet fileAsset = new FileAssetDataGen(folder, file).nextPersisted();
+		final String fileAssetTypeInode = contentTypeAPI.find("FileAsset").inode();
+
+		try {
+			// A genuine token prefix — worked before the fix and must keep working
+			assertGlobalSearchFindsOnly(fileAssetTypeInode, "IMG_" + uniqueToken, fileAsset);
+
+			// Mid-token term — the catchall prefix gate alone never matched this
+			assertGlobalSearchFindsOnly(fileAssetTypeInode, uniqueToken, fileAsset);
+
+			// Exact full name — spans the "." tokenizer boundary
+			assertGlobalSearchFindsOnly(fileAssetTypeInode, fileName, fileAsset);
+
+			// Negative control: a term in no field must still return nothing, otherwise the broad
+			// whole-document wildcard is back
+			final List results = new ContentletAjax().searchContentletsByUser(
+					ImmutableList.of(BaseContentType.ANY), fileAssetTypeInode,
+					CollectionsUtils.list("catchall", "zz" + uniqueToken),
+					Collections.emptyList(), false, false, false,
+					false, 0, "moddate", 0, systemUser, null, null, null);
+
+			assertEquals(0, Integer.parseInt(((Map) results.get(0)).get("total").toString()));
+		} finally {
+			contentletAPI.destroy(fileAsset, systemUser, false);
+			FileUtil.deltree(tempDir);
+		}
+	}
+
+	private void assertGlobalSearchFindsOnly(final String contentTypeInode, final String searchTerm,
+			final Contentlet expected) throws DotDataException, DotSecurityException {
+
+		final List results = new ContentletAjax().searchContentletsByUser(
+				ImmutableList.of(BaseContentType.ANY), contentTypeInode,
+				CollectionsUtils.list("catchall", searchTerm), Collections.emptyList(),
+				false, false, false, false, 0, "moddate", 0, systemUser, null, null, null);
+
+		assertNotNull(results);
+		assertEquals("Searching for '" + searchTerm + "' must return exactly one match",
+				1, Integer.parseInt(((Map) results.get(0)).get("total").toString()));
+		assertEquals("Searching for '" + searchTerm + "' returned the wrong content",
+				expected.getIdentifier(), ((Map) results.get(3)).get("identifier"));
 	}
 
 }


### PR DESCRIPTION
## Problem

#36791 / PR #36793 fixed the exact-name and mid-token matching gap in `GlobalSearchAttributeStrategy` — the shared strategy behind the Content Search portlet, Content Drive's keyword search, and the **new (Angular)** edit content Relationships dialog.

The **legacy (Dojo/JSP)** edit content screen never goes through that code. Its "Relate" dialog is `dotcms.dijit.form.ContentSelector`, which dispatches over DWR to `ContentletAjax.searchContentletsByUser` — a separate, drifted copy of the same logic that still gates on a catchall-only prefix:

```java
luceneQuery.append("+" + fieldName + ":" + fieldValueStr + "* ");   // +catchall:img_0004.jpeg*
...
if ("catchall".equals(fieldName)) {
    ...
    luceneQuery.append(" title_dotraw:*" + fieldValueStr + "*^5 "); // optional BOOST only
}
```

The `title_dotraw` wildcard was already there, but only as an optional boost clause — the mandatory `+catchall:<term>*` had already excluded the document, so it never rescued anything. Surfaced during QA of #36791.

## Fix

Make the `catchall` gate a disjunction, mirroring `GlobalSearchAttributeStrategy`:

```java
+(catchall:<term>*^10 OR title_dotraw:*<term>*^2)
```

- `title_dotraw` is scoped to a single field, so this recovers mid-token and exact-full-value matches **without** reintroducing the broad, whole-document `catchall:*term*` removed in #36688.
- Asymmetric boosts are deliberate and match the reference implementation: a genuine token-prefix hit outranks a raw-substring hit that can land anywhere.
- Query-construction only. No mapping/analyzer change, no reindex.

Two deliberate secondary changes worth a reviewer's eye:

1. **The `catchall` branch is now evaluated before the `contains("-")` branch.** Previously a term containing a dash (e.g. `nordic-skiing`) fell into the no-wildcard branch and behaved differently. `GlobalSearchAttributeStrategy` has no such special case, so this aligns the two. `languageId` keeps its existing handling.
2. **The standalone `title_dotraw:*value*^5` boost was removed**, since the same clause is now part of the mandatory gate at `^2`. Keeping both would duplicate the clause.

## Validation

New integration test `ContentletAjaxTest#test_searchContentletsByUser_globalSearch_matchesMidTokenAndExactFullName`, seeding a File Asset named `IMG_<uniqueToken>_0004.jpeg` (tokenizes to `img_<uniqueToken>_0004` + `jpeg`):

| Search term | Before | After | Matches via |
|---|---|---|---|
| `IMG_<uniqueToken>` (genuine token prefix) | ✅ | ✅ | catchall prefix |
| `<uniqueToken>` (mid-token) | ❌ | ✅ | `title_dotraw` substring |
| `IMG_<uniqueToken>_0004.jpeg` (exact full name, spans the `.`) | ❌ | ✅ | `title_dotraw` substring |
| `zz<uniqueToken>` (in no field) | 0 results | 0 results | negative control — no broad catchall |

The term is unique per run so the assertions hold against the shared test index.

**Red/Green verified.** With the production change reverted the test fails on the mid-token assertion (`expected:<1> but was:<0>`) while the preceding token-prefix assertion passes — so it isolates this defect rather than failing for an unrelated reason. With the fix, `ContentletAjaxTest` is 10/10 green (9 pre-existing + 1 new). The class is already registered in `MainSuite2a`, so no suite changes were needed.

## Scope

Closes #37052. Follow-up to #36791 / PR #36793 — same defect, second code path.

## Out of scope / follow-ups

- Collapsing the duplicated query-building logic by having `ContentletAjax` call `GlobalSearchAttributeStrategy` directly (as `BrowserAPIImpl` already does). Removes the drift at the root, but touches more legacy surface than this fix warrants.

This PR fixes: #37052