### PR TITLE
fix(vanity-url): stop duplicating the file name in the Forward To picker (#37050)

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/content/file_browser_field_render_old.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/content/file_browser_field_render_old.vtl
@@ -6,9 +6,12 @@
 	}
 
 	function fileSelected(file) {
-		var path = file.pageURI;
+		// Every candidate here already carries the full path: 'pageURI' and 'url' come from
+		// Identifier.getURI(), 'path' from Identifier.getPath(). Concatenating 'fileName' onto any
+		// of them duplicates the file name -- see https://github.com/dotCMS/core/issues/37050
+		var path = file.pageURI || file.url || file.path;
 		if (!path) {
-			path = file.path + file.fileName;
+			return;
 		}
 		dojo.byId('vlUri').value = path;
 		dojo.byId('${field.velocityVarName}').value = path;

--- a/dotcms-integration/src/test/java/com/dotcms/browser/BrowserAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/browser/BrowserAPITest.java
@@ -64,6 +64,8 @@ import io.vavr.control.Try;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,6 +76,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -2442,5 +2445,90 @@ public class BrowserAPITest extends IntegrationTestBase {
                         .build()).stream()
                 .map(Treeable::getIdentifier)
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link BrowserAPI#getFolderContent(BrowserQuery)}</li>
+     *     <li><b>Given Scenario:</b> A folder tree holding File Assets -- including one whose name contains
+     *     dots and one nested in a sub-folder -- and an HTML Page is browsed the way the file browser dialog
+     *     does it.</li>
+     *     <li><b>Expected Result:</b> Every row already exposes the asset's <b>full</b> path in {@code path},
+     *     {@code url} and, for Pages, {@code pageURI}: the three agree with each other and each one ends with
+     *     the asset name exactly once. Consumers must therefore use one of them as-is and never append
+     *     {@code fileName} to them.</li>
+     * </ul>
+     * Regression guard for <a href="https://github.com/dotCMS/core/issues/37050">#37050</a>: the Vanity URL
+     * "Forward To" picker used to build its value as {@code path + fileName}, which duplicated the file name.
+     * It also pins the contract against the reverse change -- making {@code path} mean "parent path" in
+     * {@code WebAssetStrategy.addPath} would silently break every consumer of this payload.
+     */
+    @Test
+    public void test_getFolderContent_webAssetRows_carryTheFullPathExactlyOnce() throws Exception {
+        final Host host = new SiteDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().name("pathFolder").site(host).nextPersisted();
+        final Folder subFolder = new FolderDataGen().name("pathSubFolder").parent(folder).nextPersisted();
+
+        final FileAsset plainFile = persistFileAsset(folder, fileNamed("pathPlainFile.txt"));
+        // Dots in the name are the interesting case: any extension-based trimming would mangle it
+        final FileAsset dottedFile = persistFileAsset(subFolder, fileNamed("my.report.v2.txt"));
+        final HTMLPageAsset page = new HTMLPageDataGen(folder,
+                new TemplateDataGen().host(host).nextPersisted()).title("pathPage").pageURL("path-page")
+                .nextPersisted();
+
+        assertWebAssetRow(folder, plainFile.getIdentifier(), "/pathFolder/pathPlainFile.txt",
+                plainFile.getFileName());
+        assertWebAssetRow(subFolder, dottedFile.getIdentifier(), "/pathFolder/pathSubFolder/my.report.v2.txt",
+                dottedFile.getFileName());
+        // Pages resolve through the 'pageURI' branch of the picker, which must keep agreeing with the rest
+        final Map<String, Object> pageRow = assertWebAssetRow(folder, page.getIdentifier(),
+                "/pathFolder/path-page", null);
+        assertEquals("A Page's 'pageURI' must agree with its 'url'", pageRow.get("url"),
+                pageRow.get("pageURI"));
+    }
+
+    /**
+     * Browses {@code folder} the way the file browser dialog does -- see
+     * {@code BrowserAjax.getFolderContentWithDotAssets} -- and asserts that the hydrated row for
+     * {@code identifier} exposes {@code expectedPath} in both {@code path} and {@code url}. When
+     * {@code fileName} is given, it also asserts the path ends with it exactly once.
+     */
+    private Map<String, Object> assertWebAssetRow(final Folder folder, final String identifier,
+            final String expectedPath, final String fileName) throws Exception {
+        final Map<String, Object> results = browserAPI.getFolderContent(BrowserQuery.builder()
+                .withUser(APILocator.systemUser())
+                .withHostOrFolderId(folder.getIdentifier())
+                .showPages(true)
+                .showFiles(true)
+                .showFolders(false)
+                .showWorking(true)
+                .build());
+        final Map<String, Object> row =
+                ((List<Map<String, Object>>) results.get("list")).stream()
+                        .filter(item -> identifier.equals(item.get("identifier")))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError(
+                                "The browse of '" + folder.getName() + "' must return " + identifier));
+
+        final String actualPath = (String) row.get("path");
+        assertEquals("'path' must be the asset's full path", expectedPath, actualPath);
+        assertEquals("'url' must agree with 'path'", expectedPath, row.get("url"));
+        if (null != fileName) {
+            assertTrue("'path' must end with the file name: " + actualPath,
+                    actualPath.endsWith("/" + fileName));
+            assertEquals("The file name must appear exactly once in 'path': " + actualPath, 1,
+                    StringUtils.countMatches(actualPath, fileName));
+        }
+        return row;
+    }
+
+    /**
+     * Creates a temporary file with an <b>exact</b> name. {@code File.createTempFile} appends random digits,
+     * which would defeat the path assertions above.
+     */
+    private static File fileNamed(final String name) throws IOException {
+        final File file = new File(Files.createTempDirectory("issue37050").toFile(), name);
+        FileUtils.writeStringToFile(file, "this is a test!", StandardCharsets.UTF_8);
+        return file;
     }
 }


### PR DESCRIPTION
Fixes #37050

## What was wrong

In the legacy (non-new-edit-mode) render path, the Vanity URL **Forward To** picker built its value as `file.path + file.fileName`. For any non-page asset that produced the file name twice with no separator — selecting `/docs/report.pdf` wrote `/docs/report.pdfreport.pdf` into both the visible `vlUri` input and the underlying `forwardTo` field. Nothing validates it on save, so the Vanity URL silently 404s at runtime.

Pages were unaffected because they take the earlier `file.pageURI` branch.

The concatenation was wrong because `path` in the browser payload **already ends with the asset name**. Two strategies in the same transform chain set it, and the last one wins:

| Step | Where | Sets `path` to |
|---|---|---|
| 1. `transform()` | `FileAssetViewStrategy.java:110` — `fileAsset.getPath()` | `/docs/` (parent path only) |
| 2. `addPath()` | `WebAssetStrategy.java:66-74` — `identifier.getPath()` | `/docs/report.pdf` (`parentPath + assetName`) |

`WebAssetStrategy.apply()` runs `super.apply()` (→ `transform()`) first and `addPath()` after, so step 2 overwrites step 1.

## The fix

`file_browser_field_render_old.vtl` now takes the asset's full path as-is instead of assembling one:

```js
var path = file.pageURI || file.url || file.path;
if (!path) {
    return;
}
```

All three candidates are already full paths, and for the asset kinds this picker can return they are the *same* value:

- `pageURI` — `HTMLPageAsset.getMap()` → `identifier.getURI()` (pages only)
- `url` — `WebAssetStrategy.urlOverride` → `ContentHelper.getUrl` → `identifier.getURI()`
- `path` — `WebAssetStrategy.addPath` → `identifier.getPath()`

Keeping `pageURI` first means the page branch is byte-for-byte what it was before. `url` second matches what new edit mode uses (`result.url`, mapped from `content.url` in `angular-form-bridge.ts:557`), so both modes now yield the same string for a given asset. `path` is the fallback because it is the one key `addPath` writes unconditionally.

The early `return` replaces the old fall-through: previously a payload with no usable path would write the literal `undefined` into a required field.

### Why not fix the payload instead

Issue #37050 offered a second option: stop `WebAssetStrategy.addPath` from overwriting the parent path that `FileAssetViewStrategy` deliberately set. That is arguably the deeper defect — two strategies disagree on what `path` means — but every existing consumer of the browser payload has been written against the current value. Changing the semantics to fix one VTL line would be a silent, wide breaking change for a Medium-severity defect. Left as a separate cleanup if the team wants the semantics settled; the test below pins the current contract so such a change can't land unnoticed.

## Blast radius

`file_browser_field_render.vtl` is referenced only by the Vanity URL content type (`VanityUrlContentType.java:83` and the `Task04200CreateDefaultVanityURL` upgrade task). Both reference it via `$velutil.mergeTemplate`, so existing installs pick the fix up without a data migration.

Within that picker the payload can only contain File Assets and Pages: `BrowserAjax.getFolderContentWithDotAssets` is called with `excludeLinks=true`, and the widget sets `includeDotAssets="false"`.

## Tests

New integration test — `BrowserAPITest#test_getFolderContent_webAssetRows_carryTheFullPathExactlyOnce`.

It browses a folder tree the way the dialog does and asserts that each row's `path` and `url` agree and are the asset's full path, with the name appearing exactly once. Covers a plain file, a file nested in a sub-folder whose name contains dots (`my.report.v2.txt`), and a Page (also asserting `pageURI` agrees with `url`).

This is a two-way guard: it fails if the concatenation bug is reintroduced downstream, and it fails if someone changes `WebAssetStrategy.addPath` to mean "parent path" without auditing consumers.

```
Tests run: 41, Failures: 0, Errors: 0, Skipped: 0 -- in com.dotcms.browser.BrowserAPITest
```
(whole class, not just the new method — confirms the fixture changes don't disturb the existing exact-count assertions)

### On TDD

Worth being explicit: there is **no red-first test for the fix itself**. The defect lives in JavaScript inlined in a Velocity template under `dotCMS/src/main/webapp`, which has no test harness in this repo — not Jest, not anything. The integration test above pins the server-side contract the fix depends on; it passes both before and after, by design. The VTL change itself was verified by tracing the payload end to end (`BrowserAjax` passes the hydrated map straight through to `onFileSelected` — `listCleanup` only drops rows by language, it strips no keys), not by an automated test.

## Acceptance criteria

- [x] Selecting a File Asset populates the field with the asset's real path, file name appearing exactly once
- [x] Selecting an HTML page produces the same correct path as before — the `pageURI` branch is untouched and evaluated first
- [x] The same value is written to both `vlUri` and `forwardTo`
- [x] Nested folders and names containing dots are handled (covered by the new test)
- [x] Legacy and new edit mode yield the same string — both resolve to `identifier.getURI()`
- [x] `WebAssetStrategy.addPath` / `FileAssetViewStrategy` deliberately left alone; the contract other consumers rely on is now covered by a test

## Out of scope — spotted while tracing

`WebAssetStrategy.urlOverride` (`WebAssetStrategy.java:49-59`) has a dead null guard:

```java
final String url = toolBox.contentHelper.getUrl(contentlet);
if (null != url) {
    map.put(URL_FIELD, url);
}
map.put(URL_FIELD, url);   // runs regardless — can write null over a good value
```

The unconditional `put` defeats the check above it. Not touched here — issue #37050 flags it as deserving its own ticket, and this fix does not depend on it (the `|| file.path` fallback covers a null `url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37050