### PR TITLE
fix(contentlet): stop timestamp preservation from failing binary copies on shared storage (#37068)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -9587,6 +9587,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             // would abort the whole copy even though the bytes were copied fine.
                             // REPLACE_EXISTING must be passed explicitly: this overload defaults
                             // to no CopyOption, and Files.copy fails if the destination exists.
+                            Logger.warn(this, "### DOTCMS-37068-MARKER ### copying binary '"
+                                    + srcFile.getAbsolutePath() + "' -> '"
+                                    + destFile.getAbsolutePath()
+                                    + "' with preserveFileDate=false");
                             FileUtils.copyFile(srcFile, destFile, false,
                                     StandardCopyOption.REPLACE_EXISTING);
                             newContentlet.setBinary(tempField.getVelocityVarName(), destFile);

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -210,6 +210,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -9579,10 +9580,15 @@ public class ESContentletAPIImpl implements ContentletAPI {
                                 fieldValue = srcFile.getName();
                             }
                             destFile = new File(temporalFolder + File.separator + fieldValue);
-                            if (!destFile.exists()) {
-                                destFile.createNewFile();
-                            }
-                            FileUtils.copyFile(srcFile, destFile);
+                            // Do NOT preserve the source's file date. The destination is a brand
+                            // new file under a throwaway temp folder, so its modification time
+                            // carries no meaning, and preserving it fails outright on shared
+                            // storage (NFS/EFS) where setting file times is not permitted, which
+                            // would abort the whole copy even though the bytes were copied fine.
+                            // REPLACE_EXISTING must be passed explicitly: this overload defaults
+                            // to no CopyOption, and Files.copy fails if the destination exists.
+                            FileUtils.copyFile(srcFile, destFile, false,
+                                    StandardCopyOption.REPLACE_EXISTING);
                             newContentlet.setBinary(tempField.getVelocityVarName(), destFile);
                         }
                     } catch (final Exception e) {

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -9587,10 +9587,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
                             // would abort the whole copy even though the bytes were copied fine.
                             // REPLACE_EXISTING must be passed explicitly: this overload defaults
                             // to no CopyOption, and Files.copy fails if the destination exists.
-                            Logger.warn(this, "### DOTCMS-37068-MARKER ### copying binary '"
-                                    + srcFile.getAbsolutePath() + "' -> '"
-                                    + destFile.getAbsolutePath()
-                                    + "' with preserveFileDate=false");
                             FileUtils.copyFile(srcFile, destFile, false,
                                     StandardCopyOption.REPLACE_EXISTING);
                             newContentlet.setBinary(tempField.getVelocityVarName(), destFile);

--- a/dotCMS/src/main/java/com/dotcms/storage/FileSystemStoragePersistenceAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/storage/FileSystemStoragePersistenceAPIImpl.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -180,7 +181,10 @@ public class FileSystemStoragePersistenceAPIImpl implements StoragePersistenceAP
 
             try {
                 final File destBucketFile = Paths.get(groupDir.getCanonicalPath(), path.toLowerCase()).toFile();
-                FileUtils.copyFile(file, destBucketFile);
+                // Do NOT preserve the source's file date: on shared storage (NFS/EFS) setting file
+                // times is not permitted and would fail the push even though the bytes were
+                // written fine. REPLACE_EXISTING keeps the previous overwrite semantics.
+                FileUtils.copyFile(file, destBucketFile, false, StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException e) {
                 Logger.error(FileSystemStoragePersistenceAPIImpl.class, e.getMessage(), e);
                 throw new DotDataException(e.getMessage(), e);

--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -3506,6 +3506,107 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
         assertEquals(respCont.getHost(), APILocator.systemHost().getIdentifier());
     }
 
+    /**
+     * Method to test: {@link ESContentletAPIImpl#copyContentlet(Contentlet, User, boolean)}
+     * Given Scenario: A {@link ContentType} with a {@link BinaryField} is copied.
+     * ExpectedResult: The copy carries its own binary, byte-identical to the source. The copy must
+     * not depend on preserving the source file's modification time, which is not settable on
+     * shared storage (NFS/EFS) and used to abort the whole copy with "Cannot set the file time."
+     */
+    @Test
+    public void copyContentletWithBinaryFieldKeepsFileContent()
+            throws DotDataException, DotSecurityException, IOException {
+        final Field binaryField = new FieldDataGen()
+                .name("binary")
+                .velocityVarName("binary")
+                .type(BinaryField.class)
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .fields(list(binaryField))
+                .nextPersisted();
+
+        final File testFile = createFile("images/test.jpg", ".jpg");
+        final Contentlet contentlet = new ContentletDataGen(contentType.id())
+                .setProperty(binaryField.variable(), testFile)
+                .nextPersisted();
+
+        final Contentlet copy = contentletAPI.copyContentlet(contentlet, user, false);
+
+        assertNotEquals(contentlet.getIdentifier(), copy.getIdentifier());
+
+        final File copiedFile = APILocator.getContentletAPI()
+                .find(copy.getInode(), APILocator.systemUser(), false)
+                .getBinary(binaryField.variable());
+
+        assertNotNull("The copy must have its own binary file", copiedFile);
+        assertNotEquals("The copy must not point at the source file",
+                testFile.getAbsolutePath(), copiedFile.getAbsolutePath());
+        FileTestUtil.compare(testFile, copiedFile);
+    }
+
+    /**
+     * Method to test: {@link ESContentletAPIImpl#copyContentlet(Contentlet, User, boolean)}
+     * Given Scenario: A {@link ContentType} with two {@link BinaryField}s whose files share the
+     * same name. Both are staged into the same temporary folder, so the second copy writes to a
+     * path the first one already created.
+     * ExpectedResult: The copy succeeds. This guards the {@code REPLACE_EXISTING} option on the
+     * underlying copy call — without it the second field fails with FileAlreadyExistsException.
+     */
+    @Test
+    public void copyContentletWithTwoBinaryFieldsSharingFileName()
+            throws DotDataException, DotSecurityException, IOException {
+        final Field firstBinaryField = new FieldDataGen()
+                .name("firstBinary")
+                .velocityVarName("firstBinary")
+                .type(BinaryField.class)
+                .next();
+        final Field secondBinaryField = new FieldDataGen()
+                .name("secondBinary")
+                .velocityVarName("secondBinary")
+                .type(BinaryField.class)
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .fields(list(firstBinaryField, secondBinaryField))
+                .nextPersisted();
+
+        // Same file name, different folders: both land on the same path in the temp staging folder
+        final String sharedFileName = "shared_" + System.currentTimeMillis() + ".jpg";
+        final File firstFile = createFileNamed("images/test.jpg", sharedFileName);
+        final File secondFile = createFileNamed("images/test.jpg", sharedFileName);
+
+        final Contentlet contentlet = new ContentletDataGen(contentType.id())
+                .setProperty(firstBinaryField.variable(), firstFile)
+                .setProperty(secondBinaryField.variable(), secondFile)
+                .nextPersisted();
+
+        final Contentlet copy = contentletAPI.copyContentlet(contentlet, user, false);
+
+        assertNotEquals(contentlet.getIdentifier(), copy.getIdentifier());
+
+        final Contentlet copyFromDataBase = APILocator.getContentletAPI()
+                .find(copy.getInode(), APILocator.systemUser(), false);
+
+        assertNotNull(copyFromDataBase.getBinary(firstBinaryField.variable()));
+        assertNotNull(copyFromDataBase.getBinary(secondBinaryField.variable()));
+    }
+
+    /**
+     * Copies a classpath resource into a fresh temp folder under an explicit file name, so two
+     * files can deliberately share a name while living in different folders.
+     */
+    private static File createFileNamed(final String path, final String fileName)
+            throws IOException {
+        final File originalFile = new File(Thread.currentThread()
+                .getContextClassLoader().getResource(path).getFile());
+
+        final File testFile = new File(Files.createTempDirectory("dotcms-test").toFile(), fileName);
+        FileUtil.copyFile(originalFile, testFile);
+
+        return testFile;
+    }
+
 
     /**
      * Method to test: {@link ESContentletAPIImpl#copyContentlet(Contentlet, User, boolean)}


### PR DESCRIPTION
Fixes #37068

## Problem

Copying a contentlet with a **binary field** aborts on NFS/EFS-backed asset volumes (clustered Cloud environments) with:

```
com.dotmarketing.exception.DotDataException: Error copying binary file: 'example-file_copy.dmg': Cannot set the file time.
Caused by: java.io.IOException: Cannot set the file time.
	at org.apache.commons.io.FileUtils.copyFile(FileUtils.java:815)
```

It surfaces as a `WorkflowActionFailureException`, so the **Copy** workflow action fails — and in a bulk copy run (`fireBulkActionTasks`) one bad file kills the task.

## Root cause

`ESContentletAPIImpl.copyContentlet(...)` staged each binary through the two-argument commons-io helper, which delegates with `preserveFileDate = true`:

```java
public static void copyFile(final File srcFile, final File destFile) throws IOException {
    copyFile(srcFile, destFile, StandardCopyOption.REPLACE_EXISTING);  // -> preserveFileDate = true
}

public static void copyFile(final File srcFile, final File destFile,
        final boolean preserveFileDate, final CopyOption... copyOptions) throws IOException {
    ...
    Files.copy(srcFile.toPath(), destFile.toPath(), copyOptions);
    if (preserveFileDate && !setTimes(srcFile, destFile)) {
        throw new IOException("Cannot set the file time.");   // <-- thrown here
    }
}
```

`setTimes(...)` tries `BasicFileAttributeView.setTimes(...)` then falls back to `File.setLastModified(long)`. On NFS/EFS-style mounts both can fail.

**The byte copy has already succeeded at that point.** Only the timestamp-preservation step fails, and the destination is a brand-new file under a throwaway UUID temp folder (`getRealAssetPathTmpBinary() + /<uuid>`), so the source's modification time carries no business meaning. A cosmetic, best-effort operation was aborting a user-facing workflow action.

The line dates to 2013 and is unchanged on `main` — it only surfaces where the timestamp call is not permitted.

## Fix

```diff
  destFile = new File(temporalFolder + File.separator + fieldValue);
- if (!destFile.exists()) {
-     destFile.createNewFile();
- }
- FileUtils.copyFile(srcFile, destFile);
+ FileUtils.copyFile(srcFile, destFile, false, StandardCopyOption.REPLACE_EXISTING);
```

Two details worth reviewing:

1. **`REPLACE_EXISTING` must be passed explicitly.** The three-arg form is `copyFile(src, dest, boolean, CopyOption...)` — writing just `copyFile(src, dest, false)` passes **zero** copy options, and `Files.copy` then fails if the destination exists. This is not merely defensive: `destFile` is `temporalFolder + "/" + srcFile.getName()` and **`temporalFolder` is shared across all fields of the contentlet**, so a content type with two binary fields holding files of the same name writes twice to the same path. That case was previously covered by `createNewFile()` plus the implicit `REPLACE_EXISTING` of the two-arg overload.
2. **Real I/O failures still propagate.** Nothing is swallowed — a genuine failure in `Files.copy` (source unreadable, disk full, destination not writable) still throws and is wrapped as `DotDataException` by the existing catch block.

The now-redundant `createNewFile()` is removed: commons-io creates parent directories and the destination file itself.

### Second call site

`FileSystemStoragePersistenceAPIImpl.pushFile(...)` had the same defect writing into the **asset bucket on the same shared volume**, and is fixed identically. `REPLACE_EXISTING` there preserves the previous overwrite semantics exactly.

### Audited but not changed

These share the `preserveFileDate = true` default but are not on the shared asset path and have no reports — flagged for a follow-up rather than widened here:

| Location | Call |
|---|---|
| `PublisherAPIImpl:379` | `copyFile` (bundle build) |
| `FsFileResource:117` | `copyFile` (WebDAV) |
| `FsDirectoryResource:122` | `copyDirectory` (WebDAV) |
| `OSGIUtil:1190` | `copyDirectory` (bundle dir bootstrap) |

## Tests

Two integration tests added to `ESContentletAPIImplTest` (already registered in `MainSuite3a`):

- `copyContentletWithBinaryFieldKeepsFileContent` — the copy carries its own binary, byte-identical to the source, not a pointer at the source file.
- `copyContentletWithTwoBinaryFieldsSharingFileName` — two binary fields whose files share a name; guards the `REPLACE_EXISTING` option described above. Without it this fails with `FileAlreadyExistsException`.

**Known coverage gap — the `setTimes` failure itself is not simulated.** There is no portable way to force it in a test: as root in CI the modification time can always be set, and a fake wedge would not reproduce the real condition. The tests cover the copy contract and the `REPLACE_EXISTING` regression; **validating the original NFS/EFS scenario requires a manual check on a clustered environment** (see QA note below).

## Verification

- `dotcms-core` compiles and installs clean.
- `dotcms-integration` test-compiles clean (`BUILD SUCCESS`).
- `openapi.yaml` unchanged — no annotation changes in this PR.
- The integration tests were **not executed locally** (they need the Postgres + Elasticsearch stack); they are left to CI.

## QA

On a clustered Cloud environment with shared asset storage:

1. Upload a File Asset (or any content type with a binary field).
2. Run the **Copy** workflow action on it — single, and via a bulk workflow action over a selection.
3. The copy completes; the new content has its binary attached and downloadable, identical to the original.
4. `dotcms.log` shows no `Cannot set the file time.` and no `WorkflowActionFailureException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
