### PR TITLE
feat(content-drive): trim quick actions to the old-search bulk operations and wire Push Publish

### DIFF
--- a/core-web/libs/data-access/src/lib/push-publish/push-publish.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/push-publish/push-publish.service.spec.ts
@@ -193,4 +193,79 @@ describe('PushPublishService', () => {
         );
         req.flush(mockResponse);
     });
+
+    describe('pushPublishAssets', () => {
+        const SETTINGS = {
+            whereToSend: 'env1,env2',
+            iWantTo: 'publish' as const,
+            publishDate: '2026-09-01',
+            publishTime: '10-00',
+            expireDate: '2026-10-01',
+            expireTime: '23-59',
+            filterKey: 'hol',
+            timezoneId: 'Costa Rica'
+        };
+
+        it('should post the split date fields through untouched', () => {
+            // The whole point of this method over `pushPublishContent`: the payload arrives already
+            // in the servlet's shape, so nothing is re-parsed and the chosen timezone survives.
+            spectator.service.pushPublishAssets('id-1', SETTINGS).subscribe((items) => {
+                expect(items).toEqual(mockResponse);
+            });
+
+            const req = spectator.expectOne(
+                '/DotAjaxDirector/com.dotcms.publisher.ajax.RemotePublishAjaxAction/cmd/publish',
+                HttpMethod.POST
+            );
+
+            expect(req.request.body).toBe(
+                'assetIdentifier=id-1&remotePublishDate=2026-09-01&remotePublishTime=10-00' +
+                    '&remotePublishExpireDate=2026-10-01&remotePublishExpireTime=23-59' +
+                    '&timezoneId=Costa Rica&iWantTo=publish&whoToSend=env1,env2' +
+                    '&bundleName=&bundleSelect=&filterKey=hol'
+            );
+            req.flush(mockResponse);
+        });
+
+        it('should send several identifiers comma-joined', () => {
+            // `RemotePublishAjaxAction` splits `assetIdentifier` on "," — bulk needs no new endpoint.
+            spectator.service.pushPublishAssets('id-1,id-2', SETTINGS).subscribe();
+
+            const req = spectator.expectOne(
+                '/DotAjaxDirector/com.dotcms.publisher.ajax.RemotePublishAjaxAction/cmd/publish',
+                HttpMethod.POST
+            );
+
+            expect(req.request.body).toContain('assetIdentifier=id-1%2Cid-2');
+            req.flush(mockResponse);
+        });
+
+        it('should omit the filter key when there is none', () => {
+            // Expiring takes no filter, so an empty value is a real case. The servlet reads the
+            // parameter straight into `getFilterDescriptorByKey`, so it is left out rather than
+            // sent blank.
+            spectator.service.pushPublishAssets('id-1', { ...SETTINGS, filterKey: '' }).subscribe();
+
+            const req = spectator.expectOne(
+                '/DotAjaxDirector/com.dotcms.publisher.ajax.RemotePublishAjaxAction/cmd/publish',
+                HttpMethod.POST
+            );
+
+            expect(req.request.body).not.toContain('filterKey');
+            req.flush(mockResponse);
+        });
+
+        it('should record the environments it last pushed to', () => {
+            spectator.service.pushPublishAssets('id-1', SETTINGS).subscribe();
+
+            spectator
+                .expectOne(
+                    '/DotAjaxDirector/com.dotcms.publisher.ajax.RemotePublishAjaxAction/cmd/publish',
+                    HttpMethod.POST
+                )
+                .flush(mockResponse);
+
+            expect(spectator.service.lastEnvironmentPushed).toEqual(['env1', 'env2']);
+        });
+    });
 });

--- a/core-web/libs/data-access/src/lib/push-publish/push-publish.service.ts
+++ b/core-web/libs/data-access/src/lib/push-publish/push-publish.service.ts
@@ -10,7 +10,8 @@ import {
     DotAjaxActionResponseView,
     DotCurrentUser,
     DotEnvironment,
-    DotPushPublishData
+    DotPushPublishData,
+    DotWorkflowPushPublishValue
 } from '@dotcms/dotcms-models';
 
 import { DotCurrentUserService } from '../dot-current-user/dot-current-user.service';
@@ -80,6 +81,62 @@ export class PushPublishService {
         const url = isBundle ? this.publishBundleURL : this.publishUrl;
 
         return this.http.post<DotAjaxActionResponseView>(url, body, { headers });
+    }
+
+    /**
+     * Push publishes one or more assets, from a payload already in the servlet's own shape.
+     *
+     * Backing endpoint: the same `RemotePublishAjaxAction/cmd/publish` servlet
+     * {@link pushPublishContent} uses. `assetIdentifier` accepts several **identifiers**
+     * comma-joined — the action splits on "," (`RemotePublishAjaxAction`, "Support for multiple ids
+     * in the assetIdentifier parameter"), so bulk needs no new endpoint.
+     *
+     * Separate from {@link pushPublishContent} because of the date handling, not the count.
+     * `DotPushPublishData` carries whole dates and this service splits them into the servlet's
+     * `remotePublishDate` / `remotePublishTime` pair. {@link DotWorkflowPushPublishValue} arrives
+     * already split — that is what the workflow push publish form emits — so routing it through the
+     * other method would mean recombining two strings into a `Date` for this service to take apart
+     * again, losing the timezone the user picked on the way. Here the values pass straight through.
+     *
+     * @param assetIdentifier One identifier, or several comma-joined
+     * @param value The payload emitted by `DotWorkflowPushPublishComponent`
+     * @returns Observable<DotAjaxActionResponseView>
+     * @memberof PushPublishService
+     */
+    pushPublishAssets(
+        assetIdentifier: string,
+        value: DotWorkflowPushPublishValue
+    ): Observable<DotAjaxActionResponseView> {
+        this._lastEnvironmentPushed = value.whereToSend.split(',');
+
+        const headers = new HttpHeaders({
+            'Content-Type': 'application/x-www-form-urlencoded'
+        });
+
+        const params = [
+            `assetIdentifier=${encodeURIComponent(assetIdentifier)}`,
+            `remotePublishDate=${value.publishDate}`,
+            `remotePublishTime=${value.publishTime}`,
+            `remotePublishExpireDate=${value.expireDate}`,
+            `remotePublishExpireTime=${value.expireTime}`,
+            `timezoneId=${value.timezoneId}`,
+            `iWantTo=${value.iWantTo}`,
+            `whoToSend=${value.whereToSend}`,
+            // Sent empty, as the legacy form does: a bundle name or id here would divert the push
+            // into a bundle instead of sending it.
+            'bundleName=',
+            'bundleSelect='
+        ];
+
+        // Only when set. The servlet reads it straight into `getFilterDescriptorByKey`, and expiring
+        // takes no filter, so an empty value is a real case rather than a missing one.
+        if (value.filterKey) {
+            params.push(`filterKey=${value.filterKey}`);
+        }
+
+        return this.http.post<DotAjaxActionResponseView>(this.publishUrl, params.join('&'), {
+            headers
+        });
     }
 
     private getPublishEnvironmentData(

--- a/core-web/libs/dotcms-models/src/lib/dot-push-publish-data.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-push-publish-data.model.ts
@@ -11,3 +11,29 @@ export interface DotPushPublishData {
     filterKey?: string;
     timezoneId: string;
 }
+
+/** What the user can ask a push publish for. Values are the backend's `iWantTo` vocabulary. */
+export type DotWorkflowPushPublishAction = 'publish' | 'expire' | 'publishexpire';
+
+/**
+ * The push publish payload, in the shape the backend's `PushPublishBean` expects.
+ *
+ * Already converted — dates split into `yyyy-MM-dd` + `HH-mm` pairs, environments comma-joined into
+ * `whereToSend` — so a consumer can hand it straight to a fire request without repeating the
+ * transformation that `DotWorkflowEventHandlerService.processWorkflowPayload` does today.
+ *
+ * Lives here rather than beside `DotWorkflowPushPublishComponent` because both the component that
+ * produces it (`@dotcms/ui`) and the service that posts it (`@dotcms/data-access`) need it, and
+ * data-access must not depend on ui.
+ */
+export interface DotWorkflowPushPublishValue {
+    /** Comma-joined environment ids. */
+    whereToSend: string;
+    iWantTo: DotWorkflowPushPublishAction;
+    publishDate: string;
+    publishTime: string;
+    expireDate: string;
+    expireTime: string;
+    filterKey: string;
+    timezoneId: string;
+}

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.html
@@ -66,6 +66,7 @@
                                     [disabled]="
                                         $executing() ||
                                         quickAction.comingSoon ||
+                                        quickAction.missingEnvironments ||
                                         quickAction.count === 0
                                     "
                                     [pTooltip]="quickActionHint(quickAction) | dm"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.html
@@ -63,7 +63,11 @@
                                 <button
                                     type="button"
                                     class="group flex w-full items-center gap-4 px-4 py-3.5 text-left transition-all enabled:hover:cursor-pointer enabled:hover:bg-surface-0 disabled:cursor-not-allowed disabled:opacity-50"
-                                    [disabled]="$executing() || quickAction.count === 0"
+                                    [disabled]="
+                                        $executing() ||
+                                        quickAction.comingSoon ||
+                                        quickAction.count === 0
+                                    "
                                     [pTooltip]="quickActionHint(quickAction) | dm"
                                     [attr.data-testid]="'quick-action-' + quickAction.id"
                                     (click)="onSelectQuickAction(quickAction)">
@@ -106,14 +110,27 @@
                                             aria-hidden="true"></i>
                                     }
 
-                                    <span class="text-xs font-medium text-surface-400">
-                                        ({{ quickAction.count }})
-                                    </span>
-                                    <i
-                                        class="material-symbols-outlined text-[20px]! text-surface-300"
-                                        aria-hidden="true">
-                                        chevron_right
-                                    </i>
+                                    <!-- A placeholder gets a badge instead of a count-and-chevron: the
+                                     chevron promises a screen to drill into, and neither the count
+                                     nor the arrow means anything for a row that cannot be opened. -->
+                                    @if (quickAction.comingSoon) {
+                                        <span
+                                            class="rounded-full bg-surface-100 px-2 py-0.5 text-[10px] font-bold tracking-wide text-surface-500 uppercase"
+                                            [attr.data-testid]="
+                                                'quick-action-coming-soon-' + quickAction.id
+                                            ">
+                                            {{ 'content-drive.work-in-progress' | dm }}
+                                        </span>
+                                    } @else {
+                                        <span class="text-xs font-medium text-surface-400">
+                                            ({{ quickAction.count }})
+                                        </span>
+                                        <i
+                                            class="material-symbols-outlined text-[20px]! text-surface-300"
+                                            aria-hidden="true">
+                                            chevron_right
+                                        </i>
+                                    }
                                 </button>
                             }
                         </div>

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.html
@@ -72,12 +72,7 @@
                                     [attr.data-testid]="'quick-action-' + quickAction.id"
                                     (click)="onSelectQuickAction(quickAction)">
                                     <span
-                                        class="flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors"
-                                        [class]="
-                                            quickAction.danger
-                                                ? 'bg-red-50 text-red-500 group-hover:bg-red-100'
-                                                : 'bg-surface-0 text-surface-400 shadow-sm group-hover:text-primary'
-                                        ">
+                                        class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-surface-0 text-surface-400 shadow-sm transition-colors group-hover:text-primary">
                                         <i
                                             class="material-symbols-outlined text-[20px]!"
                                             aria-hidden="true">
@@ -85,11 +80,7 @@
                                         </i>
                                     </span>
 
-                                    <span
-                                        class="flex-1 text-sm font-semibold"
-                                        [class]="
-                                            quickAction.danger ? 'text-red-600' : 'text-surface-700'
-                                        ">
+                                    <span class="flex-1 text-sm font-semibold text-surface-700">
                                         {{ quickAction.name | dm }}
                                     </span>
 
@@ -488,7 +479,4 @@
             }
         }
     }
-
-    <!-- Guards the destructive quick actions. Appended to body so it layers above the dialog. -->
-    <p-confirmDialog appendTo="body" [draggable]="false" [style]="{ width: '500px' }" />
 </div>

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
@@ -335,12 +335,18 @@ describe('DotContentDriveActionCenterComponent', () => {
         });
 
         it('should mark foreign locks on any action’s preview, not just Unlock', () => {
-            // A lock held by somebody else fails a Publish or an Archive just as readily, so the
-            // marker is not scoped to Unlock. Both rows here are unpublished, so Publish applies to
-            // each of them and only the foreign lock is marked.
+            // A lock held by somebody else can fail any action, so the marker is not scoped to
+            // Unlock. Driven through Add to Bundle — the only other quick action that lists every
+            // selected row — which reaches its preview via the bundle step.
             mockSelectedItems.set(lockedSelection);
 
-            openQuickActionPreview('PUBLISH');
+            spectator.detectChanges();
+            spectator.click('[data-testid="quick-action-ADD_TO_BUNDLE"]');
+            spectator.detectChanges();
+            spectator.component['onBundleChange']({ id: 'bundle-1', name: 'Release 1' });
+            spectator.detectChanges();
+            spectator.click('[data-testid="action-configure-continue"]');
+            spectator.detectChanges();
 
             expect(previewRows().length).toBe(2);
             expect(spectator.queryAll('[data-testid="lock-foreign-icon"]').length).toBe(1);
@@ -477,32 +483,79 @@ describe('DotContentDriveActionCenterComponent', () => {
 
     describe('quick actions', () => {
         it('should render a quick action for the eligible subset', () => {
+            mockSelectedItems.set([
+                contentlet({ inode: 'inode-1' }),
+                contentlet({ inode: 'inode-2', locked: true })
+            ]);
             spectator.detectChanges();
 
-            // inode-1 is not live, so Publish applies to exactly one item.
-            expect(spectator.query('[data-testid="quick-action-PUBLISH"]')).toBeTruthy();
+            // Only inode-1 is unlocked, so Lock applies to exactly one item.
+            const lock = spectator.query('[data-testid="quick-action-LOCK"]');
+
+            expect(lock).toBeTruthy();
+            expect(lock?.textContent).toContain('(1)');
         });
 
         it('should render actions that apply to nothing as non-selectable', () => {
-            // Nothing archived, so Delete applies to no item — the row stays, disabled.
+            // Nothing locked, so Unlock applies to no item — the row stays, disabled.
             spectator.detectChanges();
 
-            const remove = spectator.query(
-                '[data-testid="quick-action-DELETE"]'
+            const unlock = spectator.query(
+                '[data-testid="quick-action-UNLOCK"]'
             ) as HTMLButtonElement;
 
-            expect(remove).toBeTruthy();
-            expect(remove.disabled).toBe(true);
+            expect(unlock).toBeTruthy();
+            expect(unlock.disabled).toBe(true);
         });
 
         it('should keep applicable actions selectable', () => {
             spectator.detectChanges();
 
-            const publish = spectator.query(
-                '[data-testid="quick-action-PUBLISH"]'
-            ) as HTMLButtonElement;
+            const lock = spectator.query('[data-testid="quick-action-LOCK"]') as HTMLButtonElement;
 
-            expect(publish.disabled).toBe(false);
+            expect(lock.disabled).toBe(false);
+        });
+
+        it('should not offer the workflow state actions', () => {
+            // Publish, Unpublish, Archive, Unarchive and Delete belong to the Workflow Actions
+            // section, where they resolve to the scheme's own action rather than a system action.
+            spectator.detectChanges();
+
+            for (const id of ['PUBLISH', 'UNPUBLISH', 'ARCHIVE', 'UNARCHIVE', 'DELETE']) {
+                expect(spectator.query(`[data-testid="quick-action-${id}"]`)).toBeNull();
+            }
+        });
+
+        it('should render Push Publish and Refresh as disabled placeholders', () => {
+            spectator.detectChanges();
+
+            for (const id of ['PUSH_PUBLISH', 'REFRESH']) {
+                const row = spectator.query(
+                    `[data-testid="quick-action-${id}"]`
+                ) as HTMLButtonElement;
+
+                expect(row).toBeTruthy();
+                expect(row.disabled).toBe(true);
+                expect(
+                    spectator.query(`[data-testid="quick-action-coming-soon-${id}"]`)
+                ).toBeTruthy();
+            }
+        });
+
+        it('should not open a preview for a placeholder row', () => {
+            spectator.detectChanges();
+
+            // Disabled, so a real click cannot land — called directly to prove the guard holds if
+            // one ever does.
+            spectator.component['onSelectQuickAction'](
+                spectator.component['$quickActions']().find(
+                    (action) => action.id === 'PUSH_PUBLISH'
+                )!
+            );
+            spectator.detectChanges();
+
+            expect(spectator.query('[data-testid="action-preview"]')).toBeNull();
+            expect(store.executeQuickAction).not.toHaveBeenCalled();
         });
 
         it('should keep Add to Bundle selectable', () => {
@@ -529,43 +582,20 @@ describe('DotContentDriveActionCenterComponent', () => {
             expect(store.executeQuickAction).not.toHaveBeenCalled();
         });
 
-        it('should confirm before firing Delete, then fire on accept', () => {
-            // Delete only applies to archived items, and only it carries a confirmMessage.
-            mockSelectedItems.set([contentlet({ inode: 'inode-1', archived: true })]);
-            jest.spyOn(confirmationService, 'confirm').mockImplementation((config) => {
-                config.accept?.();
-
-                return confirmationService;
-            });
-
-            executeQuickAction('DELETE');
-
-            expect(confirmationService.confirm).toHaveBeenCalled();
-            expect(store.executeQuickAction).toHaveBeenCalledWith('DELETE', expect.any(String), [
-                'inode-1'
-            ]);
-        });
-
-        it('should not fire Delete when the confirmation is dismissed', () => {
-            mockSelectedItems.set([contentlet({ inode: 'inode-1', archived: true })]);
-            // Default mock records the call without invoking `accept`.
-            executeQuickAction('DELETE');
-
-            expect(confirmationService.confirm).toHaveBeenCalled();
-            expect(store.executeQuickAction).not.toHaveBeenCalled();
-        });
-
-        it('should fire non-destructive actions without confirming', () => {
-            executeQuickAction('PUBLISH');
+        it('should fire the remaining quick actions without confirming', () => {
+            // No quick action carries a `confirmMessage` any more — the destructive ones moved to
+            // the Workflow Actions section. The confirm branch stays for whatever comes back.
+            executeQuickAction('LOCK');
 
             expect(confirmationService.confirm).not.toHaveBeenCalled();
             expect(store.executeQuickAction).toHaveBeenCalled();
         });
 
         it('should not fire an action that applies to nothing', () => {
+            // Nothing in the default selection is locked, so Unlock has no eligible rows.
             spectator.detectChanges();
 
-            spectator.click('[data-testid="quick-action-DELETE"]');
+            spectator.click('[data-testid="quick-action-UNLOCK"]');
             spectator.detectChanges();
 
             // Never even reaches the preview.
@@ -574,10 +604,14 @@ describe('DotContentDriveActionCenterComponent', () => {
         });
 
         it('should fire only the inodes the action applies to, not the whole selection', () => {
-            // Selection is inode-1 (not live) and inode-2 (live). Publish applies to inode-1 only.
-            executeQuickAction('PUBLISH');
+            mockSelectedItems.set([
+                contentlet({ inode: 'inode-1' }),
+                contentlet({ inode: 'inode-2', locked: true })
+            ]);
 
-            expect(store.executeQuickAction).toHaveBeenCalledWith('PUBLISH', expect.any(String), [
+            executeQuickAction('LOCK');
+
+            expect(store.executeQuickAction).toHaveBeenCalledWith('LOCK', expect.any(String), [
                 'inode-1'
             ]);
         });
@@ -585,12 +619,16 @@ describe('DotContentDriveActionCenterComponent', () => {
         it('should fire exactly as many inodes as the row advertises', () => {
             // Guards the count/payload pair against drifting apart again: whatever number the row
             // shows must equal the number of inodes sent.
+            mockSelectedItems.set([
+                contentlet({ inode: 'inode-1' }),
+                contentlet({ inode: 'inode-2', locked: true })
+            ]);
             spectator.detectChanges();
 
-            const row = spectator.query('[data-testid="quick-action-PUBLISH"]');
+            const row = spectator.query('[data-testid="quick-action-LOCK"]');
             const advertised = Number(row?.textContent?.match(/\((\d+)\)/)?.[1]);
 
-            executeQuickAction('PUBLISH');
+            executeQuickAction('LOCK');
 
             const [, , inodes] = (store.executeQuickAction as unknown as jest.Mock).mock
                 .calls[0] as [string, string, string[]];
@@ -599,28 +637,10 @@ describe('DotContentDriveActionCenterComponent', () => {
             expect(inodes).toHaveLength(advertised);
         });
 
-        it('should fire only archived items for Delete', () => {
-            mockSelectedItems.set([
-                contentlet({ inode: 'archived-1', archived: true }),
-                contentlet({ inode: 'live-1', live: true })
-            ]);
-            jest.spyOn(confirmationService, 'confirm').mockImplementation((config) => {
-                config.accept?.();
-
-                return confirmationService;
-            });
-
-            executeQuickAction('DELETE');
-
-            expect(store.executeQuickAction).toHaveBeenCalledWith('DELETE', expect.any(String), [
-                'archived-1'
-            ]);
-        });
-
         it('should close the dialog as soon as the run is handed to the store', () => {
             // The dialog is modal, so leaving it open would dim the toolbar that reports the run —
             // and the counts it shows are stale the moment contentlets start moving step.
-            executeQuickAction('PUBLISH');
+            executeQuickAction('LOCK');
 
             expect(store.executeQuickAction).toHaveBeenCalled();
             expect(store.closeDialog).toHaveBeenCalled();
@@ -795,7 +815,7 @@ describe('DotContentDriveActionCenterComponent', () => {
 
     describe('quick action preview', () => {
         it('should open the preview instead of firing when a quick action is clicked', () => {
-            openQuickActionPreview('PUBLISH');
+            openQuickActionPreview('LOCK');
 
             expect(spectator.query('[data-testid="action-preview"]')).toBeTruthy();
             expect(spectator.query('[data-testid="action-center"]')).toBeNull();
@@ -803,9 +823,14 @@ describe('DotContentDriveActionCenterComponent', () => {
         });
 
         it('should list only the contentlets the quick action applies to', () => {
-            // inode-1 is not live, inode-2 is. Publish applies to inode-1 only, so the preview must
-            // not offer inode-2 as something the user could include.
-            openQuickActionPreview('PUBLISH');
+            // inode-2 is already locked, so Lock applies to inode-1 only and the preview must not
+            // offer inode-2 as something the user could include.
+            mockSelectedItems.set([
+                contentlet({ inode: 'inode-1' }),
+                contentlet({ inode: 'inode-2', locked: true })
+            ]);
+
+            openQuickActionPreview('LOCK');
 
             const rows = previewRows();
 
@@ -814,10 +839,15 @@ describe('DotContentDriveActionCenterComponent', () => {
         });
 
         it('should retitle the dialog header with the quick action and its count', () => {
-            openQuickActionPreview('PUBLISH');
+            mockSelectedItems.set([
+                contentlet({ inode: 'inode-1' }),
+                contentlet({ inode: 'inode-2', locked: true })
+            ]);
+
+            openQuickActionPreview('LOCK');
 
             expect(store.setDialogDrillDown).toHaveBeenCalledWith({
-                header: 'Default-Action-Publish',
+                header: 'content-drive.context-menu.lock',
                 itemCount: 1
             });
         });
@@ -828,12 +858,12 @@ describe('DotContentDriveActionCenterComponent', () => {
                 contentlet({ inode: 'drop-me' })
             ]);
 
-            openQuickActionPreview('PUBLISH');
+            openQuickActionPreview('LOCK');
             uncheckFirstRow();
             spectator.click('[data-testid="action-preview-execute"]');
             spectator.detectChanges();
 
-            expect(store.executeQuickAction).toHaveBeenCalledWith('PUBLISH', expect.any(String), [
+            expect(store.executeQuickAction).toHaveBeenCalledWith('LOCK', expect.any(String), [
                 'drop-me'
             ]);
         });
@@ -841,7 +871,7 @@ describe('DotContentDriveActionCenterComponent', () => {
         it('should keep Execute disabled once every row is unchecked', () => {
             mockSelectedItems.set([contentlet({ inode: 'only-one' })]);
 
-            openQuickActionPreview('PUBLISH');
+            openQuickActionPreview('LOCK');
             uncheckFirstRow();
 
             const execute = spectator.query(
@@ -852,7 +882,7 @@ describe('DotContentDriveActionCenterComponent', () => {
         });
 
         it('should return to the action list without firing when Back is clicked', () => {
-            openQuickActionPreview('PUBLISH');
+            openQuickActionPreview('LOCK');
             spectator.click('[data-testid="action-preview-back"]');
             spectator.detectChanges();
 
@@ -861,25 +891,10 @@ describe('DotContentDriveActionCenterComponent', () => {
             expect(store.clearDialogDrillDown).toHaveBeenCalled();
         });
 
-        it('should confirm at Execute rather than when the destructive row is clicked', () => {
-            // The commit point moved: opening a preview changes nothing, so prompting there would
-            // ask the user to confirm something that has not been decided yet.
-            mockSelectedItems.set([contentlet({ inode: 'inode-1', archived: true })]);
-
-            openQuickActionPreview('DELETE');
-
-            expect(confirmationService.confirm).not.toHaveBeenCalled();
-
-            spectator.click('[data-testid="action-preview-execute"]');
-            spectator.detectChanges();
-
-            expect(confirmationService.confirm).toHaveBeenCalled();
-        });
-
         it('should not show the workflow partial-match warning on a quick action', () => {
             // That warning explains a backend count falling short of the rows shown. A quick
             // action's count is derived from the rows themselves, so it can never fall short.
-            openQuickActionPreview('PUBLISH');
+            openQuickActionPreview('LOCK');
 
             expect(spectator.query('[data-testid="action-preview-partial-match"]')).toBeNull();
         });

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
@@ -5,7 +5,6 @@ import { of, throwError } from 'rxjs';
 import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 
-
 import {
     AddToBundleService,
     DotCurrentUserService,

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
@@ -17,7 +17,7 @@ import {
     PushPublishService
 } from '@dotcms/data-access';
 import { DotcmsConfigService } from '@dotcms/dotcms-js';
-import { DotBulkActionView, DotContentDriveItem } from '@dotcms/dotcms-models';
+import { DotBulkActionView, DotContentDriveItem, DotEnvironment } from '@dotcms/dotcms-models';
 import { DotBrowsingService, DotWorkflowAssignCommentComponent } from '@dotcms/ui';
 import { DotcmsConfigServiceMock } from '@dotcms/utils-testing';
 
@@ -155,6 +155,10 @@ describe('DotContentDriveActionCenterComponent', () => {
     let spectator: Spectator<DotContentDriveActionCenterComponent>;
     let store: SpyObject<InstanceType<typeof DotContentDriveStore>>;
     let workflowsActionsService: SpyObject<DotWorkflowsActionsService>;
+    /** What the push publish environments lookup answers; see the `mockProvider` below. */
+    let pushPublishEnvironments: DotEnvironment[] = [];
+    /** When true the lookup errors instead, for the fails-closed case. */
+    let pushPublishEnvironmentsFail = false;
 
     const mockSelectedItems = signal<DotContentDriveItem[]>([]);
     // Owned by the store now, so the dialog reads it rather than tracking its own executing flag.
@@ -187,7 +191,8 @@ describe('DotContentDriveActionCenterComponent', () => {
                 clearDialogDrillDown: jest.fn(),
                 executeQuickAction: jest.fn(),
                 executeWorkflowAction: jest.fn(),
-                executeAddToBundle: jest.fn()
+                executeAddToBundle: jest.fn(),
+                executePushPublish: jest.fn()
             }),
             mockProvider(DotMessageService, {
                 get: jest.fn().mockImplementation((key: string) => key)
@@ -202,7 +207,15 @@ describe('DotContentDriveActionCenterComponent', () => {
             }),
             // Backs the env selector embedded in the push publish step.
             mockProvider(PushPublishService, {
-                getEnvironments: jest.fn(() => of([])),
+                // Reads `pushPublishEnvironments` on every call rather than being re-programmed per
+                // test: `mockProvider` builds this `jest.fn` once for the whole file, and the
+                // `afterEach` `clearAllMocks` drops any `mockReturnValue` set on it, so only the
+                // first test in a block would see one. A closure over a mutable answer is immune.
+                getEnvironments: jest.fn(() =>
+                    pushPublishEnvironmentsFail
+                        ? throwError(() => new Error('environments lookup failed'))
+                        : of(pushPublishEnvironments)
+                ),
                 lastEnvironmentPushed: null
             }),
             mockProvider(DotRolesService, { get: jest.fn(() => of([])) }),
@@ -246,6 +259,8 @@ describe('DotContentDriveActionCenterComponent', () => {
         ]);
         mockActionExecution.set(undefined);
         mockCurrentUserIsAdmin.set(false);
+        pushPublishEnvironments = [];
+        pushPublishEnvironmentsFail = false;
         mockCurrentSite.set({ hostname: 'demo.dotcms.com' });
         mockPath.set('/blogs');
 
@@ -520,32 +535,47 @@ describe('DotContentDriveActionCenterComponent', () => {
             }
         });
 
-        it('should render Push Publish and Refresh as disabled placeholders', () => {
+        it('should render Refresh as a disabled placeholder', () => {
             spectator.detectChanges();
 
-            for (const id of ['PUSH_PUBLISH', 'REFRESH']) {
-                const row = spectator.query(
-                    `[data-testid="quick-action-${id}"]`
-                ) as HTMLButtonElement;
+            const row = spectator.query(
+                '[data-testid="quick-action-REFRESH"]'
+            ) as HTMLButtonElement;
 
-                expect(row).toBeTruthy();
-                expect(row.disabled).toBe(true);
-                expect(
-                    spectator.query(`[data-testid="quick-action-coming-soon-${id}"]`)
-                ).toBeTruthy();
-            }
+            expect(row).toBeTruthy();
+            expect(row.disabled).toBe(true);
+            expect(
+                spectator.query('[data-testid="quick-action-coming-soon-REFRESH"]')
+            ).toBeTruthy();
         });
 
-        it('should not open a preview for a placeholder row', () => {
+        it('should disable Push Publish without the coming-soon badge when no environment exists', () => {
+            // The default mock answers with no environments. Not a placeholder: the feature is
+            // built, the instance is not configured, and those read differently.
+            spectator.detectChanges();
+
+            const row = spectator.query(
+                '[data-testid="quick-action-PUSH_PUBLISH"]'
+            ) as HTMLButtonElement;
+
+            expect(row.disabled).toBe(true);
+            expect(
+                spectator.query('[data-testid="quick-action-coming-soon-PUSH_PUBLISH"]')
+            ).toBeNull();
+        });
+
+        it('should not open a preview for a blocked row', () => {
             spectator.detectChanges();
 
             // Disabled, so a real click cannot land — called directly to prove the guard holds if
-            // one ever does.
-            spectator.component['onSelectQuickAction'](
-                spectator.component['$quickActions']().find(
-                    (action) => action.id === 'PUSH_PUBLISH'
-                )!
-            );
+            // one ever does. Both blocked states are covered: Refresh is a placeholder, Push
+            // Publish has nowhere to send to.
+            for (const id of ['REFRESH', 'PUSH_PUBLISH']) {
+                spectator.component['onSelectQuickAction'](
+                    spectator.component['$quickActions']().find((action) => action.id === id)!
+                );
+            }
+
             spectator.detectChanges();
 
             expect(spectator.query('[data-testid="action-preview"]')).toBeNull();
@@ -1574,6 +1604,156 @@ describe('DotContentDriveActionCenterComponent', () => {
             goToPreview();
 
             expect(spectator.query('[data-testid="action-preview-partial-match"]')).toBeTruthy();
+        });
+    });
+
+    describe('push publish', () => {
+        const ENVIRONMENTS = [{ id: 'env-1', name: 'Production' }];
+
+        /**
+         * Renders as if an environment were reachable.
+         *
+         * Sets the resolved signal rather than the service answer. The lookup fires once from
+         * `ngOnInit`, and re-programming a `mockProvider` method per test proved unreliable here —
+         * the value only took for the first test in the block. The service-to-signal wiring is
+         * covered on its own by the two tests that exercise the real lookup (no environments, and
+         * the failing lookup); everything below is about what the dialog does *given* an answer.
+         */
+        const withEnvironments = (): void => {
+            spectator.detectChanges();
+            spectator.component['$hasPushPublishEnvironments'].set(true);
+            spectator.detectChanges();
+        };
+
+        /** Stands in for the push publish step emitting a complete payload. */
+        const fillPushPublishForm = (): void => {
+            spectator.component['onPushPublishChange'](PUSH_PUBLISH_SETTINGS);
+            spectator.component['$pushPublishValid'].set(true);
+            spectator.detectChanges();
+        };
+
+        it('should enable the row once an environment is reachable', () => {
+            // Through the real lookup, so the service-to-signal wiring is covered.
+            pushPublishEnvironments = ENVIRONMENTS;
+
+            spectator.detectChanges();
+
+            const row = spectator.query(
+                '[data-testid="quick-action-PUSH_PUBLISH"]'
+            ) as HTMLButtonElement;
+
+            expect(row.disabled).toBe(false);
+        });
+
+        it('should open the push publish form rather than the preview', () => {
+            // The same step the workflow-action path renders, so a push publish is collected the
+            // same way in both dialogs.
+            withEnvironments();
+
+            spectator.click('[data-testid="quick-action-PUSH_PUBLISH"]');
+            spectator.detectChanges();
+
+            // The configure bar is gated on the view; the step body itself is always rendered and
+            // merely hidden, so asserting on it alone would pass from the action list too.
+            expect(spectator.query('[data-testid="action-configure-bar"]')).toBeTruthy();
+            expect(spectator.query('[data-testid="action-configure-push-publish"]')).toBeTruthy();
+            expect(spectator.query('[data-testid="action-preview"]')).toBeNull();
+        });
+
+        it('should keep Continue disabled until the form is complete', () => {
+            withEnvironments();
+            spectator.click('[data-testid="quick-action-PUSH_PUBLISH"]');
+            spectator.detectChanges();
+
+            const continueButton = spectator.query(
+                '[data-testid="action-configure-continue"] button'
+            ) as HTMLButtonElement;
+
+            expect(continueButton.disabled).toBe(true);
+        });
+
+        it('should reach the preview once the form is complete', () => {
+            withEnvironments();
+            spectator.click('[data-testid="quick-action-PUSH_PUBLISH"]');
+            spectator.detectChanges();
+            fillPushPublishForm();
+
+            spectator.click('[data-testid="action-configure-continue"]');
+            spectator.detectChanges();
+
+            expect(spectator.query('[data-testid="action-preview"]')).toBeTruthy();
+        });
+
+        it('should push identifiers, deduped, with the collected settings', () => {
+            // Identifiers rather than inodes: a push sends the asset, so language versions of one
+            // contentlet are a single entry — the same collapse Add to Bundle makes.
+            mockSelectedItems.set([
+                contentlet({ inode: 'inode-1', identifier: 'id-1' }),
+                contentlet({ inode: 'inode-2', identifier: 'id-1' }),
+                contentlet({ inode: 'inode-3', identifier: 'id-2' })
+            ]);
+            withEnvironments();
+            spectator.click('[data-testid="quick-action-PUSH_PUBLISH"]');
+            spectator.detectChanges();
+            fillPushPublishForm();
+            spectator.click('[data-testid="action-configure-continue"]');
+            spectator.detectChanges();
+
+            spectator.click('[data-testid="action-preview-execute"]');
+
+            expect(store.executePushPublish).toHaveBeenCalledWith(
+                expect.any(String),
+                ['id-1', 'id-2'],
+                PUSH_PUBLISH_SETTINGS
+            );
+            expect(store.closeDialog).toHaveBeenCalled();
+        });
+
+        it('should honour rows unchecked in the preview', () => {
+            mockSelectedItems.set([
+                contentlet({ inode: 'keep-me', identifier: 'id-keep' }),
+                contentlet({ inode: 'drop-me', identifier: 'id-drop' })
+            ]);
+            withEnvironments();
+            spectator.click('[data-testid="quick-action-PUSH_PUBLISH"]');
+            spectator.detectChanges();
+            fillPushPublishForm();
+            spectator.click('[data-testid="action-configure-continue"]');
+            spectator.detectChanges();
+            uncheckFirstRow();
+
+            spectator.click('[data-testid="action-preview-execute"]');
+
+            expect(store.executePushPublish).toHaveBeenCalledWith(
+                expect.any(String),
+                ['id-drop'],
+                PUSH_PUBLISH_SETTINGS
+            );
+        });
+
+        it('should not push without settings', () => {
+            // Refused here as well as by the disabled Continue: the servlet answers 200 having sent
+            // nothing anywhere, which would read as a success.
+            withEnvironments();
+            spectator.click('[data-testid="quick-action-PUSH_PUBLISH"]');
+            spectator.detectChanges();
+
+            spectator.component['onExecutePreview']();
+
+            expect(store.executePushPublish).not.toHaveBeenCalled();
+        });
+
+        it('should disable the row when the environments lookup fails', () => {
+            // Fails closed: offering a push with nowhere to go fails at the servlet with a message
+            // the user cannot act on.
+            pushPublishEnvironmentsFail = true;
+
+            spectator.detectChanges();
+
+            expect(
+                (spectator.query('[data-testid="quick-action-PUSH_PUBLISH"]') as HTMLButtonElement)
+                    .disabled
+            ).toBe(true);
         });
     });
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.spec.ts
@@ -5,7 +5,6 @@ import { of, throwError } from 'rxjs';
 import { provideHttpClient } from '@angular/common/http';
 import { signal } from '@angular/core';
 
-import { ConfirmationService } from 'primeng/api';
 
 import {
     AddToBundleService,
@@ -157,7 +156,6 @@ describe('DotContentDriveActionCenterComponent', () => {
     let spectator: Spectator<DotContentDriveActionCenterComponent>;
     let store: SpyObject<InstanceType<typeof DotContentDriveStore>>;
     let workflowsActionsService: SpyObject<DotWorkflowsActionsService>;
-    let confirmationService: SpyObject<ConfirmationService>;
 
     const mockSelectedItems = signal<DotContentDriveItem[]>([]);
     // Owned by the store now, so the dialog reads it rather than tracking its own executing flag.
@@ -256,15 +254,12 @@ describe('DotContentDriveActionCenterComponent', () => {
 
         store = spectator.inject(DotContentDriveStore, true);
         workflowsActionsService = spectator.inject(DotWorkflowsActionsService, true);
-        confirmationService = spectator.inject(ConfirmationService, true);
 
         jest.spyOn(workflowsActionsService, 'getBulkActions').mockReturnValue(
             of(BULK_ACTIONS_RESPONSE)
         );
         jest.spyOn(store, 'closeDialog');
         jest.spyOn(store, 'loadItems');
-        // Records the call without accepting, so tests opt in to the accept path explicitly.
-        jest.spyOn(confirmationService, 'confirm').mockReturnValue(confirmationService);
     });
 
     afterEach(() => {
@@ -582,15 +577,6 @@ describe('DotContentDriveActionCenterComponent', () => {
             expect(store.executeQuickAction).not.toHaveBeenCalled();
         });
 
-        it('should fire the remaining quick actions without confirming', () => {
-            // No quick action carries a `confirmMessage` any more — the destructive ones moved to
-            // the Workflow Actions section. The confirm branch stays for whatever comes back.
-            executeQuickAction('LOCK');
-
-            expect(confirmationService.confirm).not.toHaveBeenCalled();
-            expect(store.executeQuickAction).toHaveBeenCalled();
-        });
-
         it('should not fire an action that applies to nothing', () => {
             // Nothing in the default selection is locked, so Unlock has no eligible rows.
             spectator.detectChanges();
@@ -802,14 +788,6 @@ describe('DotContentDriveActionCenterComponent', () => {
             expect(store.executeQuickAction).toHaveBeenCalledWith('UNLOCK', expect.any(String), [
                 'locked-1'
             ]);
-        });
-
-        it('should not confirm before locking or unlocking', () => {
-            mockSelectedItems.set([contentlet({ inode: 'locked-1', locked: true })]);
-
-            executeQuickAction('UNLOCK');
-
-            expect(confirmationService.confirm).not.toHaveBeenCalled();
         });
     });
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.ts
@@ -560,8 +560,17 @@ export class DotContentDriveActionCenterComponent implements OnInit {
         return !!selectedId && scheme.actions.some((action) => action.id === selectedId);
     }
 
-    /** Hint shown on a quick action row. Empty for a row that can be used, so no tooltip appears. */
+    /**
+     * Hint shown on a quick action row. Empty for a row that can be used, so no tooltip appears.
+     *
+     * `comingSoon` is checked first: those rows are disabled whatever their count says, so "not
+     * applicable" would explain the wrong thing about them.
+     */
     protected quickActionHint(quickAction: DotActionCenterQuickAction): string {
+        if (quickAction.comingSoon) {
+            return 'content-drive.action-center.coming-soon';
+        }
+
         return quickAction.count === 0 ? 'content-drive.action-center.not-applicable' : '';
     }
 
@@ -575,7 +584,9 @@ export class DotContentDriveActionCenterComponent implements OnInit {
      * @param quickAction - The quick action chosen by the user
      */
     protected onSelectQuickAction(quickAction: DotActionCenterQuickAction): void {
-        if (!quickAction.count) {
+        // Guarded here as well as by the disabled row: a placeholder has no preview to open and no
+        // execution path behind it, so a stray call must not reach the preview screen.
+        if (!quickAction.count || quickAction.comingSoon) {
             return;
         }
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.ts
@@ -20,7 +20,11 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { finalize, map, take } from 'rxjs/operators';
 
-import { DotMessageService, DotWorkflowsActionsService } from '@dotcms/data-access';
+import {
+    DotMessageService,
+    DotWorkflowsActionsService,
+    PushPublishService
+} from '@dotcms/data-access';
 import {
     DotActionCenterScheme,
     DotActionCenterWorkflowAction,
@@ -46,6 +50,7 @@ import { DotContentDriveStore } from '../../../store/dot-content-drive.store';
 import {
     ADD_TO_BUNDLE_ACTION_ID,
     DotActionCenterQuickAction,
+    PUSH_PUBLISH_ACTION_ID,
     DotActionInputKind,
     eligibleContentlets,
     excludeFolders,
@@ -165,6 +170,7 @@ export class DotContentDriveActionCenterComponent implements OnInit {
     readonly #store = inject(DotContentDriveStore);
     readonly #dotMessageService = inject(DotMessageService);
     readonly #workflowsActionsService = inject(DotWorkflowsActionsService);
+    readonly #pushPublishService = inject(PushPublishService);
 
     protected readonly $selectedItems = this.#store.selectedItems;
 
@@ -237,6 +243,14 @@ export class DotContentDriveActionCenterComponent implements OnInit {
     protected readonly $loadingSchemes = signal<boolean>(true);
     /** True when the lookup failed — the workflow section renders an inline error. */
     protected readonly $schemesError = signal<boolean>(false);
+    /**
+     * Whether any push publish environment is reachable by this user's role.
+     *
+     * `undefined` until the lookup lands, which keeps the Push Publish row disabled in the meantime
+     * rather than enabling it and then retracting. A failed lookup settles on `false` for the same
+     * reason: offering a push with nowhere to send it is worse than one disabled row.
+     */
+    protected readonly $hasPushPublishEnvironments = signal<boolean | undefined>(undefined);
     /** The single workflow action currently selected, across every scheme. */
     protected readonly $selectedActionId = signal<string | null>(null);
     /**
@@ -339,7 +353,16 @@ export class DotContentDriveActionCenterComponent implements OnInit {
         const quickAction = this.$pendingQuickAction();
 
         if (quickAction) {
-            return quickAction.id === ADD_TO_BUNDLE_ACTION_ID ? ['bundle'] : [];
+            switch (quickAction.id) {
+                case ADD_TO_BUNDLE_ACTION_ID:
+                    return ['bundle'];
+                case PUSH_PUBLISH_ACTION_ID:
+                    // The same section the workflow-action path renders, so the two dialogs collect a
+                    // push publish the same way.
+                    return ['pushPublish'];
+                default:
+                    return [];
+            }
         }
 
         return requiredInputKinds(this.$selectedAction());
@@ -458,7 +481,10 @@ export class DotContentDriveActionCenterComponent implements OnInit {
         // fetched when this dialog opens: reopening the Action Center is cheap and common, and a
         // per-open request would leave the first render of every open warning as a non-admin until
         // it answered. Read as a signal so a late resolution still recomputes the rows.
-        getQuickActions(this.$contentlets(), { isAdmin: this.#store.currentUserIsAdmin() })
+        getQuickActions(this.$contentlets(), {
+            isAdmin: this.#store.currentUserIsAdmin(),
+            hasPushPublishEnvironments: this.$hasPushPublishEnvironments()
+        })
     );
 
     /** Number of contentlets still checked in the preview. */
@@ -543,6 +569,29 @@ export class DotContentDriveActionCenterComponent implements OnInit {
 
     ngOnInit(): void {
         this.loadWorkflowActions();
+        this.loadPushPublishEnvironments();
+    }
+
+    /**
+     * Resolves whether Push Publish has anywhere to send to.
+     *
+     * Runs beside the workflow lookup rather than after it: the two answer different questions and
+     * neither needs the other, so chaining them would only delay the quick actions behind a request
+     * they do not depend on.
+     *
+     * A failure settles on "none", which disables the row. The alternative — treating an unreachable
+     * lookup as "probably fine" — offers a push that has nowhere to go and fails at the servlet with
+     * a message the user cannot act on.
+     */
+    private loadPushPublishEnvironments(): void {
+        this.#pushPublishService
+            .getEnvironments()
+            .pipe(take(1))
+            .subscribe({
+                next: (environments) =>
+                    this.$hasPushPublishEnvironments.set(environments.length > 0),
+                error: () => this.$hasPushPublishEnvironments.set(false)
+            });
     }
 
     /**
@@ -569,6 +618,14 @@ export class DotContentDriveActionCenterComponent implements OnInit {
             return 'content-drive.action-center.coming-soon';
         }
 
+        if (quickAction.missingEnvironments) {
+            // Only once the lookup has answered. While it is in flight the row is disabled with no
+            // tooltip, rather than blaming a configuration we have not checked yet.
+            return this.$hasPushPublishEnvironments() === undefined
+                ? ''
+                : 'content-drive.action-center.no-environments';
+        }
+
         return quickAction.count === 0 ? 'content-drive.action-center.not-applicable' : '';
     }
 
@@ -582,9 +639,9 @@ export class DotContentDriveActionCenterComponent implements OnInit {
      * @param quickAction - The quick action chosen by the user
      */
     protected onSelectQuickAction(quickAction: DotActionCenterQuickAction): void {
-        // Guarded here as well as by the disabled row: a placeholder has no preview to open and no
-        // execution path behind it, so a stray call must not reach the preview screen.
-        if (!quickAction.count || quickAction.comingSoon) {
+        // Guarded here as well as by the disabled row: a placeholder has no preview to open, and a
+        // push with no environment has nowhere to go, so a stray call must not reach the preview.
+        if (!quickAction.count || quickAction.comingSoon || quickAction.missingEnvironments) {
             return;
         }
 
@@ -639,10 +696,16 @@ export class DotContentDriveActionCenterComponent implements OnInit {
             return;
         }
 
-        // Add to Bundle leaves the workflow path entirely — different endpoint, different id kind,
-        // and a target that has to be present.
+        // Add to Bundle and Push Publish leave the workflow path entirely — different endpoints,
+        // different id kind, and settings that have to be present.
         if (quickAction.id === ADD_TO_BUNDLE_ACTION_ID) {
             this.fireAddToBundle(quickAction);
+
+            return;
+        }
+
+        if (quickAction.id === PUSH_PUBLISH_ACTION_ID) {
+            this.firePushPublish(quickAction);
 
             return;
         }
@@ -677,6 +740,29 @@ export class DotContentDriveActionCenterComponent implements OnInit {
             this.#dotMessageService.get(quickAction.name),
             bundle,
             identifiers
+        );
+        this.handOffToToolbar();
+    }
+
+    /**
+     * Pushes the checked contentlets to the chosen environments.
+     *
+     * Sends **identifiers**, deduped, for the same reason Add to Bundle does: push publish sends the
+     * asset, so every language version of a contentlet is one entry. Refuses without settings rather
+     * than posting — the servlet would answer 200 having sent nothing anywhere.
+     */
+    private firePushPublish(quickAction: DotActionCenterQuickAction): void {
+        const settings = this.$pushPublish();
+        const identifiers = toDistinctIdentifiers(this.$includedItems());
+
+        if (!settings || !identifiers.length) {
+            return;
+        }
+
+        this.#store.executePushPublish(
+            this.#dotMessageService.get(quickAction.name),
+            identifiers,
+            settings
         );
         this.handOffToToolbar();
     }

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-action-center/dot-content-drive-action-center.component.ts
@@ -11,10 +11,8 @@ import {
 import { FormsModule } from '@angular/forms';
 
 import { AccordionModule } from 'primeng/accordion';
-import { ConfirmationService } from 'primeng/api';
 import { BadgeModule } from 'primeng/badge';
 import { ButtonModule } from 'primeng/button';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { MessageModule } from 'primeng/message';
 import { RadioButtonModule } from 'primeng/radiobutton';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -75,7 +73,9 @@ type DotActionCenterConfigureKind = DotActionInputKind | 'bundle';
  *
  * Two sections:
  *
- * 1. **Quick Actions** — system actions fired over the whole eligible selection in one request via
+ * 1. **Quick Actions** — the bulk operations the old search toolbar offered outside its workflow
+ *    dropdown: Lock, Unlock, Add to Bundle, and placeholders for Push Publish and Refresh. Lock and
+ *    Unlock fire over the whole eligible selection in one request via
  *    `POST /api/v1/workflow/actions/default/fire/{systemAction}`. Counts are derived client-side
  *    from row state (see `getQuickActions`).
  * 2. **Workflow Actions** — one collapsible panel per workflow scheme, from
@@ -95,9 +95,9 @@ type DotActionCenterConfigureKind = DotActionInputKind | 'bundle';
  * This used to be workflow-only, on the reasoning that a quick action's count is derived from the
  * rows themselves and so "which items is this about to touch?" had an obvious answer. That confused
  * *knowing* the answer with *being able to change it*. The set is knowable, but the user still had no
- * way to narrow it — clicking Publish (12) published twelve items with no chance to drop one. The
- * preview is worth most on Unlock, where the row warns that some locks belong to other users and the
- * only way to act on that warning is to uncheck those rows.
+ * way to narrow it — clicking Unlock (12) unlocked twelve items with no chance to drop one. Unlock is
+ * where the preview earns its place: the row warns that some locks belong to other users, and the only
+ * way to act on that warning is to uncheck those rows.
  *
  * What still differs is what the count means. A quick action's count and its preview rows are the
  * same client-side filter, so they always agree. A workflow action's count comes from the backend and
@@ -129,7 +129,6 @@ type DotActionCenterConfigureKind = DotActionInputKind | 'bundle';
         AccordionModule,
         BadgeModule,
         ButtonModule,
-        ConfirmDialogModule,
         DotContentDriveActionBundleTargetComponent,
         DotContentDriveActionMoveTargetComponent,
         DotContentDriveActionPreviewComponent,
@@ -142,7 +141,7 @@ type DotActionCenterConfigureKind = DotActionInputKind | 'bundle';
         SkeletonModule,
         TooltipModule
     ],
-    providers: [DotWorkflowsActionsService, ConfirmationService],
+    providers: [DotWorkflowsActionsService],
     templateUrl: './dot-content-drive-action-center.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
@@ -166,7 +165,6 @@ export class DotContentDriveActionCenterComponent implements OnInit {
     readonly #store = inject(DotContentDriveStore);
     readonly #dotMessageService = inject(DotMessageService);
     readonly #workflowsActionsService = inject(DotWorkflowsActionsService);
-    readonly #confirmationService = inject(ConfirmationService);
 
     protected readonly $selectedItems = this.#store.selectedItems;
 
@@ -532,8 +530,8 @@ export class DotContentDriveActionCenterComponent implements OnInit {
      * `warningCount` — so the number the row advertises and the rows marked here cannot disagree,
      * and an administrator sees neither.
      *
-     * Applied to every action's preview, not just Unlock: a lock held by somebody else can fail a
-     * Publish or an Archive just as readily, and the row is worth flagging wherever it is listed.
+     * Applied to every action's preview, not just Unlock: a lock held by somebody else can fail any
+     * action fired over that row, and it is worth flagging wherever the row is listed.
      */
     protected readonly $lockedByOthers = computed(() => {
         const context = { isAdmin: this.#store.currentUserIsAdmin() };
@@ -627,10 +625,12 @@ export class DotContentDriveActionCenterComponent implements OnInit {
     }
 
     /**
-     * Fires a quick action over the rows left checked, prompting first when it warrants one.
+     * Fires a quick action over the rows left checked.
      *
-     * The prompt sits here rather than on the row click because this is the commit point: opening a
-     * preview changes nothing, so confirming there would ask about a decision not yet made.
+     * No confirmation prompt: none of the remaining quick actions is destructive. Lock, Unlock and
+     * Add to Bundle are all reversible, and the preview is already a commit point the user passes
+     * through. Publish, Archive and Delete — the rows that warranted one — now live in the Workflow
+     * Actions section.
      */
     private executeQuickAction(quickAction: DotActionCenterQuickAction): void {
         const inodes = this.$includedItems().map((item) => item.inode);
@@ -639,35 +639,14 @@ export class DotContentDriveActionCenterComponent implements OnInit {
             return;
         }
 
-        // Add to Bundle leaves the workflow path entirely — different endpoint, different id kind, and
-        // a target that has to be present. Handled before the confirm branch because it carries no
-        // `confirmMessage`: nothing is published or destroyed by queueing content into a bundle.
+        // Add to Bundle leaves the workflow path entirely — different endpoint, different id kind,
+        // and a target that has to be present.
         if (quickAction.id === ADD_TO_BUNDLE_ACTION_ID) {
             this.fireAddToBundle(quickAction);
 
             return;
         }
 
-        if (quickAction.confirmMessage) {
-            this.#confirmationService.confirm({
-                message: this.#dotMessageService.get(quickAction.confirmMessage),
-                header: this.#dotMessageService.get('content-drive.action-center.confirm.header'),
-                acceptLabel: this.#dotMessageService.get('dot.common.yes'),
-                rejectLabel: this.#dotMessageService.get('dot.common.no'),
-                accept: () => this.fireQuickAction(quickAction, inodes)
-            });
-
-            return;
-        }
-
-        this.fireQuickAction(quickAction, inodes);
-    }
-
-    /**
-     * Fires a quick action over the given inodes. Split out of {@link onExecuteQuickAction} so the
-     * confirmation branch and the direct branch share one execution path.
-     */
-    private fireQuickAction(quickAction: DotActionCenterQuickAction, inodes: string[]): void {
         this.#store.executeQuickAction(
             quickAction.id,
             this.#dotMessageService.get(quickAction.name),

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-folder-list-context-menu/dot-folder-list-context-menu.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-folder-list-context-menu/dot-folder-list-context-menu.component.spec.ts
@@ -24,7 +24,8 @@ import {
     DotWorkflowActionsFireService,
     DotWorkflowEventHandlerService,
     DotWorkflowsActionsService,
-    AddToBundleService
+    AddToBundleService,
+    PushPublishService
 } from '@dotcms/data-access';
 import {
     DotCMSBaseTypesContentTypes,
@@ -100,6 +101,9 @@ describe('DotFolderListViewContextMenuComponent', () => {
             mockProvider(DotHttpErrorManagerService),
             // Also required by `withActionExecution`, which fires Add to Bundle from the store.
             mockProvider(AddToBundleService),
+            mockProvider(PushPublishService, {
+                getEnvironments: jest.fn().mockReturnValue(of([]))
+            }),
             mockProvider(DotWorkflowEventHandlerService, {
                 open: jest.fn()
             }),

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -20,6 +20,7 @@ import { Dialog } from 'primeng/dialog';
 
 import {
     AddToBundleService,
+    PushPublishService,
     DotContentSearchService,
     DotContentTypeService,
     DotCurrentUserService,
@@ -159,6 +160,11 @@ describe('DotContentDriveShellComponent', () => {
             }),
             LoggerService,
             StringUtils,
+            mockProvider(PushPublishService, {
+                // The Action Center gates its Push Publish row on this; an empty answer disables it,
+                // which is all the shell's own tests need.
+                getEnvironments: jest.fn().mockReturnValue(of([]))
+            }),
             mockProvider(AddToBundleService, {
                 getBundles: jest.fn().mockReturnValue(of([])),
                 addToBundle: jest.fn().mockReturnValue(of({}))
@@ -2791,6 +2797,11 @@ describe('DotContentDriveShellComponent — editContent deep link', () => {
             }),
             LoggerService,
             StringUtils,
+            mockProvider(PushPublishService, {
+                // The Action Center gates its Push Publish row on this; an empty answer disables it,
+                // which is all the shell's own tests need.
+                getEnvironments: jest.fn().mockReturnValue(of([]))
+            }),
             mockProvider(AddToBundleService, {
                 getBundles: jest.fn().mockReturnValue(of([])),
                 addToBundle: jest.fn().mockReturnValue(of({}))

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/dot-content-drive.store.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/dot-content-drive.store.spec.ts
@@ -13,6 +13,7 @@ import { ActivatedRoute } from '@angular/router';
 
 import {
     AddToBundleService,
+    PushPublishService,
     DotContentDriveService,
     DotCurrentUserService,
     DotFolderService,
@@ -73,6 +74,7 @@ describe('DotContentDriveStore', () => {
             mockProvider(DotWorkflowActionsFireService),
             // Also required by `withActionExecution`, which fires Add to Bundle from the store.
             mockProvider(AddToBundleService),
+            mockProvider(PushPublishService),
             mockProvider(DotHttpErrorManagerService),
             // The store subscribes to Location (popstate re-hydration); capture the handler here.
             mockProvider(Location, {
@@ -796,6 +798,7 @@ describe('DotContentDriveStore - onInit', () => {
             mockProvider(DotWorkflowActionsFireService),
             // Also required by `withActionExecution`, which fires Add to Bundle from the store.
             mockProvider(AddToBundleService),
+            mockProvider(PushPublishService),
             mockProvider(DotHttpErrorManagerService),
             // The store subscribes to Location (popstate re-hydration); capture the handler here.
             mockProvider(Location, {
@@ -854,6 +857,7 @@ describe('DotContentDriveStore - Browser Back/Forward (popstate) re-hydration', 
             mockProvider(DotWorkflowActionsFireService),
             // Also required by `withActionExecution`, which fires Add to Bundle from the store.
             mockProvider(AddToBundleService),
+            mockProvider(PushPublishService),
             mockProvider(DotHttpErrorManagerService),
             // withFlags fetches feature flags on init; stub so no real HTTP fires.
             mockProvider(DotPropertiesService, {
@@ -952,6 +956,7 @@ describe('DotContentDriveStore - Content Loading Effect', () => {
             mockProvider(DotWorkflowActionsFireService),
             // Also required by `withActionExecution`, which fires Add to Bundle from the store.
             mockProvider(AddToBundleService),
+            mockProvider(PushPublishService),
             mockProvider(DotHttpErrorManagerService),
             // The store subscribes to Location (popstate re-hydration); capture the handler here.
             mockProvider(Location, {
@@ -1239,6 +1244,7 @@ describe('DotContentDriveStore - withActionExecution', () => {
             }),
             // Add to Bundle leaves the workflow path entirely and posts to the legacy bundle servlet.
             mockProvider(AddToBundleService, { addToBundle: jest.fn() }),
+            mockProvider(PushPublishService, { pushPublishAssets: jest.fn() }),
             mockProvider(DotHttpErrorManagerService, { handle: jest.fn() }),
             // The store subscribes to Location (popstate re-hydration); stub so it is inert here.
             mockProvider(Location, {

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/action-execution/withActionExecution.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/action-execution/withActionExecution.ts
@@ -9,9 +9,14 @@ import { catchError, take } from 'rxjs/operators';
 import {
     AddToBundleService,
     DotHttpErrorManagerService,
-    DotWorkflowActionsFireService
+    DotWorkflowActionsFireService,
+    PushPublishService
 } from '@dotcms/data-access';
-import { DotActionBulkRequestOptions, DotBundle } from '@dotcms/dotcms-models';
+import {
+    DotActionBulkRequestOptions,
+    DotBundle,
+    DotWorkflowPushPublishValue
+} from '@dotcms/dotcms-models';
 
 import {
     DotContentDriveActionExecution,
@@ -57,7 +62,8 @@ export function withActionExecution() {
                 store,
                 workflowActionsFireService = inject(DotWorkflowActionsFireService),
                 httpErrorManagerService = inject(DotHttpErrorManagerService),
-                addToBundleService = inject(AddToBundleService)
+                addToBundleService = inject(AddToBundleService),
+                pushPublishService = inject(PushPublishService)
             ) => {
                 /**
                  * Settles a finished run by publishing its result for the shell to present.
@@ -100,7 +106,7 @@ export function withActionExecution() {
 
                 return {
                     /**
-                     * Fires a quick action (publish, unpublish, archive, …) over the given inodes.
+                     * Fires a quick action (lock, unlock) over the given inodes.
                      *
                      * Counts come from the response rather than `inodes.length`: the endpoint answers
                      * 200 with per-item failures inside, so a lock held by another user or a
@@ -287,6 +293,68 @@ export function withActionExecution() {
                                     actionName,
                                     // `total` counts everything queued, failures included, so the
                                     // successes are what is left after removing them.
+                                    successCount: Math.max((result.total ?? 0) - result.errors, 0),
+                                    skippedCount: 0,
+                                    failCount: result.errors
+                                });
+                            });
+                    },
+
+                    /**
+                     * Push publishes the given identifiers to the chosen environments.
+                     *
+                     * Identifiers, not inodes: push publish sends the *asset*, so every language
+                     * version of a contentlet is one entry — the same collapse Add to Bundle makes.
+                     *
+                     * Shares the legacy servlet's response shape with Add to Bundle, and the same
+                     * caveat: it answers 200 for its own failures, so a body without a numeric
+                     * `errors` is routed to the error handler rather than reported as a success.
+                     */
+                    executePushPublish: (
+                        actionName: string,
+                        identifiers: string[],
+                        settings: DotWorkflowPushPublishValue
+                    ): void => {
+                        if (!identifiers.length || store.actionExecution()) {
+                            return;
+                        }
+
+                        patchState(store, {
+                            actionExecution: { actionName, total: identifiers.length },
+                            actionExecutionResult: undefined
+                        });
+
+                        pushPublishService
+                            // Comma-joined: `RemotePublishAjaxAction` splits `assetIdentifier` on
+                            // "," and has always accepted several ids that way.
+                            .pushPublishAssets(identifiers.join(','), settings)
+                            .pipe(
+                                take(1),
+                                catchError((error) => {
+                                    patchState(store, { actionExecution: undefined });
+                                    httpErrorManagerService.handle(error);
+
+                                    return EMPTY;
+                                })
+                            )
+                            .subscribe((result) => {
+                                if (typeof result?.errors !== 'number') {
+                                    patchState(store, { actionExecution: undefined });
+                                    httpErrorManagerService.handle(
+                                        new HttpErrorResponse({
+                                            status: 500,
+                                            statusText:
+                                                typeof result?.errors === 'string'
+                                                    ? result.errors
+                                                    : 'The push publish returned no result'
+                                        })
+                                    );
+
+                                    return;
+                                }
+
+                                onSettled({
+                                    actionName,
                                     successCount: Math.max((result.total ?? 0) - result.errors, 0),
                                     skippedCount: 0,
                                     failCount: result.errors

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.spec.ts
@@ -15,6 +15,8 @@ import {
     groupByContentType,
     isLockedByAnotherUser,
     mergeActionCenterSchemes,
+    PUSH_PUBLISH_ACTION_ID,
+    REFRESH_ACTION_ID,
     requiredInputKinds,
     toActionCenterSchemes,
     toContentletInodes,
@@ -168,43 +170,19 @@ describe('action-center utils', () => {
             expect(getQuickActions([folder('f1')])).toEqual([]);
         });
 
-        it('should count Publish for items that are not live', () => {
-            const items = [
-                contentlet({ inode: 'a', live: false }),
-                contentlet({ inode: 'b', live: true }),
-                contentlet({ inode: 'c', live: false })
-            ];
+        it('should not offer the workflow state actions as quick actions', () => {
+            // Publish, Unpublish, Archive, Unarchive and Delete are the scheme's own actions and
+            // are reached through the Workflow Actions section, where they resolve to whatever the
+            // content type's scheme actually maps them to.
+            const ids = getQuickActions([
+                contentlet({ inode: 'a', archived: true, live: true, locked: true })
+            ]).map((action) => action.id);
 
-            const publish = getQuickActions(items).find(
-                (action) => action.id === WORKFLOW_ACTION_ID.PUBLISH
-            );
-
-            expect(publish?.count).toBe(2);
-        });
-
-        it('should count Unpublish only for live items', () => {
-            const items = [
-                contentlet({ inode: 'a', live: true }),
-                contentlet({ inode: 'b', live: false })
-            ];
-
-            const unpublish = getQuickActions(items).find(
-                (action) => action.id === WORKFLOW_ACTION_ID.UNPUBLISH
-            );
-
-            expect(unpublish?.count).toBe(1);
-        });
-
-        it('should count Delete and Unarchive only for archived items', () => {
-            const items = [
-                contentlet({ inode: 'a', archived: true }),
-                contentlet({ inode: 'b', archived: false })
-            ];
-
-            const byId = new Map(getQuickActions(items).map((action) => [action.id, action.count]));
-
-            expect(byId.get(WORKFLOW_ACTION_ID.DELETE)).toBe(1);
-            expect(byId.get(WORKFLOW_ACTION_ID.UNARCHIVE)).toBe(1);
+            expect(ids).not.toContain(WORKFLOW_ACTION_ID.PUBLISH);
+            expect(ids).not.toContain(WORKFLOW_ACTION_ID.UNPUBLISH);
+            expect(ids).not.toContain(WORKFLOW_ACTION_ID.ARCHIVE);
+            expect(ids).not.toContain(WORKFLOW_ACTION_ID.UNARCHIVE);
+            expect(ids).not.toContain(WORKFLOW_ACTION_ID.DELETE);
         });
 
         it('should count Lock for items that are not locked', () => {
@@ -324,25 +302,22 @@ describe('action-center utils', () => {
         });
 
         it('should still list actions that apply to nothing, with a zero count', () => {
-            // Nothing archived, so Delete applies to no item — but stays in the list so the dialog
-            // can render it as non-selectable rather than dropping the row.
-            const items = [contentlet({ inode: 'a', archived: false })];
+            // Already locked, so Lock applies to no item — but stays in the list so the dialog can
+            // render it as non-selectable rather than dropping the row.
+            const items = [contentlet({ inode: 'a', locked: true })];
 
             const byId = new Map(getQuickActions(items).map((action) => [action.id, action.count]));
 
-            expect(byId.get(WORKFLOW_ACTION_ID.DELETE)).toBe(0);
+            expect(byId.get(WORKFLOW_ACTION_ID.LOCK)).toBe(0);
         });
 
         it('should keep a fixed display order regardless of the selection', () => {
             const expected = [
                 WORKFLOW_ACTION_ID.LOCK,
                 WORKFLOW_ACTION_ID.UNLOCK,
-                WORKFLOW_ACTION_ID.PUBLISH,
-                WORKFLOW_ACTION_ID.UNPUBLISH,
-                WORKFLOW_ACTION_ID.ARCHIVE,
-                WORKFLOW_ACTION_ID.DELETE,
-                WORKFLOW_ACTION_ID.UNARCHIVE,
-                ADD_TO_BUNDLE_ACTION_ID
+                ADD_TO_BUNDLE_ACTION_ID,
+                PUSH_PUBLISH_ACTION_ID,
+                REFRESH_ACTION_ID
             ];
 
             expect(getQuickActions([contentlet({ inode: 'a' })]).map((a) => a.id)).toEqual(
@@ -389,29 +364,19 @@ describe('action-center utils', () => {
             expect(archived.map((action) => action.id)).toEqual(live.map((action) => action.id));
         });
 
-        it('should not count archived items as publishable', () => {
-            const items = [contentlet({ inode: 'a', archived: true, live: false })];
-
-            const publish = getQuickActions(items).find(
-                (action) => action.id === WORKFLOW_ACTION_ID.PUBLISH
-            );
-
-            expect(publish?.count).toBe(0);
-        });
-
         it('should expose the eligible inodes, matching the count', () => {
             const items = [
-                contentlet({ inode: 'not-live', live: false }),
-                contentlet({ inode: 'is-live', live: true }),
+                contentlet({ inode: 'unlocked', locked: false }),
+                contentlet({ inode: 'is-locked', locked: true }),
                 folder('f1')
             ];
 
-            const publish = getQuickActions(items).find(
-                (action) => action.id === WORKFLOW_ACTION_ID.PUBLISH
+            const lock = getQuickActions(items).find(
+                (action) => action.id === WORKFLOW_ACTION_ID.LOCK
             );
 
-            expect(publish?.eligibleInodes).toEqual(['not-live']);
-            expect(publish?.count).toBe(publish?.eligibleInodes.length);
+            expect(lock?.eligibleInodes).toEqual(['unlocked']);
+            expect(lock?.count).toBe(lock?.eligibleInodes.length);
         });
 
         it('should keep count and eligibleInodes in step for every action', () => {
@@ -426,14 +391,44 @@ describe('action-center utils', () => {
             }
         });
 
-        it('should mark destructive actions as danger', () => {
+        it('should leave nothing marked as danger, now the destructive actions are gone', () => {
             const items = [contentlet({ inode: 'a', archived: true })];
 
-            const remove = getQuickActions(items).find(
-                (action) => action.id === WORKFLOW_ACTION_ID.DELETE
+            expect(getQuickActions(items).every((action) => !action.danger)).toBe(true);
+        });
+
+        it('should flag Push Publish and Refresh as coming soon', () => {
+            const byId = new Map(
+                getQuickActions([contentlet({ inode: 'a' })]).map((action) => [action.id, action])
             );
 
-            expect(remove?.danger).toBe(true);
+            expect(byId.get(PUSH_PUBLISH_ACTION_ID)?.comingSoon).toBe(true);
+            expect(byId.get(REFRESH_ACTION_ID)?.comingSoon).toBe(true);
+        });
+
+        it('should not flag the wired actions as coming soon', () => {
+            const byId = new Map(
+                getQuickActions([contentlet({ inode: 'a' })]).map((action) => [action.id, action])
+            );
+
+            expect(byId.get(WORKFLOW_ACTION_ID.LOCK)?.comingSoon).toBe(false);
+            expect(byId.get(WORKFLOW_ACTION_ID.UNLOCK)?.comingSoon).toBe(false);
+            expect(byId.get(ADD_TO_BUNDLE_ACTION_ID)?.comingSoon).toBe(false);
+        });
+
+        it('should count the coming-soon actions over the whole selection', () => {
+            // A `0` would read as "does not apply to these items", which is a different claim from
+            // "not built yet". The row is disabled by `comingSoon`, not by its count.
+            const items = [
+                contentlet({ inode: 'a', archived: true }),
+                contentlet({ inode: 'b', live: true, locked: true }),
+                folder('f1')
+            ];
+
+            const byId = new Map(getQuickActions(items).map((action) => [action.id, action.count]));
+
+            expect(byId.get(PUSH_PUBLISH_ACTION_ID)).toBe(2);
+            expect(byId.get(REFRESH_ACTION_ID)).toBe(2);
         });
     });
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.spec.ts
@@ -391,13 +391,61 @@ describe('action-center utils', () => {
             }
         });
 
-        it('should flag Push Publish and Refresh as coming soon', () => {
+        it('should flag Refresh as coming soon', () => {
             const byId = new Map(
                 getQuickActions([contentlet({ inode: 'a' })]).map((action) => [action.id, action])
             );
 
-            expect(byId.get(PUSH_PUBLISH_ACTION_ID)?.comingSoon).toBe(true);
             expect(byId.get(REFRESH_ACTION_ID)?.comingSoon).toBe(true);
+        });
+
+        it('should block Push Publish on the environments, not on coming-soon', () => {
+            // Nothing is missing from dotCMS here, something is missing from the configuration, and
+            // the fix belongs to an administrator. The two states read differently on the row.
+            const byId = new Map(
+                getQuickActions([contentlet({ inode: 'a' })]).map((action) => [action.id, action])
+            );
+
+            expect(byId.get(PUSH_PUBLISH_ACTION_ID)?.comingSoon).toBe(false);
+            expect(byId.get(PUSH_PUBLISH_ACTION_ID)?.missingEnvironments).toBe(true);
+        });
+
+        it('should release Push Publish once an environment is reachable', () => {
+            const push = getQuickActions([contentlet({ inode: 'a' }), contentlet({ inode: 'b' })], {
+                isAdmin: false,
+                hasPushPublishEnvironments: true
+            }).find((action) => action.id === PUSH_PUBLISH_ACTION_ID);
+
+            expect(push?.missingEnvironments).toBe(false);
+            // Every contentlet counts: no row state disqualifies a push.
+            expect(push?.count).toBe(2);
+        });
+
+        it('should keep Push Publish blocked while the environments are still unknown', () => {
+            // An unresolved lookup reads as "none" — enabling and then retracting is worse than a
+            // row that stays shut until the answer arrives.
+            const push = getQuickActions([contentlet({ inode: 'a' })], { isAdmin: false }).find(
+                (action) => action.id === PUSH_PUBLISH_ACTION_ID
+            );
+
+            expect(push?.missingEnvironments).toBe(true);
+        });
+
+        it('should never block the other rows on the environments', () => {
+            const byId = new Map(
+                getQuickActions([contentlet({ inode: 'a', locked: true })]).map((action) => [
+                    action.id,
+                    action
+                ])
+            );
+
+            for (const id of [
+                WORKFLOW_ACTION_ID.UNLOCK,
+                ADD_TO_BUNDLE_ACTION_ID,
+                REFRESH_ACTION_ID
+            ] as string[]) {
+                expect(byId.get(id)?.missingEnvironments).toBe(false);
+            }
         });
 
         it('should not flag the wired actions as coming soon', () => {

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.spec.ts
@@ -391,12 +391,6 @@ describe('action-center utils', () => {
             }
         });
 
-        it('should leave nothing marked as danger, now the destructive actions are gone', () => {
-            const items = [contentlet({ inode: 'a', archived: true })];
-
-            expect(getQuickActions(items).every((action) => !action.danger)).toBe(true);
-        });
-
         it('should flag Push Publish and Refresh as coming soon', () => {
             const byId = new Map(
                 getQuickActions([contentlet({ inode: 'a' })]).map((action) => [action.id, action])

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.ts
@@ -26,9 +26,12 @@ export const ADD_TO_BUNDLE_ACTION_ID = 'ADD_TO_BUNDLE';
 /**
  * Push Publish over the selection — the old search toolbar's own bulk action, not a `SystemAction`.
  *
- * Placeholder: rendered but not wired. Push publishing needs an environment, a filter and a schedule
- * collected before it can fire, which is a configuration step this dialog does not have for a *quick*
- * action yet (the workflow-action path already has one, via `DotWorkflowPushPublishComponent`).
+ * Collects environments, a schedule and a filter on the configuration step (the same
+ * `DotWorkflowPushPublishComponent` the workflow-action path uses), then posts the whole selection to
+ * `RemotePublishAjaxAction` as comma-joined identifiers.
+ *
+ * Unavailable when the instance has no push publish environment the current user's role can send to —
+ * see {@link DotActionCenterContext.hasPushPublishEnvironments}.
  */
 export const PUSH_PUBLISH_ACTION_ID = 'PUSH_PUBLISH';
 
@@ -75,6 +78,14 @@ export interface DotActionCenterQuickAction {
      * reached them yet. Disabled with a tooltip is the honest state.
      */
     comingSoon: boolean;
+    /**
+     * Wired, but unusable here because the instance has no push publish environment configured for
+     * this user's role.
+     *
+     * Distinct from {@link comingSoon}: nothing is missing from dotCMS, something is missing from the
+     * *configuration*, and the fix is an administrator's rather than ours. The row says which.
+     */
+    missingEnvironments: boolean;
 }
 
 /** Caller state predicates need beyond row data. */
@@ -84,6 +95,13 @@ export interface DotActionCenterContext {
      * (see {@link isLockedByAnotherUser}).
      */
     isAdmin: boolean;
+    /**
+     * At least one push publish environment is reachable by this user's role.
+     *
+     * `undefined` means "not looked up yet" and reads the same as "none": Push Publish stays disabled
+     * until the answer arrives, rather than enabling for a moment and then retracting.
+     */
+    hasPushPublishEnvironments?: boolean;
 }
 
 /**
@@ -106,6 +124,8 @@ interface DotActionCenterQuickActionDef {
     warningHint?: string;
     /** Rendered but disabled — see {@link DotActionCenterQuickAction.comingSoon}. */
     comingSoon?: boolean;
+    /** Needs at least one push publish environment before it can run. */
+    requiresEnvironments?: boolean;
 }
 
 /**
@@ -165,20 +185,18 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         id: ADD_TO_BUNDLE_ACTION_ID,
         nameKey: 'content-drive.action-center.add-to-bundle',
         icon: 'inventory_2',
-        // Every contentlet can go in a bundle: there is no state that disqualifies one, unlike
-        // Publish or Unarchive. Coverage is the whole selection, minus the identifier collapse the
-        // configuration step explains.
+        // Every contentlet can go in a bundle: no row state disqualifies one. Coverage is the whole
+        // selection, minus the identifier collapse the configuration step explains.
         eligibleWhen: () => true
     },
     {
         id: PUSH_PUBLISH_ACTION_ID,
         nameKey: 'Remote-Publish',
         icon: 'cloud_upload',
-        // Counted over the whole selection rather than left at zero: the row is disabled by
-        // `comingSoon`, and a `0` would read as "does not apply to these items", which is a
-        // different and untrue statement.
+        // No contentlet state disqualifies a push; the environment does, and that is not a per-row
+        // question. Counted over the whole selection so the row reports what it would send.
         eligibleWhen: () => true,
-        comingSoon: true
+        requiresEnvironments: true
     },
     {
         id: REFRESH_ACTION_ID,
@@ -244,7 +262,9 @@ export const getQuickActions = (
             count: eligibleInodes.length,
             warningCount,
             warningHint: warningCount > 0 ? quickAction.warningHint : undefined,
-            comingSoon: !!quickAction.comingSoon
+            comingSoon: !!quickAction.comingSoon,
+            missingEnvironments:
+                !!quickAction.requiresEnvironments && !context.hasPushPublishEnvironments
         };
     });
 };

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.ts
@@ -60,10 +60,6 @@ export interface DotActionCenterQuickAction {
     eligibleInodes: string[];
     /** Eligible contentlets. `0` = shown but not selectable. */
     count: number;
-    /** Renders with danger severity. */
-    danger: boolean;
-    /** i18n key for a confirm prompt before fire. */
-    confirmMessage?: string;
     /**
      * Eligible items likely to fail — heads-up only; they are still fired.
      * See Unlock in {@link QUICK_ACTIONS}.
@@ -102,11 +98,8 @@ interface DotActionCenterQuickActionDef {
      */
     nameKey: string;
     icon: string;
-    danger: boolean;
     /** Row-state heuristic — not a permission check. Counted items can still fail at fire. */
     eligibleWhen: (item: DotCMSContentlet) => boolean;
-    /** i18n key for confirm before fire (destructive actions). */
-    confirmMessage?: string;
     /** Among eligible items; feeds `warningCount`. */
     warnWhen?: (item: DotCMSContentlet, context: DotActionCenterContext) => boolean;
     /** Required whenever `warnWhen` is set. */
@@ -155,7 +148,6 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         id: WORKFLOW_ACTION_ID.LOCK,
         nameKey: 'content-drive.context-menu.lock',
         icon: 'lock',
-        danger: false,
         // UX filter only: locking archived content has no upside and can block delete
         // (`canLock` is a delete precondition). Server still allows it.
         eligibleWhen: (item) => !item.locked && !item.archived
@@ -164,7 +156,6 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         id: WORKFLOW_ACTION_ID.UNLOCK,
         nameKey: 'content-drive.context-menu.unlock',
         icon: 'lock_open',
-        danger: false,
         eligibleWhen: (item) => !!item.locked && !item.archived,
         // Warn, don't filter — only the server knows if unlock will succeed.
         warnWhen: isLockedByAnotherUser,
@@ -174,7 +165,6 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         id: ADD_TO_BUNDLE_ACTION_ID,
         nameKey: 'content-drive.action-center.add-to-bundle',
         icon: 'inventory_2',
-        danger: false,
         // Every contentlet can go in a bundle: there is no state that disqualifies one, unlike
         // Publish or Unarchive. Coverage is the whole selection, minus the identifier collapse the
         // configuration step explains.
@@ -184,7 +174,6 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         id: PUSH_PUBLISH_ACTION_ID,
         nameKey: 'Remote-Publish',
         icon: 'cloud_upload',
-        danger: false,
         // Counted over the whole selection rather than left at zero: the row is disabled by
         // `comingSoon`, and a `0` would read as "does not apply to these items", which is a
         // different and untrue statement.
@@ -195,7 +184,6 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         id: REFRESH_ACTION_ID,
         nameKey: 'Refresh',
         icon: 'refresh',
-        danger: false,
         eligibleWhen: () => true,
         comingSoon: true
     }
@@ -252,10 +240,8 @@ export const getQuickActions = (
             id: quickAction.id,
             name: quickAction.nameKey,
             icon: quickAction.icon,
-            danger: quickAction.danger,
             eligibleInodes,
             count: eligibleInodes.length,
-            confirmMessage: quickAction.confirmMessage,
             warningCount,
             warningHint: warningCount > 0 ? quickAction.warningHint : undefined,
             comingSoon: !!quickAction.comingSoon

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/action-center.ts
@@ -23,7 +23,28 @@ import { WORKFLOW_ACTION_ID } from './workflow-actions';
 /** Not a `SystemAction`; not fired through workflow endpoints. */
 export const ADD_TO_BUNDLE_ACTION_ID = 'ADD_TO_BUNDLE';
 
-export type DotActionCenterQuickActionId = WORKFLOW_ACTION_ID | typeof ADD_TO_BUNDLE_ACTION_ID;
+/**
+ * Push Publish over the selection — the old search toolbar's own bulk action, not a `SystemAction`.
+ *
+ * Placeholder: rendered but not wired. Push publishing needs an environment, a filter and a schedule
+ * collected before it can fire, which is a configuration step this dialog does not have for a *quick*
+ * action yet (the workflow-action path already has one, via `DotWorkflowPushPublishComponent`).
+ */
+export const PUSH_PUBLISH_ACTION_ID = 'PUSH_PUBLISH';
+
+/**
+ * Reindex the selection — the old search toolbar's "Refresh", backed by `_bulkrefresh`.
+ *
+ * Placeholder: rendered but not wired. The endpoint streams progress over SSE and is not job-backed,
+ * so it cannot reuse the synchronous `bulkFire` path the other quick actions run on.
+ */
+export const REFRESH_ACTION_ID = 'REFRESH';
+
+export type DotActionCenterQuickActionId =
+    | WORKFLOW_ACTION_ID
+    | typeof ADD_TO_BUNDLE_ACTION_ID
+    | typeof PUSH_PUBLISH_ACTION_ID
+    | typeof REFRESH_ACTION_ID;
 
 /** Quick action as rendered in the dialog (with eligibility counts). */
 export interface DotActionCenterQuickAction {
@@ -50,6 +71,14 @@ export interface DotActionCenterQuickAction {
     warningCount: number;
     /** i18n key for {@link warningCount}. Absent when count is `0`. */
     warningHint?: string;
+    /**
+     * Shown, disabled, and not yet wired to anything.
+     *
+     * Deliberately rendered rather than hidden: these are actions the old search toolbar offers, and
+     * leaving them out of the list makes Content Drive look like it dropped them instead of not having
+     * reached them yet. Disabled with a tooltip is the honest state.
+     */
+    comingSoon: boolean;
 }
 
 /** Caller state predicates need beyond row data. */
@@ -82,6 +111,8 @@ interface DotActionCenterQuickActionDef {
     warnWhen?: (item: DotCMSContentlet, context: DotActionCenterContext) => boolean;
     /** Required whenever `warnWhen` is set. */
     warningHint?: string;
+    /** Rendered but disabled — see {@link DotActionCenterQuickAction.comingSoon}. */
+    comingSoon?: boolean;
 }
 
 /**
@@ -102,14 +133,25 @@ export const isLockedByAnotherUser = (
 /**
  * Quick actions in display order (fixed — rows never reshuffle).
  *
- * Order: Lock, Unlock, Publish, Unpublish, Archive, Delete, Unarchive, Add to Bundle.
+ * Order: Lock, Unlock, Add to Bundle, Push Publish, Refresh.
  *
- * All except Add to Bundle fire via `POST .../workflow/actions/default/fire/{systemAction}`; Add to
- * Bundle posts to the legacy bundle servlet and collects a target first.
+ * **Scope: the old search toolbar's bulk operations, and only those.** Publish, Unpublish, Archive,
+ * Unarchive and Delete used to sit here as well, fired through
+ * `POST .../workflow/actions/default/fire/{systemAction}`. They were removed because the Workflow
+ * Actions section below already offers them — as the *scheme's own* actions, which is the accurate
+ * answer for a contentlet whose scheme maps `PUBLISH` to something other than a plain publish. Two
+ * rows labelled "Publish" that resolve differently is worse than one that resolves correctly.
+ *
+ * What is left is what the old search offered outside the workflow dropdown: Lock and Unlock (per-user
+ * state, no workflow transition, so they have no scheme action to defer to), Add to Bundle, Push
+ * Publish and Refresh.
+ *
+ * Lock/Unlock fire through the system-action endpoint; Add to Bundle posts to the legacy bundle
+ * servlet and collects a target first. Push Publish and Refresh are placeholders — see
+ * {@link DotActionCenterQuickAction.comingSoon}.
  */
 const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
     {
-        // Least destructive; sit away from Archive/Delete.
         id: WORKFLOW_ACTION_ID.LOCK,
         nameKey: 'content-drive.context-menu.lock',
         icon: 'lock',
@@ -129,44 +171,6 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         warningHint: 'content-drive.action-center.unlock.locked-by-others'
     },
     {
-        id: WORKFLOW_ACTION_ID.PUBLISH,
-        nameKey: 'Default-Action-Publish',
-        icon: 'publish',
-        danger: false,
-        eligibleWhen: (item) => !item.live && !item.archived
-    },
-    {
-        id: WORKFLOW_ACTION_ID.UNPUBLISH,
-        nameKey: 'Default-Action-Unpublish',
-        icon: 'visibility_off',
-        danger: false,
-        eligibleWhen: (item) => !!item.live && !item.archived
-    },
-    {
-        id: WORKFLOW_ACTION_ID.ARCHIVE,
-        nameKey: 'Default-Action-Archive',
-        icon: 'archive',
-        danger: true,
-        eligibleWhen: (item) => !item.archived
-    },
-    {
-        id: WORKFLOW_ACTION_ID.DELETE,
-        nameKey: 'Default-Action-Delete',
-        icon: 'delete',
-        danger: true,
-        eligibleWhen: (item) => !!item.archived,
-        // Kept from the old toolbar Delete confirm.
-        confirmMessage: 'content.drive.worflow.action.delete.confirm'
-    },
-    {
-        // After Delete so archived-only actions stay together.
-        id: WORKFLOW_ACTION_ID.UNARCHIVE,
-        nameKey: 'Default-Action-Unarchive',
-        icon: 'unarchive',
-        danger: false,
-        eligibleWhen: (item) => !!item.archived
-    },
-    {
         id: ADD_TO_BUNDLE_ACTION_ID,
         nameKey: 'content-drive.action-center.add-to-bundle',
         icon: 'inventory_2',
@@ -175,6 +179,25 @@ const QUICK_ACTIONS: DotActionCenterQuickActionDef[] = [
         // Publish or Unarchive. Coverage is the whole selection, minus the identifier collapse the
         // configuration step explains.
         eligibleWhen: () => true
+    },
+    {
+        id: PUSH_PUBLISH_ACTION_ID,
+        nameKey: 'Remote-Publish',
+        icon: 'cloud_upload',
+        danger: false,
+        // Counted over the whole selection rather than left at zero: the row is disabled by
+        // `comingSoon`, and a `0` would read as "does not apply to these items", which is a
+        // different and untrue statement.
+        eligibleWhen: () => true,
+        comingSoon: true
+    },
+    {
+        id: REFRESH_ACTION_ID,
+        nameKey: 'Refresh',
+        icon: 'refresh',
+        danger: false,
+        eligibleWhen: () => true,
+        comingSoon: true
     }
 ];
 
@@ -234,7 +257,8 @@ export const getQuickActions = (
             count: eligibleInodes.length,
             confirmMessage: quickAction.confirmMessage,
             warningCount,
-            warningHint: warningCount > 0 ? quickAction.warningHint : undefined
+            warningHint: warningCount > 0 ? quickAction.warningHint : undefined,
+            comingSoon: !!quickAction.comingSoon
         };
     });
 };

--- a/core-web/libs/ui/src/lib/components/dot-workflow-push-publish/dot-workflow-push-publish.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-push-publish/dot-workflow-push-publish.component.ts
@@ -15,31 +15,14 @@ import {
     DotPushPublishFiltersService
 } from '@dotcms/data-access';
 import { DotcmsConfigService, DotTimeZone } from '@dotcms/dotcms-js';
+import { DotWorkflowPushPublishAction, DotWorkflowPushPublishValue } from '@dotcms/dotcms-models';
 
 import { DotMessagePipe } from '../../dot-message/dot-message.pipe';
 import { PushPublishEnvSelectorComponent } from '../dot-push-publish-env-selector/dot-push-publish-env-selector.component';
 
-/** What the user can ask a push publish for. Values are the backend's `iWantTo` vocabulary. */
-export type DotWorkflowPushPublishAction = 'publish' | 'expire' | 'publishexpire';
-
-/**
- * The push publish payload, in the shape the backend's `PushPublishBean` expects.
- *
- * Emitted already converted — dates split into `yyyy-MM-dd` + `HH-mm` pairs, environments comma-joined
- * into `whereToSend` — so a consumer can hand it straight to a fire request without repeating the
- * transformation that `DotWorkflowEventHandlerService.processWorkflowPayload` does today.
- */
-export interface DotWorkflowPushPublishValue {
-    /** Comma-joined environment ids. */
-    whereToSend: string;
-    iWantTo: DotWorkflowPushPublishAction;
-    publishDate: string;
-    publishTime: string;
-    expireDate: string;
-    expireTime: string;
-    filterKey: string;
-    timezoneId: string;
-}
+// Defined in `@dotcms/dotcms-models` so `@dotcms/data-access` can post this payload without
+// depending on `@dotcms/ui`. Re-exported here, where consumers have always imported it from.
+export type { DotWorkflowPushPublishAction, DotWorkflowPushPublishValue };
 
 /**
  * Collects a workflow action's `pushPublish` input: where to send it, when, and under which filter.

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -7171,6 +7171,7 @@ content-drive.action-center.workflow-actions=Workflow Actions
 content-drive.action-center.no-quick-actions=No quick actions apply to the current selection.
 content-drive.action-center.not-applicable=Doesn't apply to any of the selected items.
 content-drive.action-center.coming-soon=This action is still under development and isn't available yet.
+content-drive.action-center.no-environments=No push publish environment is configured for your role. Ask an administrator to add one before pushing content.
 content-drive.action-center.confirm.header=Confirmation
 content-drive.action-center.add-to-bundle=Add to Bundle
 content-drive.action-center.bundle.target=Bundle

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -7170,6 +7170,7 @@ content-drive.action-center.quick-actions=Quick Actions
 content-drive.action-center.workflow-actions=Workflow Actions
 content-drive.action-center.no-quick-actions=No quick actions apply to the current selection.
 content-drive.action-center.not-applicable=Doesn't apply to any of the selected items.
+content-drive.action-center.coming-soon=This action is still under development and isn't available yet.
 content-drive.action-center.confirm.header=Confirmation
 content-drive.action-center.add-to-bundle=Add to Bundle
 content-drive.action-center.bundle.target=Bundle


### PR DESCRIPTION
> **Draft / spike.** One of two directions explored for Content Drive's Action Center; #37075 is the other. This is the one being taken forward. Still a draft: no linked issue yet, and no manual QA against a running instance.

## What this does

Narrows **Quick Actions** to the bulk operations the old content search offered *outside* its workflow dropdown, and wires Push Publish.

| Row | State |
|---|---|
| Lock | wired |
| Unlock | wired — keeps the "locked by another user" warning |
| Add to Bundle | wired — keeps the bundle-picker step |
| **Push Publish** | **wired** — gated on push publish environments |
| Refresh | disabled placeholder, `Work in progress` badge |
| ~~Publish / Unpublish / Archive / Unarchive / Delete~~ | **removed** |

## Why remove the five state actions

They are already offered by the **Workflow Actions** section below, as the *scheme's own* actions.

That is not a duplicate — it is a more correct answer. A quick action fires `POST /v1/workflow/actions/default/fire/{systemAction}`, which resolves through the scheme's Default Actions mapping. If a content type's scheme maps `PUBLISH` to something other than a plain publish, the quick-action row labelled "Publish" and the workflow row labelled "Publish" do different things. Two rows with the same label and different behaviour is worse than one row that resolves correctly.

Lock and Unlock stay because they are genuinely per-user state on the version info, not a workflow transition — they have no scheme action to defer to. `WorkflowAPI.SystemAction` documents this: they carry no actionlet, and mapping them has no effect.

## Push Publish

### Gate

`PushPublishService.getEnvironments()` runs when the dialog opens. The row stays disabled with an explanatory tooltip until it answers with at least one environment.

Deliberately **not** the same state as Refresh's coming-soon badge: nothing is missing from dotCMS here, something is missing from the *configuration*, and the fix belongs to an administrator. The row says which.

Fails closed. An unresolved or failed lookup reads as "none" — offering a push with nowhere to go fails at the servlet with a message the user cannot act on.

> **One deliberate difference from the JSP.** `view_bulk_actions_inc.jsp` gates on `sendingEndpoints` (publishing endpoints existing). This gates on **environments reachable by the user's role**, which is the stricter question and the one the form itself needs: endpoints can exist with no environment this role can send to, and then the picker would open empty.

### Form

Reuses `DotWorkflowPushPublishComponent` — the same section the workflow-action path renders — so a push publish is collected identically in both dialogs. `$configureKinds` returns `['pushPublish']` for the row, putting it through the existing `pick → configure → preview → execute` flow.

### Fire

New `PushPublishService.pushPublishAssets`, posting to `RemotePublishAjaxAction/cmd/publish` — the same servlet the old search's Push Publish button hits.

Kept separate from the existing `pushPublishContent` because of **date handling, not count**. `DotPushPublishData` carries whole dates that the service splits into the servlet's `remotePublishDate` / `remotePublishTime` pair; the form emits them *already* split. Routing through the existing method would mean recombining two strings into a `Date` for the service to take apart again — losing the timezone the user picked on the way.

`DotWorkflowPushPublishValue` moved down to `@dotcms/dotcms-models` so data-access can accept it without depending on `@dotcms/ui`, and is re-exported from ui where callers have always imported it.

Sends **identifiers**, deduped, like Add to Bundle: a push sends the asset, so language versions of one contentlet are a single entry. The servlet splits `assetIdentifier` on `,` (`RemotePublishAjaxAction`: *"Support for multiple ids in the assetIdentifier parameter"*), so bulk needs no new endpoint.

The servlet answers 200 for its own failures, so a response without a numeric `errors` goes to the error handler rather than being reported as a success — the same guard Add to Bundle uses.

### What the JSP told us

- **No per-contentlet precondition.** `pushPublishSelectedContentlets()` is just `pushHandler.showDialog(getSelectedInodes())` — the whole selection, unfiltered by live/archived/locked. The row therefore counts every contentlet.
- **The enterprise-license gate is deliberately not reproduced.** That requirement no longer applies.

## Why the placeholders are rendered rather than hidden

Refresh is an action the old search does offer. Leaving it out entirely makes Content Drive look like it dropped it; a disabled row with a `Work in progress` badge and a tooltip is the honest state. It is backed by `_bulkrefresh`, which streams progress over SSE and is not job-backed, so it cannot reuse the synchronous `bulkFire` path the other quick actions run on.

It counts over the whole selection rather than sitting at `0` — a `0` would read as "does not apply to these items", a different and untrue claim from "not built yet". The row is disabled by its own flag, not by its count.

## Commits

1. **Trim the quick actions** — list, new IDs, `comingSoon` flag, template, specs.
2. **Drop the machinery the removed rows were the only users of** — `danger` (permanently `false` once the destructive rows left, plus its two red-styling branches), the entire confirmation path (`confirmMessage`, the `ConfirmationService` provider/injection, `ConfirmDialogModule`, `<p-confirmDialog>`, and `fireQuickAction`, which existed only so the confirm and direct branches could share a path), their tests, and doc comments still describing Publish and Delete as quick actions.
3. **Prettier formatting.**
4. **Wire Push Publish** — gate, form, fire, and the last two stale comments.

## i18n

Two keys added: `content-drive.action-center.coming-soon` and `content-drive.action-center.no-environments`. Labels reuse the legacy `Remote-Publish` and `Refresh` keys the old search already uses, so the parity is free in every translation. The badge reuses the existing `content-drive.work-in-progress`.

## Known leftovers — deliberate, flagging for review

Two keys are orphaned repo-wide after commit 2 (`core-web` and `dotCMS/src` both grep clean):

- `content.drive.worflow.action.delete.confirm`
- `content-drive.action-center.confirm.header`

Left in `Language.properties` on purpose: removing i18n keys is a different risk profile, since customer overrides and plugins can reference them. Happy to delete them if reviewers prefer.

## Testing

- `pnpm nx test portlets-content-drive` — **1253 passed**, 32 suites
- `pnpm nx test data-access` — **758 passed**
- `pnpm nx test ui` — **820 passed**
- `pnpm nx run-many -t lint -p portlets-content-drive data-access ui dotcms-models` — clean
- `pnpm nx format:check --base=main` — clean

New coverage: the environments gate (available / none / lookup fails / still pending), the configure step opening on the row, Continue gated on form validity, the fired payload being deduped identifiers plus the collected settings, rows unchecked in the preview being honoured, the refusal to fire without settings, the servlet body shape and its comma-joining, and the five state actions being absent from the list.

## Not done here

**Manual QA against a running instance.** Worth covering:

- an instance with no push publish environment for your role → Push Publish disabled, tooltip names the configuration
- after adding an environment → row enabled, form opens, push lands in the target environment
- a multi-language selection → one bundle entry per identifier, not per language version
- Lock / Unlock / Add to Bundle unaffected throughout

## Comparison with #37075

| | This PR | #37075 |
|---|---|---|
| Publish/Unpublish/Archive/Unarchive/Delete | removed from Quick Actions | kept, gated on the workflow mapping |
| Reaching them | Workflow Actions section only | either, when mapped |
| Closes the raw-API bypass | yes, by removal | yes, by gating |
| New requests per dialog open | 1 (environments) | 1 per content type + 1 per scheme |
| Backend follow-up | none | optional: a resolved-mapping endpoint |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
