### PR TITLE
fix(sdk): render dotImage href/target as an anchor in Block Editor renderers (#36998)

### DIFF
--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.html
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.html
@@ -162,11 +162,23 @@
 
             @case (BLOCKS.DOT_IMAGE) {
                 <figure [style]="imageStyle(node.attrs)">
+                    @if (imageLink(node.attrs); as link) {
+                        <!-- target/rel are attribute bindings so a null value omits the
+                             attribute instead of rendering the string "null". -->
+                        <a [href]="link.href" [attr.target]="link.target" [attr.rel]="link.rel">
+                            <ng-container *ngTemplateOutlet="dotImageEl" />
+                        </a>
+                    } @else {
+                        <ng-container *ngTemplateOutlet="dotImageEl" />
+                    }
+                </figure>
+
+                <ng-template #dotImageEl>
                     <img
                         [alt]="node.attrs?.['alt']"
                         [src]="node.attrs?.['src']"
                         style="max-width: 100%; height: auto" />
-                </figure>
+                </ng-template>
             }
 
             @case (BLOCKS.DOT_VIDEO) {

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.ts
@@ -136,8 +136,9 @@ export class DotCMSBlockEditorRendererNativeComponent implements OnInit {
 
     /**
      * The link assigned to a `dotImage` in the Block Editor, stored as
-     * `href`/`target` on the node. Returns `null` when the image has no link —
-     * `href` is `null` when never set and `''` once the editor unsets it.
+     * `href`/`target` on the node. Returns `null` when the image has no link,
+     * i.e. when `href` is `null`. The truthiness check also covers the
+     * transient `''` the editor writes while unsetting a link.
      *
      * `rel` guards against reverse tabnabbing when the link opens in a new tab.
      */

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.component.ts
@@ -134,6 +134,27 @@ export class DotCMSBlockEditorRendererNativeComponent implements OnInit {
         return {};
     }
 
+    /**
+     * The link assigned to a `dotImage` in the Block Editor, stored as
+     * `href`/`target` on the node. Returns `null` when the image has no link —
+     * `href` is `null` when never set and `''` once the editor unsets it.
+     *
+     * `rel` guards against reverse tabnabbing when the link opens in a new tab.
+     */
+    imageLink(
+        attrs: BlockEditorNode['attrs']
+    ): { href: string; target: string | null; rel: string | null } | null {
+        const href = attrs?.['href'];
+
+        if (!href) {
+            return null;
+        }
+
+        const target = attrs?.['target'] || null;
+
+        return { href, target, rel: target === '_blank' ? 'noopener noreferrer' : null };
+    }
+
     /** Poster URL for a `dotVideo` `<video>` (from `attrs.data.thumbnail`). */
     videoPoster(attrs: BlockEditorNode['attrs']): string | undefined {
         return attrs?.['data']?.['thumbnail'];

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
@@ -648,7 +648,7 @@ describe('DotCMSBlockEditorRendererNativeComponent — semantic dispatch', () =>
             expect(spectator.query('figure > img')).toBeTruthy();
         });
 
-        it('should render a bare dotImage when the link was unset in the editor (empty href)', () => {
+        it('should render a bare dotImage when href is an empty string', () => {
             render([
                 {
                     type: BlockEditorDefaultBlocks.DOT_IMAGE,

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
@@ -635,7 +635,20 @@ describe('DotCMSBlockEditorRendererNativeComponent — semantic dispatch', () =>
             expect(spectator.query('figure > a > img')).toBeTruthy();
         });
 
-        it('should render a bare dotImage when href is unset or empty', () => {
+        it('should render a bare dotImage when the link was never set', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.DOT_IMAGE,
+                    attrs: { src: 'i.jpg', href: null },
+                    content: []
+                }
+            ]);
+
+            expect(spectator.query('a')).toBeNull();
+            expect(spectator.query('figure > img')).toBeTruthy();
+        });
+
+        it('should render a bare dotImage when the link was unset in the editor (empty href)', () => {
             render([
                 {
                     type: BlockEditorDefaultBlocks.DOT_IMAGE,

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer-semantic/dotcms-block-editor-renderer-native.dispatch.spec.ts
@@ -592,6 +592,62 @@ describe('DotCMSBlockEditorRendererNativeComponent — semantic dispatch', () =>
             expect(img.style.height).toBe('auto');
         });
 
+        it('should wrap a linked dotImage in an anchor inside the figure', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.DOT_IMAGE,
+                    attrs: { src: 'i.jpg', alt: 'a picture', href: '/about-us' },
+                    content: []
+                }
+            ]);
+
+            const anchor = spectator.query('figure > a') as HTMLAnchorElement;
+            expect(anchor).toBeTruthy();
+            expect(anchor.getAttribute('href')).toBe('/about-us');
+            expect(anchor.querySelector('img')?.getAttribute('src')).toBe('i.jpg');
+        });
+
+        it('should set target and rel on a linked dotImage that opens in a new tab', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.DOT_IMAGE,
+                    attrs: { src: 'i.jpg', href: 'https://dotcms.com', target: '_blank' },
+                    content: []
+                }
+            ]);
+
+            const anchor = spectator.query('figure > a') as HTMLAnchorElement;
+            expect(anchor.getAttribute('target')).toBe('_blank');
+            expect(anchor.getAttribute('rel')).toBe('noopener noreferrer');
+        });
+
+        it('should keep the float wrapper style when the dotImage is linked', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.DOT_IMAGE,
+                    attrs: { src: 'i.jpg', href: '/about-us', textWrap: 'right' },
+                    content: []
+                }
+            ]);
+
+            const figure = spectator.query('figure') as HTMLElement;
+            expect(figure.style.float).toBe('right');
+            expect(spectator.query('figure > a > img')).toBeTruthy();
+        });
+
+        it('should render a bare dotImage when href is unset or empty', () => {
+            render([
+                {
+                    type: BlockEditorDefaultBlocks.DOT_IMAGE,
+                    attrs: { src: 'i.jpg', href: '' },
+                    content: []
+                }
+            ]);
+
+            expect(spectator.query('a')).toBeNull();
+            expect(spectator.query('figure > img')).toBeTruthy();
+        });
+
         it('should render a real <video> for dotVideo, with no wrapper element', () => {
             render([
                 {

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.spec.ts
@@ -54,4 +54,72 @@ describe('DotImageBlock', () => {
         const figure = spectator.query<HTMLElement>('figure');
         expect(figure?.getAttribute('style')).toBeFalsy();
     });
+
+    describe('image link', () => {
+        it('should wrap the img in an anchor when href is set', () => {
+            spectator.setInput('attrs', { src: 'image.png', alt: 'alt', href: '/about-us' });
+            spectator.detectChanges();
+            const anchor = spectator.query<HTMLAnchorElement>('a');
+            expect(anchor).toBeTruthy();
+            expect(anchor?.getAttribute('href')).toBe('/about-us');
+            expect(anchor?.querySelector('img')).toBeTruthy();
+        });
+
+        it('should keep the anchor inside the figure so wrapper styles still apply', () => {
+            spectator.setInput('attrs', {
+                src: 'image.png',
+                alt: 'alt',
+                href: '/about-us',
+                textWrap: 'left'
+            });
+            spectator.detectChanges();
+            const figure = spectator.query<HTMLElement>('figure');
+            expect(figure?.style.float).toBe('left');
+            expect(figure?.querySelector('a > img')).toBeTruthy();
+        });
+
+        it('should set target when the link opens in a new tab', () => {
+            spectator.setInput('attrs', {
+                src: 'image.png',
+                alt: 'alt',
+                href: 'https://dotcms.com',
+                target: '_blank'
+            });
+            spectator.detectChanges();
+            expect(spectator.query('a')?.getAttribute('target')).toBe('_blank');
+        });
+
+        it('should add rel noopener noreferrer when target is _blank', () => {
+            spectator.setInput('attrs', {
+                src: 'image.png',
+                alt: 'alt',
+                href: 'https://dotcms.com',
+                target: '_blank'
+            });
+            spectator.detectChanges();
+            expect(spectator.query('a')?.getAttribute('rel')).toBe('noopener noreferrer');
+        });
+
+        it('should not add rel or target when the link opens in the same tab', () => {
+            spectator.setInput('attrs', { src: 'image.png', alt: 'alt', href: '/about-us' });
+            spectator.detectChanges();
+            const anchor = spectator.query<HTMLAnchorElement>('a');
+            expect(anchor?.getAttribute('rel')).toBeNull();
+            expect(anchor?.getAttribute('target')).toBeNull();
+        });
+
+        it('should render a bare img when href is null', () => {
+            spectator.setInput('attrs', { src: 'image.png', alt: 'alt', href: null });
+            spectator.detectChanges();
+            expect(spectator.query('a')).toBeNull();
+            expect(spectator.query('figure > img')).toBeTruthy();
+        });
+
+        it('should render a bare img when href is an empty string (link unset in the editor)', () => {
+            spectator.setInput('attrs', { src: 'image.png', alt: 'alt', href: '' });
+            spectator.detectChanges();
+            expect(spectator.query('a')).toBeNull();
+            expect(spectator.query('figure > img')).toBeTruthy();
+        });
+    });
 });

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.spec.ts
@@ -115,7 +115,7 @@ describe('DotImageBlock', () => {
             expect(spectator.query('figure > img')).toBeTruthy();
         });
 
-        it('should render a bare img when href is an empty string (link unset in the editor)', () => {
+        it('should render a bare img when href is an empty string', () => {
             spectator.setInput('attrs', { src: 'image.png', alt: 'alt', href: '' });
             spectator.detectChanges();
             expect(spectator.query('a')).toBeNull();

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
@@ -1,14 +1,27 @@
+import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, Input } from '@angular/core';
 
 import { BlockEditorNode } from '@dotcms/types';
 
 @Component({
     selector: 'dotcms-block-editor-renderer-image',
-    imports: [],
+    imports: [NgTemplateOutlet],
     template: `
         <figure [style]="$wrapperStyle()">
-            <img [alt]="attrs?.['alt']" [src]="$srcURL()" />
+            @if ($href(); as href) {
+                <!-- target/rel are attribute bindings so a null value omits the
+                     attribute instead of rendering the string "null". -->
+                <a [href]="href" [attr.target]="$target()" [attr.rel]="$rel()">
+                    <ng-container [ngTemplateOutlet]="image" />
+                </a>
+            } @else {
+                <ng-container [ngTemplateOutlet]="image" />
+            }
         </figure>
+
+        <ng-template #image>
+            <img [alt]="attrs?.['alt']" [src]="$srcURL()" />
+        </ng-template>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -16,6 +29,20 @@ export class DotImageBlock {
     @Input() attrs!: BlockEditorNode['attrs'];
 
     protected readonly $srcURL = computed(() => this.attrs?.['src']);
+
+    /**
+     * Link assigned to the image in the Block Editor, stored as `href` on the
+     * `dotImage` node. `null` when never set, `''` after the editor unsets it —
+     * both mean "no link", so the image renders without an anchor.
+     */
+    protected readonly $href = computed(() => this.attrs?.['href'] || null);
+
+    protected readonly $target = computed(() => this.attrs?.['target'] || null);
+
+    /** Guards against reverse tabnabbing when the link opens in a new tab. */
+    protected readonly $rel = computed(() =>
+        this.$target() === '_blank' ? 'noopener noreferrer' : null
+    );
 
     protected readonly $wrapperStyle = computed(() => {
         const textWrap = this.attrs?.['textWrap'];

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 
 import { BlockEditorNode } from '@dotcms/types';
 
@@ -20,24 +20,24 @@ import { BlockEditorNode } from '@dotcms/types';
         </figure>
 
         <ng-template #image>
-            <img [alt]="attrs?.['alt']" [src]="$srcURL()" />
+            <img [alt]="attrs()?.['alt']" [src]="$srcURL()" />
         </ng-template>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotImageBlock {
-    @Input() attrs!: BlockEditorNode['attrs'];
+    readonly attrs = input<BlockEditorNode['attrs']>();
 
-    protected readonly $srcURL = computed(() => this.attrs?.['src']);
+    protected readonly $srcURL = computed(() => this.attrs()?.['src']);
 
     /**
      * Link assigned to the image in the Block Editor, stored as `href` on the
      * `dotImage` node. `null` when never set, `''` after the editor unsets it —
      * both mean "no link", so the image renders without an anchor.
      */
-    protected readonly $href = computed(() => this.attrs?.['href'] || null);
+    protected readonly $href = computed(() => this.attrs()?.['href'] || null);
 
-    protected readonly $target = computed(() => this.attrs?.['target'] || null);
+    protected readonly $target = computed(() => this.attrs()?.['target'] || null);
 
     /** Guards against reverse tabnabbing when the link opens in a new tab. */
     protected readonly $rel = computed(() =>
@@ -45,8 +45,8 @@ export class DotImageBlock {
     );
 
     protected readonly $wrapperStyle = computed(() => {
-        const textWrap = this.attrs?.['textWrap'];
-        const textAlign = this.attrs?.['textAlign'];
+        const textWrap = this.attrs()?.['textWrap'];
+        const textAlign = this.attrs()?.['textAlign'];
 
         if (textWrap === 'left') {
             return { float: 'left', width: '50%', margin: '0 1rem 1rem 0' };

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
@@ -32,8 +32,9 @@ export class DotImageBlock {
 
     /**
      * Link assigned to the image in the Block Editor, stored as `href` on the
-     * `dotImage` node. `null` when never set, `''` after the editor unsets it —
-     * both mean "no link", so the image renders without an anchor.
+     * `dotImage` node. `null` when the image has no link, in which case it
+     * renders without an anchor. The truthiness check also covers the
+     * transient `''` the editor writes while unsetting a link.
      */
     protected readonly $href = computed(() => this.attrs()?.['href'] || null);
 

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Image.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Image.test.tsx
@@ -136,7 +136,7 @@ describe('DotCMSImage', () => {
             expect(container.querySelector('figure > img')).toBeInTheDocument();
         });
 
-        it('should render a bare img when href is an empty string (link unset in the editor)', () => {
+        it('should render a bare img when href is an empty string', () => {
             const { container } = render(
                 <DotCMSImage node={baseNode({ src: 'img.png', alt: 'alt', href: '' })} />
             );

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Image.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Image.test.tsx
@@ -63,4 +63,85 @@ describe('DotCMSImage', () => {
         const figure = container.querySelector('figure') as HTMLElement;
         expect(figure.getAttribute('style')).toBeFalsy();
     });
+
+    describe('image link', () => {
+        it('should wrap the img in an anchor when href is set', () => {
+            const { container } = render(
+                <DotCMSImage node={baseNode({ src: 'img.png', alt: 'alt', href: '/about-us' })} />
+            );
+            const anchor = container.querySelector('a') as HTMLAnchorElement;
+            expect(anchor).toBeInTheDocument();
+            expect(anchor).toHaveAttribute('href', '/about-us');
+            expect(anchor.querySelector('img')).toBeInTheDocument();
+        });
+
+        it('should keep the anchor inside the figure so wrapper styles still apply', () => {
+            const { container } = render(
+                <DotCMSImage
+                    node={baseNode({
+                        src: 'img.png',
+                        alt: 'alt',
+                        href: '/about-us',
+                        textWrap: 'left'
+                    })}
+                />
+            );
+            const figure = container.querySelector('figure') as HTMLElement;
+            expect(figure.style.float).toBe('left');
+            expect(figure.querySelector('a > img')).toBeInTheDocument();
+        });
+
+        it('should set target when the link opens in a new tab', () => {
+            const { container } = render(
+                <DotCMSImage
+                    node={baseNode({
+                        src: 'img.png',
+                        alt: 'alt',
+                        href: 'https://dotcms.com',
+                        target: '_blank'
+                    })}
+                />
+            );
+            expect(container.querySelector('a')).toHaveAttribute('target', '_blank');
+        });
+
+        it('should add rel noopener noreferrer when target is _blank', () => {
+            const { container } = render(
+                <DotCMSImage
+                    node={baseNode({
+                        src: 'img.png',
+                        alt: 'alt',
+                        href: 'https://dotcms.com',
+                        target: '_blank'
+                    })}
+                />
+            );
+            expect(container.querySelector('a')).toHaveAttribute('rel', 'noopener noreferrer');
+        });
+
+        it('should not add rel when the link opens in the same tab', () => {
+            const { container } = render(
+                <DotCMSImage node={baseNode({ src: 'img.png', alt: 'alt', href: '/about-us' })} />
+            );
+            const anchor = container.querySelector('a') as HTMLAnchorElement;
+            expect(anchor).not.toHaveAttribute('rel');
+            expect(anchor).not.toHaveAttribute('target');
+        });
+
+        it('should render a bare img when href is null', () => {
+            const { container } = render(
+                <DotCMSImage node={baseNode({ src: 'img.png', alt: 'alt', href: null })} />
+            );
+            expect(container.querySelector('a')).not.toBeInTheDocument();
+            expect(container.querySelector('figure > img')).toBeInTheDocument();
+        });
+
+        it('should render a bare img when href is an empty string (link unset in the editor)', () => {
+            const { container } = render(
+                <DotCMSImage node={baseNode({ src: 'img.png', alt: 'alt', href: '' })} />
+            );
+            expect(container.querySelector('a')).not.toBeInTheDocument();
+            expect(container.querySelector('figure > img')).toBeInTheDocument();
+        });
+    });
 });

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
@@ -3,6 +3,8 @@ import { BlockEditorNode } from '@dotcms/types';
 interface DotCMSImageProps {
     src: string;
     alt: string;
+    href?: string | null;
+    target?: string | null;
     textWrap?: 'left' | 'right';
     textAlign?: string;
 }
@@ -10,11 +12,16 @@ interface DotCMSImageProps {
 /**
  * Renders an image component for dotCMS.
  *
+ * When the Block Editor assigns a link to the image, it is stored as `href` /
+ * `target` on the `dotImage` node and the image is wrapped in an anchor. `href`
+ * is `null` when never set and `''` once the editor unsets it — both mean "no
+ * link", so the image renders bare.
+ *
  * @param node - The node for the DotCMSImage component.
  * @returns The rendered image component.
  */
 export const DotCMSImage = ({ node }: { node: BlockEditorNode }) => {
-    const { src, alt, textWrap, textAlign } = node.attrs as DotCMSImageProps;
+    const { src, alt, href, target, textWrap, textAlign } = node.attrs as DotCMSImageProps;
 
     let wrapperStyle: React.CSSProperties = {};
 
@@ -26,13 +33,27 @@ export const DotCMSImage = ({ node }: { node: BlockEditorNode }) => {
         wrapperStyle = { textAlign: textAlign as React.CSSProperties['textAlign'] };
     }
 
+    const image = (
+        <img
+            alt={alt}
+            src={src}
+            style={textWrap ? { maxWidth: '100%', height: 'auto' } : undefined}
+        />
+    );
+
     return (
         <figure style={wrapperStyle}>
-            <img
-                alt={alt}
-                src={src}
-                style={textWrap ? { maxWidth: '100%', height: 'auto' } : undefined}
-            />
+            {href ? (
+                <a
+                    href={href}
+                    target={target ?? undefined}
+                    // Guards against reverse tabnabbing when the link opens in a new tab.
+                    rel={target === '_blank' ? 'noopener noreferrer' : undefined}>
+                    {image}
+                </a>
+            ) : (
+                image
+            )}
         </figure>
     );
 };

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
@@ -14,8 +14,9 @@ interface DotCMSImageProps {
  *
  * When the Block Editor assigns a link to the image, it is stored as `href` /
  * `target` on the `dotImage` node and the image is wrapped in an anchor. `href`
- * is `null` when never set and `''` once the editor unsets it — both mean "no
- * link", so the image renders bare.
+ * is `null` when the image has no link, in which case it renders bare. The
+ * truthiness check also covers the transient `''` the editor writes while
+ * unsetting a link.
  *
  * @param node - The node for the DotCMSImage component.
  * @returns The rendered image component.

--- a/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.spec.ts
+++ b/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.spec.ts
@@ -1,0 +1,84 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import type { BlockEditorNode } from '@dotcms/types';
+
+import DotImage from './DotImage.vue';
+
+const imageNode = (attrs: Record<string, unknown>): BlockEditorNode =>
+    ({ type: 'dotImage', attrs }) as unknown as BlockEditorNode;
+
+const mountImage = (attrs: Record<string, unknown>) =>
+    mount(DotImage, { props: { node: imageNode(attrs) } });
+
+describe('DotImage', () => {
+    it('renders a figure with the img src and alt', () => {
+        const wrapper = mountImage({ src: 'image.png', alt: 'a picture' });
+        expect(wrapper.find('figure').exists()).toBe(true);
+        const img = wrapper.find('img');
+        expect(img.attributes('src')).toBe('image.png');
+        expect(img.attributes('alt')).toBe('a picture');
+    });
+
+    it('applies the float style when textWrap is set', () => {
+        const wrapper = mountImage({ src: 'image.png', alt: '', textWrap: 'right' });
+        expect(wrapper.find('figure').attributes('style')).toContain('float: right');
+    });
+
+    it('applies the text-align style when textAlign is set', () => {
+        const wrapper = mountImage({ src: 'image.png', alt: '', textAlign: 'center' });
+        expect(wrapper.find('figure').attributes('style')).toContain('text-align: center');
+    });
+
+    describe('image link', () => {
+        it('wraps the img in an anchor when href is set', () => {
+            const wrapper = mountImage({ src: 'image.png', alt: 'alt', href: '/about-us' });
+            const anchor = wrapper.find('figure > a');
+            expect(anchor.exists()).toBe(true);
+            expect(anchor.attributes('href')).toBe('/about-us');
+            expect(anchor.find('img').attributes('src')).toBe('image.png');
+        });
+
+        it('keeps the wrapper style on the figure when the image is linked', () => {
+            const wrapper = mountImage({
+                src: 'image.png',
+                alt: 'alt',
+                href: '/about-us',
+                textWrap: 'right'
+            });
+            expect(wrapper.find('figure').attributes('style')).toContain('float: right');
+            expect(wrapper.find('figure > a > img').exists()).toBe(true);
+        });
+
+        it('sets target and rel when the link opens in a new tab', () => {
+            const wrapper = mountImage({
+                src: 'image.png',
+                alt: 'alt',
+                href: 'https://dotcms.com',
+                target: '_blank'
+            });
+            const anchor = wrapper.find('a');
+            expect(anchor.attributes('target')).toBe('_blank');
+            expect(anchor.attributes('rel')).toBe('noopener noreferrer');
+        });
+
+        it('omits target and rel when the link opens in the same tab', () => {
+            const wrapper = mountImage({ src: 'image.png', alt: 'alt', href: '/about-us' });
+            const anchor = wrapper.find('a');
+            expect(anchor.attributes('target')).toBeUndefined();
+            expect(anchor.attributes('rel')).toBeUndefined();
+        });
+
+        it('renders a bare img when href is null', () => {
+            const wrapper = mountImage({ src: 'image.png', alt: 'alt', href: null });
+            expect(wrapper.find('a').exists()).toBe(false);
+            expect(wrapper.find('figure > img').exists()).toBe(true);
+        });
+
+        it('renders a bare img when href is an empty string (link unset in the editor)', () => {
+            const wrapper = mountImage({ src: 'image.png', alt: 'alt', href: '' });
+            expect(wrapper.find('a').exists()).toBe(false);
+            expect(wrapper.find('figure > img').exists()).toBe(true);
+        });
+    });
+});

--- a/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.spec.ts
+++ b/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.spec.ts
@@ -75,7 +75,7 @@ describe('DotImage', () => {
             expect(wrapper.find('figure > img').exists()).toBe(true);
         });
 
-        it('renders a bare img when href is an empty string (link unset in the editor)', () => {
+        it('renders a bare img when href is an empty string', () => {
             const wrapper = mountImage({ src: 'image.png', alt: 'alt', href: '' });
             expect(wrapper.find('a').exists()).toBe(false);
             expect(wrapper.find('figure > img').exists()).toBe(true);

--- a/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.vue
+++ b/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.vue
@@ -6,11 +6,13 @@ import type { BlockEditorNode } from '@dotcms/types';
 interface DotCMSImageAttrs {
     src: string;
     alt: string;
+    href?: string | null;
+    target?: string | null;
     textWrap?: 'left' | 'right';
     textAlign?: string;
 }
 
-/** Renders a dotCMS image block with optional text-wrap / alignment. */
+/** Renders a dotCMS image block with optional link, text-wrap / alignment. */
 const props = defineProps<{ node: BlockEditorNode }>();
 
 const attrs = computed(() => (props.node.attrs ?? {}) as unknown as DotCMSImageAttrs);
@@ -36,10 +38,34 @@ const wrapperStyle = computed<CSSProperties>(() => {
 const imgStyle = computed<CSSProperties | undefined>(() =>
     attrs.value.textWrap ? { maxWidth: '100%', height: 'auto' } : undefined
 );
+
+/**
+ * The link assigned to the image in the Block Editor, stored as `href` /
+ * `target` on the `dotImage` node. `null` when the image has no link — `href`
+ * is `null` when never set and `''` once the editor unsets it.
+ *
+ * `rel` guards against reverse tabnabbing when the link opens in a new tab.
+ */
+const link = computed(() => {
+    const { href, target } = attrs.value;
+
+    if (!href) {
+        return null;
+    }
+
+    return {
+        href,
+        target: target ?? undefined,
+        rel: target === '_blank' ? 'noopener noreferrer' : undefined
+    };
+});
 </script>
 
 <template>
     <figure :style="wrapperStyle">
-        <img :alt="attrs.alt" :src="attrs.src" :style="imgStyle" />
+        <a v-if="link" :href="link.href" :target="link.target" :rel="link.rel">
+            <img :alt="attrs.alt" :src="attrs.src" :style="imgStyle" />
+        </a>
+        <img v-else :alt="attrs.alt" :src="attrs.src" :style="imgStyle" />
     </figure>
 </template>

--- a/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.vue
+++ b/core-web/libs/sdk/vue/src/lib/components/DotCMSBlockEditorRenderer/components/blocks/DotImage.vue
@@ -41,8 +41,9 @@ const imgStyle = computed<CSSProperties | undefined>(() =>
 
 /**
  * The link assigned to the image in the Block Editor, stored as `href` /
- * `target` on the `dotImage` node. `null` when the image has no link — `href`
- * is `null` when never set and `''` once the editor unsets it.
+ * `target` on the `dotImage` node. `null` when the image has no link, i.e.
+ * when `href` is `null`. The truthiness check also covers the transient `''`
+ * the editor writes while unsetting a link.
  *
  * `rel` guards against reverse tabnabbing when the link opens in a new tab.
  */

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
@@ -1,5 +1,10 @@
 #set($allowedAligns = ["left", "center", "right", "justify"])
 
+## Link target set on the dotImage node. Checked against both "" and "null":
+## $! renders an unset reference as empty, but the value also reaches this
+## template as the literal string "null" (same idiom as the href check below).
+#set($imageTarget = "$!item.attrs.target")
+
 #if($item.attrs.textWrap == "left")
     #set($figureStyle = "float: left; width: 50%; margin: 0 1rem 1rem 0;")
 #elseif($item.attrs.textWrap == "right")
@@ -11,7 +16,7 @@
 <figure#if($figureStyle) style="$figureStyle"#end>
 
     #if ($!item.attrs.href != "null")
-    <a href="$!item.attrs.href">
+    <a href="$!item.attrs.href"#if($imageTarget != "null" && $imageTarget != "") target="$imageTarget"#end#if($imageTarget == "_blank") rel="noopener noreferrer"#end>
     #end
 
     <img

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
@@ -1,8 +1,12 @@
 #set($allowedAligns = ["left", "center", "right", "justify"])
 
-## Link target set on the dotImage node. Checked against both "" and "null":
-## $! renders an unset reference as empty, but the value also reaches this
-## template as the literal string "null" (same idiom as the href check below).
+## Link href/target set on the dotImage node. Both are checked against "null"
+## and "": an unset attribute reaches this template as the literal string
+## "null", while "" is a state the Block Editor holds transiently and other
+## write paths (REST, imports) can persist. Empty means "no link", so it must
+## not produce an anchor — this matches the four SDK renderers, which guard
+## the same two forms.
+#set($imageHref = "$!item.attrs.href")
 #set($imageTarget = "$!item.attrs.target")
 
 #if($item.attrs.textWrap == "left")
@@ -15,8 +19,8 @@
 
 <figure#if($figureStyle) style="$figureStyle"#end>
 
-    #if ($!item.attrs.href != "null")
-    <a href="$!item.attrs.href"#if($imageTarget != "null" && $imageTarget != "") target="$imageTarget"#end#if($imageTarget == "_blank") rel="noopener noreferrer"#end>
+    #if ($imageHref != "null" && $imageHref != "")
+    <a href="$imageHref"#if($imageTarget != "null" && $imageTarget != "") target="$imageTarget"#end#if($imageTarget == "_blank") rel="noopener noreferrer"#end>
     #end
 
     <img
@@ -25,7 +29,7 @@
         title="#if($!item.attrs.title && $!item.attrs.title != "null")$!item.attrs.title#{else}$!item.attrs.data.title#end"
     />
 
-    #if ($!item.attrs.href != "null")
+    #if ($imageHref != "null" && $imageHref != "")
     </a>
     #end
 


### PR DESCRIPTION
## What

Fixes #36998 — a linked image authored in the Block Editor rendered without an anchor on the frontend, so it was not clickable.

The data layer was never the gap. The Block Editor stores the link as `href`/`target` on the `dotImage` node (`image.node.ts:63-77`) and its own `renderHTML` wraps the image in an anchor — which is why the link looks correct inside the CMS. The renderers simply never read those attributes.

## Approach

Wrap the `<img>` in `<a href target>` when `href` is present, mirroring the editor's `renderHTML` output. Absent `href` leaves the existing markup untouched, so this is additive for every unlinked image.

The guard is a truthiness check rather than a null check because the editor produces two "no link" states: `href: null` when never set, and `href: ''` after `unsetImageLink` (`image.node.ts:110`).

## Scope

The issue was reported against `@dotcms/angular` and `@dotcms/react`. The same gap existed in `@dotcms/vue` and in the Velocity template (`dotImage.vtl`, where `href` was already handled but `target` was not), so both are fixed here as well.

## Implementation notes

**`rel="noopener noreferrer"` is emitted when `target="_blank"`.** The editor's own `renderHTML` does not emit it; this is an intentional divergence to prevent reverse tabnabbing on the published page.

**Angular binds `target`/`rel` as attributes, not properties.** With `[target]`/`[rel]`, Angular renders the literal string `"null"`, so every linked image without a target would ship `rel="null"`. `[attr.*]` omits the attribute instead. Covered by tests in both Angular renderers.

## Testing

```
sdk-angular   246 passed
sdk-react     138 passed
sdk-vue        55 passed   (DotImage.spec.ts is new)
lint 3/3, build 3/3
```

Each renderer covers: anchor with correct `href`; `figure` wrapper style preserved when linked; `target` + `rel` on `_blank`; neither attribute on same-tab links; bare `<img>` for `href: null` and `href: ''`.

Manual — each SDK built and swapped into its example app against a live instance, plus the Velocity path:

- `examples/angular` (semantic renderer) — anchor renders, image clickable
- `examples/nextjs` (React) — confirmed
- `examples/vuejs` (Vue) — confirmed
- Velocity page with three images — no link, `_blank`, and same-tab — renders no anchor, `target`+`rel`, and a bare anchor respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36998