### PR TITLE
#37087: fix(graphql): resolve Block Editor fields via canonical StoryBlockAPI.toMap

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
@@ -92,8 +92,9 @@ public interface StoryBlockAPI {
     /**
      * Takes the actual value of the Story Block field and transforms it into a Linked Map. The value may arrive
      * in two shapes depending on the read path: a raw JSON String, or a Map when the field has already been
-     * hydrated by the contentlet transformers (e.g. during page rendering). This method is the single canonical
-     * conversion for both shapes.
+     * hydrated by the contentlet transformers (e.g. during page rendering). Consumers of a Block Editor value
+     * should convert through this method rather than assuming one shape. Note that a Map input yields a
+     * <b>shallow</b> copy: nested structures are shared with the input and must not be mutated.
      *
      * @param blockEditorValue The value of the Story Block field, either a JSON String or an already-hydrated Map.
      *

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * This API allows you to interact with information related to Story Block fields in a given Contentlet. For example, it
@@ -103,6 +104,23 @@ public interface StoryBlockAPI {
      * @throws JsonProcessingException An error occurred when processing the JSON data.
      */
     LinkedHashMap<String, Object> toMap(final Object blockEditorValue) throws JsonProcessingException;
+
+    /**
+     * Tolerant variant of {@link #toMap(Object)} for read paths that must never fail or reshape
+     * stored data. A Map or JSON-object String converts exactly like {@link #toMap(Object)}; any
+     * other value — e.g. HTML from a WYSIWYG field later converted to Block Editor — is returned
+     * unchanged, with a rate-limited WARN identifying the unparseable value. Use this from
+     * consumers that render stored values (GraphQL, REST); use the strict {@link #toMap(Object)}
+     * from transforms that require a valid Story Block document and must fail otherwise.
+     *
+     * @param blockEditorValue The value of the Story Block field, in any of the shapes described above.
+     * @param valueContext     Describes where the value came from (contentlet identifier, field
+     *                         variable, etc.); only evaluated when the WARN is logged.
+     *
+     * @return The Story Block field as a {@link LinkedHashMap}, or {@code blockEditorValue}
+     * unchanged when it does not hold a Story Block JSON document.
+     */
+    Object toMapOrPassthrough(final Object blockEditorValue, final Supplier<String> valueContext);
 
     /**
      * Takes the Map containing the properties of a specific Story Block field and transforms it into JSON data as a

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
@@ -90,9 +90,12 @@ public interface StoryBlockAPI {
     Object addContentlet(final Object storyBlockValue, final Contentlet contentlet);
 
     /**
-     * Takes the actual value of the Story Block field in the form of JSON and transforms it into a Linked Map.
+     * Takes the actual value of the Story Block field and transforms it into a Linked Map. The value may arrive
+     * in two shapes depending on the read path: a raw JSON String, or a Map when the field has already been
+     * hydrated by the contentlet transformers (e.g. during page rendering). This method is the single canonical
+     * conversion for both shapes.
      *
-     * @param blockEditorValue The value of the Story Block field as JSON.
+     * @param blockEditorValue The value of the Story Block field, either a JSON String or an already-hydrated Map.
      *
      * @return The Story Block field as a {@link LinkedHashMap}.
      *

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
@@ -599,6 +599,11 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
     @Override
     @SuppressWarnings("unchecked")
     public LinkedHashMap<String, Object> toMap(final Object blockEditorValue) throws JsonProcessingException {
+        if (blockEditorValue instanceof Map) {
+            // Already hydrated into a Map -- e.g. by StoryBlockViewStrategy during page rendering.
+            // Map.toString() produces Java map notation, not JSON, so it must never be re-parsed.
+            return new LinkedHashMap<>((Map<String, Object>) blockEditorValue);
+        }
         return ContentletJsonHelper.INSTANCE.get().objectMapper()
                        .readValue(Try.of(blockEditorValue::toString)
                                           .getOrElse(StringPool.BLANK), LinkedHashMap.class);

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -85,6 +86,12 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
             ThreadLocal.withInitial(HashSet::new);
     private static final Lazy<String> MAX_RELATIONSHIP_DEPTH = Lazy.of(() -> Config.getStringProperty(
             "STORY_BLOCK_MAX_RELATIONSHIP_DEPTH", DEFAULT_MAX_RECURSION_LEVEL));
+    /**
+     * Minimum interval between two {@link #toMapOrPassthrough} WARN entries for the same value
+     * context, so legacy non-JSON values (e.g. converted WYSIWYG fields) stay visible in the logs
+     * without flooding them on every read.
+     */
+    private static final int UNPARSEABLE_VALUE_WARN_INTERVAL_MILLIS = 30_000;
 
     /**
      * This method hydrates all the Story Block -- a.k.a. Block Editor -- fields within the
@@ -609,6 +616,30 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
         return ContentletJsonHelper.INSTANCE.get().objectMapper()
                        .readValue(Try.of(blockEditorValue::toString)
                                           .getOrElse(StringPool.BLANK), LinkedHashMap.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object toMapOrPassthrough(final Object blockEditorValue, final Supplier<String> valueContext) {
+        if (blockEditorValue instanceof Map) {
+            // Same shallow-copy semantics as toMap(Object).
+            return new LinkedHashMap<>((Map<String, Object>) blockEditorValue);
+        }
+        if (null != blockEditorValue) {
+            try {
+                if (isJsonObject(blockEditorValue.toString())) {
+                    return this.toMap(blockEditorValue);
+                }
+            } catch (final Exception e) {
+                Logger.debug(this, () -> String.format("Unable to parse Story Block value (%s): %s",
+                        valueContext.get(), ExceptionUtil.getErrorMessage(e)));
+            }
+            final String context = valueContext.get();
+            Logger.warnEvery(StoryBlockAPIImpl.class, context, String.format(
+                    "Unable to parse Story Block value as JSON (%s); returning the stored value unchanged",
+                    context), UNPARSEABLE_VALUE_WARN_INTERVAL_MILLIS);
+        }
+        return blockEditorValue;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
@@ -602,6 +602,8 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
         if (blockEditorValue instanceof Map) {
             // Already hydrated into a Map -- e.g. by StoryBlockViewStrategy during page rendering.
             // Map.toString() produces Java map notation, not JSON, so it must never be re-parsed.
+            // NOTE: this is a SHALLOW copy -- nested content lists/maps are shared with the
+            // caller's value. Callers must not mutate nested structures of a Map-sourced result.
             return new LinkedHashMap<>((Map<String, Object>) blockEditorValue);
         }
         return ContentletJsonHelper.INSTANCE.get().objectMapper()

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
@@ -1,5 +1,6 @@
 package com.dotcms.graphql.datafetcher;
 
+import com.dotcms.util.JsonUtil;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.Logger;
@@ -18,8 +19,11 @@ import java.util.Map;
  * are resolved through the canonical {@link com.dotcms.contenttype.business.StoryBlockAPI#toMap(Object)}
  * conversion so every consumer of a Block Editor value behaves the same.
  * <p>
- * A value that cannot be resolved into JSON degrades gracefully: the field resolves to
- * {@code null} and a WARN is logged, instead of failing the whole GraphQL query.
+ * The read path never reshapes stored data: a String value that is not a Block Editor JSON
+ * document (e.g. HTML from a converted WYSIWYG field) is returned unchanged, matching {@code _map}
+ * and the Page REST API. A missing/blank value resolves to an empty json object. If resolution
+ * still fails, the field degrades gracefully to {@code null} with a WARN instead of failing the
+ * whole GraphQL query.
  */
 public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Object>> {
 
@@ -41,6 +45,14 @@ public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Objec
             return storyBlockMap;
         }
 
+        if (fieldValue instanceof String && !isJsonObject((String) fieldValue)) {
+            // A stored value that is not a Block Editor JSON document -- e.g. HTML from a WYSIWYG
+            // field later converted to Block Editor -- is returned unchanged. The read path never
+            // reshapes stored data, matching what _map and the Page REST API return.
+            storyBlockMap.put("json", fieldValue);
+            return storyBlockMap;
+        }
+
         try {
             storyBlockMap.put("json", APILocator.getStoryBlockAPI().toMap(fieldValue));
         } catch (final Exception e) {
@@ -51,5 +63,15 @@ public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Objec
         }
 
         return storyBlockMap;
+    }
+
+    /**
+     * Mirrors {@code StoryBlockAPIImpl.isJsonObject}: Story Block documents are always JSON
+     * objects, so only a value whose root token is an object is parsed; everything else is a
+     * legacy value passed through as-is.
+     */
+    private static boolean isJsonObject(final String value) {
+        final String trimmed = value.trim();
+        return trimmed.startsWith("{") && JsonUtil.isValidJSON(trimmed);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
@@ -57,8 +57,9 @@ public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Objec
             storyBlockMap.put("json", APILocator.getStoryBlockAPI().toMap(fieldValue));
         } catch (final Exception e) {
             Logger.warnAndDebug(this.getClass(), String.format(
-                    "Unable to resolve Story Block field '%s' of contentlet '%s' as JSON: %s",
-                    variableName, contentlet.getIdentifier(), e.getMessage()), e);
+                    "Unable to resolve Story Block field '%s' as JSON (identifier: %s, inode: %s, languageId: %d): %s",
+                    variableName, contentlet.getIdentifier(), contentlet.getInode(),
+                    contentlet.getLanguageId(), e.getMessage()), e);
             return null;
         }
 

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
@@ -31,14 +31,12 @@ public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Objec
         Logger.debug(this, ()-> "Fetching StoryBlock field for contentlet: " + contentlet.getIdentifier() + " field: " + variableName);
 
         final Object fieldValue = contentlet.get(variableName);
-        if (null == fieldValue) {
-            return null;
-        }
 
         final Map<String, Object> storyBlockMap = new HashMap<>();
-        if (fieldValue instanceof String && !UtilMethods.isSet((String) fieldValue)) {
-            // Existing contract (see GraphQLTests postman collection): an empty Story Block
-            // field resolves to an empty json object, not to null.
+        if (null == fieldValue
+                || (fieldValue instanceof String && !UtilMethods.isSet((String) fieldValue))) {
+            // Existing contract (see GraphQLTests postman collection): a Story Block field
+            // without a value resolves to an empty json object, not to null.
             storyBlockMap.put("json", Map.of());
             return storyBlockMap;
         }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
@@ -31,12 +31,18 @@ public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Objec
         Logger.debug(this, ()-> "Fetching StoryBlock field for contentlet: " + contentlet.getIdentifier() + " field: " + variableName);
 
         final Object fieldValue = contentlet.get(variableName);
-        if (null == fieldValue
-                || (fieldValue instanceof String && !UtilMethods.isSet((String) fieldValue))) {
+        if (null == fieldValue) {
             return null;
         }
 
         final Map<String, Object> storyBlockMap = new HashMap<>();
+        if (fieldValue instanceof String && !UtilMethods.isSet((String) fieldValue)) {
+            // Existing contract (see GraphQLTests postman collection): an empty Story Block
+            // field resolves to an empty json object, not to null.
+            storyBlockMap.put("json", Map.of());
+            return storyBlockMap;
+        }
+
         try {
             storyBlockMap.put("json", APILocator.getStoryBlockAPI().toMap(fieldValue));
         } catch (final Exception e) {

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
@@ -1,26 +1,50 @@
 package com.dotcms.graphql.datafetcher;
 
-import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.json.JSONObject;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Resolves a Story Block (Block Editor) field for GraphQL queries.
+ * <p>
+ * The field value can arrive in two shapes depending on the read path: an already-hydrated
+ * {@link Map} (page queries, where {@code StoryBlockViewStrategy} has transformed the contentlet)
+ * or a raw JSON {@link String} (collection queries, which return the raw contentlet). Both shapes
+ * are resolved through the canonical {@link com.dotcms.contenttype.business.StoryBlockAPI#toMap(Object)}
+ * conversion so every consumer of a Block Editor value behaves the same.
+ * <p>
+ * A value that cannot be resolved into JSON degrades gracefully: the field resolves to
+ * {@code null} and a WARN is logged, instead of failing the whole GraphQL query.
+ */
 public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Object>> {
+
     @Override
-    public Map<String, Object> get(DataFetchingEnvironment environment) throws Exception {
+    public Map<String, Object> get(final DataFetchingEnvironment environment) throws Exception {
         final Contentlet contentlet = environment.getSource();
         final String variableName = environment.getField().getName();
 
         Logger.debug(this, ()-> "Fetching StoryBlock field for contentlet: " + contentlet.getIdentifier() + " field: " + variableName);
-        final Map<String, Object> storyBlockMap = new HashMap<>();
 
-        final String contFieldValue = contentlet.getStringProperty(variableName);
-        final JSONObject jsonContFieldValue = new JSONObject(contFieldValue);
-        storyBlockMap.put("json",new ObjectMapper().readValue(jsonContFieldValue.toString(), HashMap.class));
+        final Object fieldValue = contentlet.get(variableName);
+        if (null == fieldValue
+                || (fieldValue instanceof String && !UtilMethods.isSet((String) fieldValue))) {
+            return null;
+        }
+
+        final Map<String, Object> storyBlockMap = new HashMap<>();
+        try {
+            storyBlockMap.put("json", APILocator.getStoryBlockAPI().toMap(fieldValue));
+        } catch (final Exception e) {
+            Logger.warnAndDebug(this.getClass(), String.format(
+                    "Unable to resolve Story Block field '%s' of contentlet '%s' as JSON: %s",
+                    variableName, contentlet.getIdentifier(), e.getMessage()), e);
+            return null;
+        }
 
         return storyBlockMap;
     }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcher.java
@@ -1,6 +1,5 @@
 package com.dotcms.graphql.datafetcher;
 
-import com.dotcms.util.JsonUtil;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.Logger;
@@ -16,14 +15,12 @@ import java.util.Map;
  * The field value can arrive in two shapes depending on the read path: an already-hydrated
  * {@link Map} (page queries, where {@code StoryBlockViewStrategy} has transformed the contentlet)
  * or a raw JSON {@link String} (collection queries, which return the raw contentlet). Both shapes
- * are resolved through the canonical {@link com.dotcms.contenttype.business.StoryBlockAPI#toMap(Object)}
- * conversion so every consumer of a Block Editor value behaves the same.
- * <p>
- * The read path never reshapes stored data: a String value that is not a Block Editor JSON
- * document (e.g. HTML from a converted WYSIWYG field) is returned unchanged, matching {@code _map}
- * and the Page REST API. A missing/blank value resolves to an empty json object. If resolution
- * still fails, the field degrades gracefully to {@code null} with a WARN instead of failing the
- * whole GraphQL query.
+ * — plus legacy values that are not Block Editor JSON at all, e.g. HTML from a converted WYSIWYG
+ * field — are resolved through the canonical
+ * {@link com.dotcms.contenttype.business.StoryBlockAPI#toMapOrPassthrough(Object, java.util.function.Supplier)}
+ * conversion, which never reshapes stored data and never throws: unparseable values are returned
+ * unchanged (matching {@code _map} and the Page REST API) with a rate-limited WARN. A
+ * missing/blank value resolves to an empty json object per the existing contract.
  */
 public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Object>> {
 
@@ -45,34 +42,10 @@ public class StoryBlockFieldDataFetcher implements DataFetcher<Map<String, Objec
             return storyBlockMap;
         }
 
-        if (fieldValue instanceof String && !isJsonObject((String) fieldValue)) {
-            // A stored value that is not a Block Editor JSON document -- e.g. HTML from a WYSIWYG
-            // field later converted to Block Editor -- is returned unchanged. The read path never
-            // reshapes stored data, matching what _map and the Page REST API return.
-            storyBlockMap.put("json", fieldValue);
-            return storyBlockMap;
-        }
-
-        try {
-            storyBlockMap.put("json", APILocator.getStoryBlockAPI().toMap(fieldValue));
-        } catch (final Exception e) {
-            Logger.warnAndDebug(this.getClass(), String.format(
-                    "Unable to resolve Story Block field '%s' as JSON (identifier: %s, inode: %s, languageId: %d): %s",
-                    variableName, contentlet.getIdentifier(), contentlet.getInode(),
-                    contentlet.getLanguageId(), e.getMessage()), e);
-            return null;
-        }
-
+        storyBlockMap.put("json", APILocator.getStoryBlockAPI().toMapOrPassthrough(fieldValue,
+                () -> String.format("field: '%s', identifier: %s, inode: %s, languageId: %d",
+                        variableName, contentlet.getIdentifier(), contentlet.getInode(),
+                        contentlet.getLanguageId())));
         return storyBlockMap;
-    }
-
-    /**
-     * Mirrors {@code StoryBlockAPIImpl.isJsonObject}: Story Block documents are always JSON
-     * objects, so only a value whose root token is an object is parsed; everything else is a
-     * legacy value passed through as-is.
-     */
-    private static boolean isJsonObject(final String value) {
-        final String trimmed = value.trim();
-        return trimmed.startsWith("{") && JsonUtil.isValidJSON(trimmed);
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/contenttype/business/StoryBlockAPIImplToMapTest.java
+++ b/dotCMS/src/test/java/com/dotcms/contenttype/business/StoryBlockAPIImplToMapTest.java
@@ -1,0 +1,57 @@
+package com.dotcms.contenttype.business;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import com.dotcms.UnitTestBase;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link StoryBlockAPIImpl#toMap(Object)}, the single canonical conversion for
+ * Block Editor values. It must accept both value shapes: a raw JSON String and an
+ * already-hydrated Map (e.g. from {@code StoryBlockViewStrategy}).
+ */
+public class StoryBlockAPIImplToMapTest extends UnitTestBase {
+
+    private final StoryBlockAPIImpl storyBlockAPI = new StoryBlockAPIImpl();
+
+    @Test
+    public void toMap_parsesJsonString() throws JsonProcessingException {
+        final String json = "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\","
+                + "\"text\":\"Securely, visually, and without the chaos: https://dotcms.com\"}]}";
+
+        final LinkedHashMap<String, Object> result = storyBlockAPI.toMap(json);
+
+        assertEquals("doc", result.get("type"));
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> paragraph = (Map<String, Object>) ((List<Object>) result.get("content")).get(0);
+        assertEquals("Securely, visually, and without the chaos: https://dotcms.com", paragraph.get("text"));
+    }
+
+    /**
+     * A hydrated Map must be copied, never round-tripped through {@code Map.toString()} — Java map
+     * notation is not JSON and text containing commas/URLs breaks any parser fed with it.
+     */
+    @Test
+    public void toMap_acceptsHydratedMap() throws JsonProcessingException {
+        final Map<String, Object> hydrated = new LinkedHashMap<>();
+        hydrated.put("type", "doc");
+        hydrated.put("content", List.of(Map.of(
+                "type", "paragraph",
+                "text", "Run your entire digital ecosystem - securely, visually, and without the chaos.")));
+
+        final LinkedHashMap<String, Object> result = storyBlockAPI.toMap(hydrated);
+
+        assertEquals(hydrated, result);
+        assertNotSame("toMap must return a defensive copy", hydrated, result);
+    }
+
+    @Test(expected = JsonProcessingException.class)
+    public void toMap_rejectsJavaMapNotationString() throws JsonProcessingException {
+        storyBlockAPI.toMap("{type=doc, content=[{type=paragraph, text=securely, visually}]}");
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/contenttype/business/StoryBlockAPIImplToMapTest.java
+++ b/dotCMS/src/test/java/com/dotcms/contenttype/business/StoryBlockAPIImplToMapTest.java
@@ -2,6 +2,8 @@ package com.dotcms.contenttype.business;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import com.dotcms.UnitTestBase;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -11,9 +13,10 @@ import java.util.Map;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link StoryBlockAPIImpl#toMap(Object)}, the single canonical conversion for
- * Block Editor values. It must accept both value shapes: a raw JSON String and an
- * already-hydrated Map (e.g. from {@code StoryBlockViewStrategy}).
+ * Unit tests for {@link StoryBlockAPIImpl#toMap(Object)} and its tolerant variant
+ * {@code toMapOrPassthrough}, the single canonical conversion for Block Editor values. It must
+ * accept both value shapes: a raw JSON String and an already-hydrated Map (e.g. from
+ * {@code StoryBlockViewStrategy}).
  */
 public class StoryBlockAPIImplToMapTest extends UnitTestBase {
 
@@ -53,5 +56,39 @@ public class StoryBlockAPIImplToMapTest extends UnitTestBase {
     @Test(expected = JsonProcessingException.class)
     public void toMap_rejectsJavaMapNotationString() throws JsonProcessingException {
         storyBlockAPI.toMap("{type=doc, content=[{type=paragraph, text=securely, visually}]}");
+    }
+
+    /**
+     * The tolerant variant behaves exactly like {@code toMap} for the two valid shapes: a JSON
+     * String parses into a Map, and a hydrated Map yields a defensive copy.
+     */
+    @Test
+    public void toMapOrPassthrough_convertsValidShapesLikeToMap() {
+        final Object parsed = storyBlockAPI.toMapOrPassthrough(
+                "{\"type\":\"doc\",\"content\":[]}", () -> "test");
+        assertEquals("doc", ((Map<?, ?>) parsed).get("type"));
+
+        final Map<String, Object> hydrated = new LinkedHashMap<>();
+        hydrated.put("type", "doc");
+        final Object copied = storyBlockAPI.toMapOrPassthrough(hydrated, () -> "test");
+        assertEquals(hydrated, copied);
+        assertNotSame("must return a defensive copy of a hydrated Map", hydrated, copied);
+    }
+
+    /**
+     * The read path never reshapes stored data and never throws: any value that is not a Story
+     * Block JSON document — legacy WYSIWYG HTML, Java map notation, scalars — is returned
+     * unchanged (same instance).
+     */
+    @Test
+    public void toMapOrPassthrough_returnsUnparseableValuesUnchanged() {
+        for (final Object value : new Object[] {
+                "<p>Save 20% today, <a href=\"https://dotcms.com/offer\">see details</a></p>",
+                "{type=doc, content=[{type=paragraph, text=securely, visually}]}",
+                "plain text", 42L}) {
+            assertSame("value: <" + value + ">", value,
+                    storyBlockAPI.toMapOrPassthrough(value, () -> "test"));
+        }
+        assertNull(storyBlockAPI.toMapOrPassthrough(null, () -> "test"));
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
@@ -3,7 +3,6 @@ package com.dotcms.graphql.datafetcher;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -79,14 +78,33 @@ public class StoryBlockFieldDataFetcherTest extends UnitTestBase {
     }
 
     /**
-     * A malformed value (e.g. the Java {@code Map.toString()} notation that used to reach the
-     * legacy parser) must degrade gracefully: the field resolves to null, no exception thrown.
+     * The read path never reshapes stored data: a String value that is not a Block Editor JSON
+     * document — e.g. HTML from a WYSIWYG field later converted to Block Editor — is returned
+     * unchanged, matching what {@code _map} and the Page REST API return for the same contentlet.
      */
     @Test
-    public void malformedValue_resolvesToNull() throws Exception {
+    public void nonJsonStringValue_isPassedThroughUnchanged() throws Exception {
+        final String legacyHtml = "<p>Save 20% today, <a href=\"https://dotcms.com/offer\">see details</a></p>";
+
+        final Map<String, Object> result = fetcher.get(environmentWith(legacyHtml));
+
+        assertNotNull(result);
+        assertEquals(legacyHtml, result.get("json"));
+    }
+
+    /**
+     * A value that merely looks like JSON but is not (e.g. the Java {@code Map.toString()}
+     * notation that used to crash the legacy parser) is also passed through unchanged — never an
+     * exception, never a dropped field.
+     */
+    @Test
+    public void malformedValue_isPassedThroughUnchanged() throws Exception {
         final String javaMapNotation = "{type=doc, content=[{type=paragraph, text=Run your entire digital ecosystem - securely, visually}]}";
 
-        assertNull(fetcher.get(environmentWith(javaMapNotation)));
+        final Map<String, Object> result = fetcher.get(environmentWith(javaMapNotation));
+
+        assertNotNull(result);
+        assertEquals(javaMapNotation, result.get("json"));
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
@@ -94,8 +94,19 @@ public class StoryBlockFieldDataFetcherTest extends UnitTestBase {
         assertNull(fetcher.get(environmentWith(null)));
     }
 
+    /**
+     * Existing contract, pinned by the GraphQLTests postman collection ("Get Content With Empty
+     * StoryBlock via GraphQL"): an empty Story Block field resolves to an empty json object.
+     */
     @Test
-    public void blankValue_resolvesToNull() throws Exception {
-        assertNull(fetcher.get(environmentWith("  ")));
+    public void blankValue_resolvesToEmptyJsonObject() throws Exception {
+        final Map<String, Object> result = fetcher.get(environmentWith(""));
+
+        assertNotNull(result);
+        assertEquals(Map.of(), result.get("json"));
+
+        final Map<String, Object> whitespaceResult = fetcher.get(environmentWith("  "));
+        assertNotNull(whitespaceResult);
+        assertEquals(Map.of(), whitespaceResult.get("json"));
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
@@ -89,24 +89,18 @@ public class StoryBlockFieldDataFetcherTest extends UnitTestBase {
         assertNull(fetcher.get(environmentWith(javaMapNotation)));
     }
 
-    @Test
-    public void nullValue_resolvesToNull() throws Exception {
-        assertNull(fetcher.get(environmentWith(null)));
-    }
-
     /**
      * Existing contract, pinned by the GraphQLTests postman collection ("Get Content With Empty
-     * StoryBlock via GraphQL"): an empty Story Block field resolves to an empty json object.
+     * StoryBlock via GraphQL"): a Story Block field without a value — null (never stored, the
+     * shape the collection query actually sees) or a blank String — resolves to an empty json
+     * object.
      */
     @Test
-    public void blankValue_resolvesToEmptyJsonObject() throws Exception {
-        final Map<String, Object> result = fetcher.get(environmentWith(""));
-
-        assertNotNull(result);
-        assertEquals(Map.of(), result.get("json"));
-
-        final Map<String, Object> whitespaceResult = fetcher.get(environmentWith("  "));
-        assertNotNull(whitespaceResult);
-        assertEquals(Map.of(), whitespaceResult.get("json"));
+    public void missingValue_resolvesToEmptyJsonObject() throws Exception {
+        for (final Object missing : new Object[] {null, "", "  "}) {
+            final Map<String, Object> result = fetcher.get(environmentWith(missing));
+            assertNotNull("value: <" + missing + ">", result);
+            assertEquals("value: <" + missing + ">", Map.of(), result.get("json"));
+        }
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
@@ -1,0 +1,101 @@
+package com.dotcms.graphql.datafetcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.UnitTestBase;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import graphql.language.Field;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class StoryBlockFieldDataFetcherTest extends UnitTestBase {
+
+    private static final String FIELD_VAR = "subheading";
+
+    private final StoryBlockFieldDataFetcher fetcher = new StoryBlockFieldDataFetcher();
+
+    private DataFetchingEnvironment environmentWith(final Object fieldValue) {
+        final Contentlet contentlet = new Contentlet();
+        contentlet.setIdentifier("test-identifier");
+        if (fieldValue != null) {
+            contentlet.getMap().put(FIELD_VAR, fieldValue);
+        }
+
+        final DataFetchingEnvironment environment = mock(DataFetchingEnvironment.class);
+        when(environment.getSource()).thenReturn(contentlet);
+        when(environment.getField()).thenReturn(Field.newField(FIELD_VAR).build());
+        return environment;
+    }
+
+    /**
+     * Page queries: the transformer ({@code StoryBlockViewStrategy}) has already hydrated the
+     * field into a Map. The fetcher must resolve it from the Map instead of round-tripping it
+     * through {@code Map.toString()}.
+     */
+    @Test
+    public void mapValue_isResolvedWithoutStringRoundTrip() throws Exception {
+        final Map<String, Object> hydrated = new LinkedHashMap<>();
+        hydrated.put("type", "doc");
+        hydrated.put("content", List.of(Map.of(
+                "type", "paragraph",
+                "text", "Run your entire digital ecosystem - securely, visually, and without the chaos. https://dotcms.com")));
+
+        final Map<String, Object> result = fetcher.get(environmentWith(hydrated));
+
+        assertNotNull(result);
+        assertEquals(hydrated, result.get("json"));
+        assertNotSame("toMap must return a defensive copy of the hydrated value", hydrated, result.get("json"));
+    }
+
+    /**
+     * Collection queries: the field still holds its stored JSON String. Text containing commas,
+     * colons and URLs must parse correctly.
+     */
+    @Test
+    public void jsonStringValue_withCommasAndUrls_isParsed() throws Exception {
+        final String json = "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"href\":\"https://dotcms.com/path?a=1&b=2\"},"
+                + "\"text\":\"Securely, visually, and without the chaos; also: [brackets] {braces} \\\"quotes\\\" = # signs\"}]}";
+
+        final Map<String, Object> result = fetcher.get(environmentWith(json));
+
+        assertNotNull(result);
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> parsed = (Map<String, Object>) result.get("json");
+        assertEquals("doc", parsed.get("type"));
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> paragraph = (Map<String, Object>) ((List<Object>) parsed.get("content")).get(0);
+        assertEquals("Securely, visually, and without the chaos; also: [brackets] {braces} \"quotes\" = # signs",
+                paragraph.get("text"));
+        assertEquals("https://dotcms.com/path?a=1&b=2",
+                ((Map<?, ?>) paragraph.get("attrs")).get("href"));
+    }
+
+    /**
+     * A malformed value (e.g. the Java {@code Map.toString()} notation that used to reach the
+     * legacy parser) must degrade gracefully: the field resolves to null, no exception thrown.
+     */
+    @Test
+    public void malformedValue_resolvesToNull() throws Exception {
+        final String javaMapNotation = "{type=doc, content=[{type=paragraph, text=Run your entire digital ecosystem - securely, visually}]}";
+
+        assertNull(fetcher.get(environmentWith(javaMapNotation)));
+    }
+
+    @Test
+    public void nullValue_resolvesToNull() throws Exception {
+        assertNull(fetcher.get(environmentWith(null)));
+    }
+
+    @Test
+    public void blankValue_resolvesToNull() throws Exception {
+        assertNull(fetcher.get(environmentWith("  ")));
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
@@ -65,7 +65,7 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotcms.graphql.datafetcher.page.RunningExperimentFetcherTest.class,
         com.dotcms.graphql.datafetcher.CategoryFieldDataFetcherTest.class,
         com.dotcms.graphql.datafetcher.FolderCollectionDataFetcherTest.class,
-        com.dotcms.graphql.datafetcher.StoryBlockFieldDataFetcherTest.class,
+        com.dotcms.graphql.datafetcher.StoryBlockFieldDataFetcherIntegrationTest.class,
         com.dotcms.rest.TagResourceIntegrationTest.class,
         com.dotcms.rest.api.v2.tags.TagResourceIntegrationTest.class,
         com.dotcms.rest.MapToContentletPopulatorTest.class,

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
@@ -65,6 +65,7 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotcms.graphql.datafetcher.page.RunningExperimentFetcherTest.class,
         com.dotcms.graphql.datafetcher.CategoryFieldDataFetcherTest.class,
         com.dotcms.graphql.datafetcher.FolderCollectionDataFetcherTest.class,
+        com.dotcms.graphql.datafetcher.StoryBlockFieldDataFetcherTest.class,
         com.dotcms.rest.TagResourceIntegrationTest.class,
         com.dotcms.rest.api.v2.tags.TagResourceIntegrationTest.class,
         com.dotcms.rest.MapToContentletPopulatorTest.class,

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
@@ -2,7 +2,6 @@ package com.dotcms.graphql.datafetcher;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.dotcms.contenttype.model.field.Field;
@@ -191,16 +190,48 @@ public class StoryBlockFieldDataFetcherIntegrationTest {
 
     /**
      * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
-     * Given Scenario: the field holds a value that cannot be resolved into JSON.
-     * ExpectedResult: the field resolves to null and no exception is thrown, so a single bad
-     * field cannot fail the whole GraphQL query (see #36297).
+     * Given Scenario: a contentlet whose Block Editor field holds a legacy non-JSON value — HTML
+     * from a WYSIWYG field later converted to Block Editor, persisted before the save-path
+     * conversion introduced in #36473.
+     * ExpectedResult: the stored value is returned unchanged on both read paths — the read path
+     * never reshapes stored data, matching what _map and the Page REST API return.
      */
     @Test
-    public void malformedValue_resolvesToNullWithoutFailing() throws Exception {
-        final Contentlet contentlet = persistContentlet(STORY_BLOCK_JSON);
-        contentlet.getMap().put(storyBlockField.variable(),
-                "{type=doc, content=[{type=paragraph, text=securely, visually}]}");
+    public void legacyHtmlValue_isPassedThroughUnchangedOnBothPaths() throws Exception {
+        final String legacyHtml = "<p>Save 20% today, <a href=\"https://dotcms.com/offer\">see details</a></p>";
+        final Contentlet persisted = persistContentlet(STORY_BLOCK_JSON);
+        // Simulate the legacy row: bypass the save-path HTML→JSON conversion (#36473)
+        persisted.getMap().put(storyBlockField.variable(), legacyHtml);
 
-        assertNull(new StoryBlockFieldDataFetcher().get(environmentFor(contentlet)));
+        final Map<String, Object> rawResult =
+                new StoryBlockFieldDataFetcher().get(environmentFor(persisted));
+        assertNotNull(rawResult);
+        assertEquals(legacyHtml, rawResult.get("json"));
+
+        final Contentlet hydrated = new DotTransformerBuilder()
+                .defaultOptions().content(persisted).build().hydrate().get(0);
+        final Map<String, Object> hydratedResult =
+                new StoryBlockFieldDataFetcher().get(environmentFor(hydrated));
+        assertNotNull(hydratedResult);
+        assertEquals(legacyHtml, hydratedResult.get("json"));
+    }
+
+    /**
+     * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
+     * Given Scenario: the field holds a value that merely looks like JSON but is not (Java
+     * Map.toString() notation, which used to crash the legacy parser).
+     * ExpectedResult: passed through unchanged — never an exception, never a dropped field
+     * (see #36297).
+     */
+    @Test
+    public void malformedValue_isPassedThroughWithoutFailing() throws Exception {
+        final String javaMapNotation = "{type=doc, content=[{type=paragraph, text=securely, visually}]}";
+        final Contentlet contentlet = persistContentlet(STORY_BLOCK_JSON);
+        contentlet.getMap().put(storyBlockField.variable(), javaMapNotation);
+
+        final Map<String, Object> result =
+                new StoryBlockFieldDataFetcher().get(environmentFor(contentlet));
+        assertNotNull(result);
+        assertEquals(javaMapNotation, result.get("json"));
     }
 }

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
@@ -38,7 +38,7 @@ import org.mockito.Mockito;
  * Both paths must return the same JSON structure for content whose text contains commas, colons
  * and hyperlinks (see issue #37087).
  */
-public class StoryBlockFieldDataFetcherTest {
+public class StoryBlockFieldDataFetcherIntegrationTest {
 
     private static final String STORY_BLOCK_JSON =
             "{"

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
@@ -163,14 +163,17 @@ public class StoryBlockFieldDataFetcherIntegrationTest {
 
     /**
      * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
-     * Given Scenario: a contentlet whose Block Editor field is empty (stored as an empty String).
+     * Given Scenario: a contentlet whose Block Editor field has no value (never set, so it reads
+     * as null — the shape GraphQL collection queries see for empty content).
      * ExpectedResult: the field resolves to an empty json object — the existing contract pinned
      * by the GraphQLTests postman collection ("Get Content With Empty StoryBlock via GraphQL") —
      * on both the raw and the hydrated read paths.
      */
     @Test
     public void emptyValue_resolvesToEmptyJsonObject() throws Exception {
-        final Contentlet persisted = persistContentlet("");
+        final Contentlet persisted = new ContentletDataGen(storyBlockType.id())
+                .languageId(APILocator.getLanguageAPI().getDefaultLanguage().getId())
+                .nextPersisted();
 
         final Map<String, Object> rawResult =
                 new StoryBlockFieldDataFetcher().get(environmentFor(persisted));

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
@@ -65,6 +65,7 @@ public class StoryBlockFieldDataFetcherIntegrationTest {
                 .nextPersisted();
         storyBlockField = new FieldDataGen()
                 .type(StoryBlockField.class)
+                .defaultValue(null)
                 .contentTypeId(storyBlockType.id())
                 .nextPersisted();
     }

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherIntegrationTest.java
@@ -163,6 +163,30 @@ public class StoryBlockFieldDataFetcherIntegrationTest {
 
     /**
      * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
+     * Given Scenario: a contentlet whose Block Editor field is empty (stored as an empty String).
+     * ExpectedResult: the field resolves to an empty json object — the existing contract pinned
+     * by the GraphQLTests postman collection ("Get Content With Empty StoryBlock via GraphQL") —
+     * on both the raw and the hydrated read paths.
+     */
+    @Test
+    public void emptyValue_resolvesToEmptyJsonObject() throws Exception {
+        final Contentlet persisted = persistContentlet("");
+
+        final Map<String, Object> rawResult =
+                new StoryBlockFieldDataFetcher().get(environmentFor(persisted));
+        assertNotNull(rawResult);
+        assertEquals(Map.of(), rawResult.get("json"));
+
+        final Contentlet hydrated = new DotTransformerBuilder()
+                .defaultOptions().content(persisted).build().hydrate().get(0);
+        final Map<String, Object> hydratedResult =
+                new StoryBlockFieldDataFetcher().get(environmentFor(hydrated));
+        assertNotNull(hydratedResult);
+        assertEquals(Map.of(), hydratedResult.get("json"));
+    }
+
+    /**
+     * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
      * Given Scenario: the field holds a value that cannot be resolved into JSON.
      * ExpectedResult: the field resolves to null and no exception is thrown, so a single bad
      * field cannot fail the whole GraphQL query (see #36297).

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/StoryBlockFieldDataFetcherTest.java
@@ -1,0 +1,178 @@
+package com.dotcms.graphql.datafetcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.StoryBlockField;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.FieldDataGen;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.transform.DotContentletTransformer;
+import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+import java.util.Map;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Integration tests for {@link StoryBlockFieldDataFetcher}.
+ * <p>
+ * Covers the two read paths a typed Block Editor GraphQL field can take:
+ * <ul>
+ *     <li><b>Page queries</b>: {@code PageRenderUtil} hydrates contentlets with
+ *     {@code DotTransformerBuilder().defaultOptions()}, so {@code StoryBlockViewStrategy} has
+ *     already turned the field's JSON String into a Map before the fetcher runs.</li>
+ *     <li><b>Collection queries</b>: the contentlet is raw and the field still holds its stored
+ *     JSON String.</li>
+ * </ul>
+ * Both paths must return the same JSON structure for content whose text contains commas, colons
+ * and hyperlinks (see issue #37087).
+ */
+public class StoryBlockFieldDataFetcherTest {
+
+    private static final String STORY_BLOCK_JSON =
+            "{"
+            + "\"type\":\"doc\","
+            + "\"content\":["
+            + "  {\"type\":\"paragraph\",\"content\":["
+            + "    {\"type\":\"text\",\"text\":\"Run your entire digital ecosystem - securely, visually, and without the chaos. \"},"
+            + "    {\"type\":\"text\",\"marks\":[{\"type\":\"link\",\"attrs\":{\"href\":\"https://dotcms.com/product\",\"target\":\"_blank\"}}],\"text\":\"Learn more, here\"}"
+            + "  ]}"
+            + "]"
+            + "}";
+
+    private static ContentType storyBlockType;
+    private static Field storyBlockField;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+
+        final long timestamp = System.currentTimeMillis();
+        storyBlockType = new ContentTypeDataGen()
+                .name("storyBlockFetcher" + timestamp)
+                .velocityVarName("storyBlockFetcher" + timestamp)
+                .nextPersisted();
+        storyBlockField = new FieldDataGen()
+                .type(StoryBlockField.class)
+                .contentTypeId(storyBlockType.id())
+                .nextPersisted();
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        if (storyBlockType != null) {
+            ContentTypeDataGen.remove(storyBlockType);
+        }
+    }
+
+    private static Contentlet persistContentlet(final String storyBlockValue) {
+        return new ContentletDataGen(storyBlockType.id())
+                .languageId(APILocator.getLanguageAPI().getDefaultLanguage().getId())
+                .setProperty(storyBlockField.variable(), storyBlockValue)
+                .nextPersisted();
+    }
+
+    private static DataFetchingEnvironment environmentFor(final Contentlet contentlet) {
+        final DataFetchingEnvironment environment = Mockito.mock(DataFetchingEnvironment.class);
+        Mockito.when(environment.getSource()).thenReturn(contentlet);
+        Mockito.when(environment.getField())
+                .thenReturn(graphql.language.Field.newField(storyBlockField.variable()).build());
+        return environment;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertStoryBlockJson(final Map<String, Object> result) {
+        assertNotNull(result);
+        final Map<String, Object> json = (Map<String, Object>) result.get("json");
+        assertNotNull("The 'json' entry must be present", json);
+        assertEquals("doc", json.get("type"));
+
+        final Map<String, Object> paragraph =
+                (Map<String, Object>) ((List<Object>) json.get("content")).get(0);
+        final List<Map<String, Object>> textNodes = (List<Map<String, Object>>) paragraph.get("content");
+        assertEquals("Run your entire digital ecosystem - securely, visually, and without the chaos. ",
+                textNodes.get(0).get("text"));
+        assertEquals("Learn more, here", textNodes.get(1).get("text"));
+
+        final Map<String, Object> linkMark =
+                ((List<Map<String, Object>>) textNodes.get(1).get("marks")).get(0);
+        assertEquals("link", linkMark.get("type"));
+        assertEquals("https://dotcms.com/product",
+                ((Map<String, Object>) linkMark.get("attrs")).get("href"));
+    }
+
+    /**
+     * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
+     * Given Scenario: a contentlet hydrated through {@code DotTransformerBuilder().defaultOptions()}
+     * — exactly what {@code PageRenderUtil} does for page GraphQL queries — whose Block Editor
+     * content includes commas and a hyperlink. The field value reaching the fetcher is a Map.
+     * ExpectedResult: the field resolves to its correct JSON structure instead of failing with a
+     * JSONException from parsing {@code Map.toString()}.
+     */
+    @Test
+    public void pagePath_hydratedContentletWithCommasAndLink_returnsJson() throws Exception {
+        final Contentlet persisted = persistContentlet(STORY_BLOCK_JSON);
+
+        final DotContentletTransformer transformer = new DotTransformerBuilder()
+                .defaultOptions().content(persisted).build();
+        final Contentlet hydrated = transformer.hydrate().get(0);
+        assertTrue("Precondition: defaultOptions must hydrate the field into a Map",
+                hydrated.get(storyBlockField.variable()) instanceof Map);
+
+        final Map<String, Object> result =
+                new StoryBlockFieldDataFetcher().get(environmentFor(hydrated));
+
+        assertStoryBlockJson(result);
+    }
+
+    /**
+     * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
+     * Given Scenario: a raw contentlet — the shape GraphQL collection queries resolve — whose
+     * Block Editor field still holds its stored JSON String.
+     * ExpectedResult: the field resolves to the same JSON structure as the page path.
+     */
+    @Test
+    public void collectionPath_rawContentlet_returnsSameJsonAsPagePath() throws Exception {
+        final Contentlet persisted = persistContentlet(STORY_BLOCK_JSON);
+        assertTrue("Precondition: the raw contentlet must hold the field as a String",
+                persisted.get(storyBlockField.variable()) instanceof String);
+
+        final Map<String, Object> rawResult =
+                new StoryBlockFieldDataFetcher().get(environmentFor(persisted));
+        assertStoryBlockJson(rawResult);
+
+        final Contentlet hydrated = new DotTransformerBuilder()
+                .defaultOptions().content(persisted).build().hydrate().get(0);
+        final Map<String, Object> hydratedResult =
+                new StoryBlockFieldDataFetcher().get(environmentFor(hydrated));
+
+        assertEquals("Both read paths must resolve to the same JSON",
+                hydratedResult.get("json"), rawResult.get("json"));
+    }
+
+    /**
+     * MethodToTest {@link StoryBlockFieldDataFetcher#get(DataFetchingEnvironment)}
+     * Given Scenario: the field holds a value that cannot be resolved into JSON.
+     * ExpectedResult: the field resolves to null and no exception is thrown, so a single bad
+     * field cannot fail the whole GraphQL query (see #36297).
+     */
+    @Test
+    public void malformedValue_resolvesToNullWithoutFailing() throws Exception {
+        final Contentlet contentlet = persistContentlet(STORY_BLOCK_JSON);
+        contentlet.getMap().put(storyBlockField.variable(),
+                "{type=doc, content=[{type=paragraph, text=securely, visually}]}");
+
+        assertNull(new StoryBlockFieldDataFetcher().get(environmentFor(contentlet)));
+    }
+}


### PR DESCRIPTION
Fixes #37087 · Related: #36297

GraphQL **page** queries returned `null` + `Internal Server Error` for any Block Editor field containing a comma, URL, or most punctuation. Collection queries and `_map` worked on the same content, so it was historically misdiagnosed as content corruption.

### Before

Page rendering hydrates the field into a `Map`; the fetcher assumed a JSON `String` and parsed `Map.toString()` — Java map notation — with the legacy json.org parser.

```mermaid
flowchart LR
    page["page query"] --> hydrate["PageRenderUtil<br/>field → Map"] --> fetcher
    coll["collection query"] --> raw["field → JSON String"] --> fetcher
    fetcher["fetcher<br/>getStringProperty()"] --> legacy["legacy json.org parser"]
    legacy -->|"String"| ok["✅ JSON"]
    legacy -->|"Map.toString()<br/>not JSON"| boom["❌ JSONException<br/>Internal Server Error"]
    style boom fill:#cf222e,color:#fff
```

### After

One path: `StoryBlockAPI.toMap()` is the canonical conversion — accepts both shapes, legacy parser removed.

```mermaid
flowchart LR
    page["page query"] --> hydrate["field → Map"] --> toMap
    coll["collection query"] --> raw["field → JSON String"] --> toMap
    toMap["StoryBlockAPI.toMap()<br/>one canonical conversion"] --> ok["✅ identical JSON<br/>on both paths"]
    toMap -->|"non-JSON string<br/>(legacy WYSIWYG, pseudo-JSON)"| raw["passed through unchanged<br/>same as _map"]
    toMap -->|"missing / empty"| empty["json = empty object<br/>unchanged contract"]
    style toMap fill:#1a7f37,color:#fff
```

### Tests

* **Unit (8):** `StoryBlockAPIImplToMapTest` — Map copied (never `toString()`-parsed), String parsed, map-notation rejected. `StoryBlockFieldDataFetcherTest` — page path, collection path with commas/URLs/brackets/quotes, non-JSON strings (legacy HTML, pseudo-JSON) passed through unchanged; missing/empty → `json: {}` (existing postman contract).
* **Integration (5, `MainSuite1b`):** `StoryBlockFieldDataFetcherIntegrationTest` — persists content with commas + a hyperlink, hydrates via `DotTransformerBuilder().defaultOptions()` (the `PageRenderUtil` transform), asserts both read paths return identical JSON; a never-set field resolves to `json: {}`, and legacy HTML / pseudo-JSON values pass through unchanged, on both paths.

### Checklist
- [x] Tests
- [x] Security Implications Contemplated (malformed values degrade to `null` + WARN; no internal errors surfaced)

### Notes

* Rollback-safe: no DB/ES/API contract changes; `DotStoryBlock.json` scalar shape unchanged.
* `refreshStoryBlockValueReferences` still skips Map values at its `isJsonObject` gate (pre-existing); with `toMap` Map-tolerant, fixing it is a one-line follow-up.
* Integration tests compile locally, execute in CI (requires license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- system-recap:start -->

<details>
<summary>System recap — <b>extends a primitive's contract</b> (medium risk)</summary>

**Mode:** recap · **Base:** `main` @ `1de0886` · **Head:** `1ba263b`

**Classification:** extends — `StoryBlockAPI.toMap(Object)` widens its accepted input (JSON String **or** hydrated Map) and becomes the single canonical Block Editor conversion; the GraphQL fetcher is rewired to compose it. No new primitives. (Note: this repo has no `docs/contributing/architecture/primitives.yaml`; component names below are descriptive.)

### Primitives touched

| Primitive | Group | Impact |
| --- | --- | --- |
| `story-block-api` | content | extends — `toMap()` accepts Map or JSON String; defensive copy for Maps |
| `graphql-storyblock-fetcher` | surfaces | composes — reads via `contentlet.get()`, delegates to `toMap()`; legacy json.org parser removed; malformed → `null` + WARN |

### System map

```mermaid
flowchart LR
	pageQuery["GraphQL page query"]:::untouched
	collectionQuery["GraphQL collection query"]:::untouched
	pageRenderUtil["PageRenderUtil + StoryBlockViewStrategy<br/>(hydrates field → Map)"]:::untouched
	fetcher["StoryBlockFieldDataFetcher"]:::touched
	storyBlockAPI["StoryBlockAPI.toMap()"]:::extended
	legacyParser["legacy json.org JSONObject"]:::untouched
	pageQuery --> pageRenderUtil --> fetcher
	collectionQuery --> fetcher
	fetcher --> storyBlockAPI
	fetcher -. removed .-> legacyParser
	classDef touched fill:#1a7f37,color:#fff
	classDef extended fill:#9a6700,color:#fff
	classDef added fill:#cf222e,color:#fff
	classDef untouched fill:#57606a,color:#fff
```

### Change flow

```mermaid
sequenceDiagram
	participant Q as GraphQL query
	participant F as StoryBlockFieldDataFetcher
	participant A as StoryBlockAPI.toMap()
	Q->>F: resolve typed StoryBlock field
	F->>F: contentlet.get(variable)
	alt value is Map (page path)
		F->>A: toMap(Map)
		A-->>F: defensive LinkedHashMap copy
	else value is JSON String (collection path)
		F->>A: toMap(String)
		A-->>F: Jackson-parsed LinkedHashMap
	else value missing or blank
		F-->>Q: json = empty object (unchanged contract)
	else non-JSON string (legacy WYSIWYG, pseudo-JSON)
		F-->>Q: json = stored value unchanged (same as _map)
	end
	F-->>Q: { json: <map> }
```

### Before / after

| | Before | After |
| --- | --- | --- |
| Page query, text with `,` `:` URLs | `null` + `Internal Server Error` (`JSONException`) | correct JSON |
| Collection query | correct JSON | correct JSON (unchanged, now same code path) |
| Legacy non-JSON value (converted WYSIWYG) | query-level error | passed through unchanged, query succeeds |
| GraphQL schema (`DotStoryBlock.json`) | `ExtendedScalars.Json` | unchanged |

</details>

<!-- system-recap:end -->







