### PR TITLE
fix(uve): stop deriving injection indices from a lowercased copy of the page HTML (#37072)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImpl.java
@@ -43,15 +43,16 @@ import com.dotmarketing.portlets.rules.model.Rule.FireOn;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UUIDUtil;
+import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Set;
 
@@ -64,6 +65,16 @@ import java.util.Set;
 public class HTMLPageAssetRenderedAPIImpl implements HTMLPageAssetRenderedAPI {
 
     public static final String HTML_HEAD = "<head>";
+
+    /**
+     * Matches the opening {@code <head>} tag case-insensitively against the <b>original</b> HTML,
+     * for the same reason as {@code CLOSING_BODY_TAG_PATTERN} in
+     * {@link HTMLPageAssetRenderedBuilder} — an index taken from a lowercased copy is not valid
+     * against the source string, because some code points lowercase to more than one char
+     * (e.g. {@code İ} U+0130 -> {@code i} + U+0307). See #37072.
+     */
+    private static final Pattern OPENING_HEAD_TAG_PATTERN =
+            Pattern.compile(Pattern.quote(HTML_HEAD), Pattern.CASE_INSENSITIVE);
 
     // Matches either the full UVE script block (init function + <script src> with onload)
     // or the plain SDK script tag injected when no schemas are found.
@@ -350,14 +361,17 @@ public class HTMLPageAssetRenderedAPIImpl implements HTMLPageAssetRenderedAPI {
 
     }
 
-    private String injectJSCode(final String pageHTML, final String JsCode) {
+    private String injectJSCode(final String pageHTML, final String jsCode) {
 
-        if (StringUtils.containsIgnoreCase(pageHTML, HTML_HEAD)) {
-            final int indexOf = pageHTML.toLowerCase().indexOf(HTML_HEAD);
-            return pageHTML.substring(0, indexOf + HTML_HEAD.length()) + JsCode + pageHTML.substring(indexOf + 6);
-        } else {
-            return JsCode + "\n" + pageHTML;
+        if (!UtilMethods.isSet(pageHTML)) {
+            return jsCode;
         }
+        final Matcher headMatcher = OPENING_HEAD_TAG_PATTERN.matcher(pageHTML);
+        if (headMatcher.find()) {
+            final int headTagEnd = headMatcher.end();
+            return pageHTML.substring(0, headTagEnd) + jsCode + pageHTML.substring(headTagEnd);
+        }
+        return jsCode + "\n" + pageHTML;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/HTMLPageAssetRenderedBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/HTMLPageAssetRenderedBuilder.java
@@ -49,6 +49,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -96,6 +98,15 @@ public class HTMLPageAssetRenderedBuilder {
      * Prefix of the inline init function — referenced by {@code UVE_SCRIPT_BLOCK_PATTERN} in HTMLPageAssetRenderedAPIImpl.
      */
     public static final String UVE_INIT_FUNCTION_PREFIX = "<script>function initDotUVE()";
+
+    /**
+     * Matches the closing {@code </body>} tag case-insensitively against the <b>original</b> HTML.
+     * Deriving the index from a {@code toLowerCase()} copy is unsafe: some code points lowercase to
+     * more than one char (e.g. {@code İ} U+0130 -> {@code i} + U+0307), which shifts every
+     * subsequent index in the copy relative to the original. See #37072.
+     */
+    private static final Pattern CLOSING_BODY_TAG_PATTERN =
+            Pattern.compile("</body>", Pattern.CASE_INSENSITIVE);
 
     /**
      * Creates an instance of this Builder, along with all the required dotCMS APIs.
@@ -459,7 +470,11 @@ public class HTMLPageAssetRenderedBuilder {
         Logger.debug(this, () -> styleEditorScript.isPresent()
                 ? "Injecting UVE script with style editor schemas"
                 : "Injecting plain UVE script (no style editor schemas found)");
-        final int closingBodyIndex = html.toLowerCase().lastIndexOf("</body>");
+        final Matcher closingBodyMatcher = CLOSING_BODY_TAG_PATTERN.matcher(html);
+        int closingBodyIndex = -1;
+        while (closingBodyMatcher.find()) {
+            closingBodyIndex = closingBodyMatcher.start();
+        }
         if (closingBodyIndex != -1) {
             return html.substring(0, closingBodyIndex) + scripts + html.substring(closingBodyIndex);
         }

--- a/dotCMS/src/test/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImplTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/portlets/htmlpageasset/business/render/HTMLPageAssetRenderedAPIImplTest.java
@@ -27,9 +27,14 @@ import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -258,5 +263,84 @@ public class HTMLPageAssetRenderedAPIImplTest {
                 hTMLPageAssetRenderedAPIImpl.getDefaultEditPageMode(user, request, pageUri);
 
         assertEquals(PageMode.ADMIN_MODE, defaultEditPageMode);
+    }
+
+    /**
+     * U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE — lowercases to two chars ({@code i} + U+0307),
+     * so any index taken from a lowercased copy of the HTML is invalid against the original string.
+     * See #37072.
+     */
+    private static final String DOTTED_CAPITAL_I = "İ";
+
+    private static final String JS_CODE = "<script>console.log('injected');</script>";
+
+    /**
+     * Invokes the private {@code injectJSCode(String, String)} method via reflection.
+     */
+    private String invokeInjectJSCode(final String pageHTML, final String jsCode) throws Exception {
+        final Method method = HTMLPageAssetRenderedAPIImpl.class.getDeclaredMethod(
+                "injectJSCode", String.class, String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(hTMLPageAssetRenderedAPIImpl, pageHTML, jsCode);
+    }
+
+    /**
+     * Builds a page whose doctype prelude carries {@code count} occurrences of {@code İ} ahead of
+     * the opening {@code <head>} tag.
+     */
+    private static String htmlWithDottedCapitalIBeforeHead(final int count) {
+        return "<!DOCTYPE html><!-- " + DOTTED_CAPITAL_I.repeat(count)
+                + " --><html lang=\"tr\"><head><title>Test</title></head><body></body></html>";
+    }
+
+    @Test
+    public void testInjectJSCode_shouldInjectAfterHeadWhenHtmlContainsDottedCapitalI() throws Exception {
+        for (final int count : new int[]{1, 7, 9, 14, 20}) {
+            final String result = invokeInjectJSCode(htmlWithDottedCapitalIBeforeHead(count), JS_CODE);
+
+            assertTrue("JS code should be injected immediately after <head> with " + count
+                            + " dotted capital I chars",
+                    result.contains("<head>" + JS_CODE));
+            assertTrue("The <head> tag should remain intact with " + count + " dotted capital I chars",
+                    result.contains("<head>" + JS_CODE + "<title>Test</title></head>"));
+        }
+    }
+
+    @Test
+    public void testInjectJSCode_shouldInjectAfterUpperCaseHeadTag() throws Exception {
+        final String result = invokeInjectJSCode("<html><HEAD><title>Test</title></HEAD></html>", JS_CODE);
+
+        assertTrue("JS code should be injected immediately after <HEAD>",
+                result.contains("<HEAD>" + JS_CODE + "<title>Test</title>"));
+    }
+
+    @Test
+    public void testInjectJSCode_shouldPrependWhenNoHeadTag() throws Exception {
+        final String pageHTML = "<html><body><p>Hello</p></body></html>";
+
+        final String result = invokeInjectJSCode(pageHTML, JS_CODE);
+
+        assertEquals(JS_CODE + "\n" + pageHTML, result);
+    }
+
+    @Test
+    public void testInjectJSCode_shouldReturnJsCodeWhenPageHtmlIsNull() throws Exception {
+        assertEquals(JS_CODE, invokeInjectJSCode(null, JS_CODE));
+    }
+
+    @Test
+    public void testInjectJSCode_shouldProduceIdenticalOutputAcrossDefaultLocales() throws Exception {
+        final Locale originalLocale = Locale.getDefault();
+        try {
+            final Set<String> outputs = new HashSet<>();
+            for (final String languageTag : new String[]{"en", "tr", "lt"}) {
+                Locale.setDefault(Locale.forLanguageTag(languageTag));
+                outputs.add(invokeInjectJSCode(htmlWithDottedCapitalIBeforeHead(9), JS_CODE));
+            }
+            assertEquals("Injection result should not depend on the JVM default locale",
+                    1, outputs.size());
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 }

--- a/dotCMS/src/test/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/HTMLPageAssetRenderedBuilderUVEScriptTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/portlets/htmlpageasset/business/render/page/HTMLPageAssetRenderedBuilderUVEScriptTest.java
@@ -11,7 +11,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -34,6 +37,25 @@ public class HTMLPageAssetRenderedBuilderUVEScriptTest {
 
     private static final String HTML_WITHOUT_BODY =
             "<html><head><title>Test</title></head><p>Hello</p></html>";
+
+    /**
+     * U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE — the one code point (under a non-Turkish
+     * default locale) whose {@code toLowerCase()} form is longer than itself: {@code i} + U+0307.
+     * Any index derived from a lowercased copy of the HTML drifts by one per occurrence. See #37072.
+     */
+    private static final String DOTTED_CAPITAL_I = "İ";
+
+    /** Occurrence counts that mangled the closing tags (1, 9), coincidentally worked (7, 14), or threw (20). */
+    private static final int[] DOTTED_CAPITAL_I_COUNTS = {1, 7, 9, 14, 20};
+
+    /**
+     * Builds a well-formed page whose body carries {@code count} occurrences of {@code İ} ahead of
+     * the closing {@code </body>} tag.
+     */
+    private static String htmlWithDottedCapitalI(final int count) {
+        return "<html><head><title>Test</title></head><body><p>"
+                + DOTTED_CAPITAL_I.repeat(count) + "</p></body></html>";
+    }
 
     /**
      * Creates a builder instance without calling the constructor to avoid
@@ -121,6 +143,92 @@ public class HTMLPageAssetRenderedBuilderUVEScriptTest {
         final int initIdx = result.indexOf(HTMLPageAssetRenderedBuilder.UVE_INIT_FUNCTION_PREFIX);
         final int bodyIdx = result.indexOf("</body>");
         assertTrue("Init function should appear before </body>", initIdx < bodyIdx);
+    }
+
+    /**
+     * The reported defect: the injection index was computed from {@code html.toLowerCase()} and then
+     * used to slice the original string, so every {@code İ} before {@code </body>} pushed the splice
+     * one char too far — into the middle of the closing tags, and eventually past the end of the
+     * string entirely.
+     */
+    @Test
+    public void shouldInjectBeforeClosingBodyWhenHtmlContainsDottedCapitalI() throws Exception {
+        for (final int count : DOTTED_CAPITAL_I_COUNTS) {
+            final String result = invokeInjectUVEScript(
+                    createBuilder(), htmlWithDottedCapitalI(count), Collections.emptyList());
+
+            final int scriptIdx = result.indexOf(HTMLPageAssetRenderedBuilder.SDK_EDITOR_SCRIPT_SOURCE);
+            assertTrue("Script should be injected with " + count + " dotted capital I chars",
+                    scriptIdx != -1);
+            assertTrue("Script should be injected before </body> with " + count + " dotted capital I chars",
+                    scriptIdx < result.indexOf("</body>"));
+            assertTrue("Closing tags should remain intact with " + count + " dotted capital I chars",
+                    result.endsWith("</body></html>"));
+        }
+    }
+
+    /**
+     * Pins the exact symptom from the report: with 9 occurrences the script landed inside
+     * {@code </html>}, leaving {@code </<script ...>} for the parser to swallow as a bogus comment
+     * and a bare {@code html>} text node at the end of the body.
+     */
+    @Test
+    public void shouldNotSplitClosingTagsWithNineDottedCapitalI() throws Exception {
+        final String result = invokeInjectUVEScript(
+                createBuilder(), htmlWithDottedCapitalI(9), Collections.emptyList());
+
+        assertFalse("Closing tags should not be split by the injected script",
+                result.contains("</<script"));
+        assertFalse("No bare 'html>' text node should be emitted",
+                result.contains("></script>html>"));
+    }
+
+    @Test
+    public void shouldInjectBeforeUpperCaseClosingBodyTag() throws Exception {
+        final String result = invokeInjectUVEScript(
+                createBuilder(), "<html><BODY><p>Hello</p></BODY></html>", Collections.emptyList());
+
+        final int scriptIdx = result.indexOf(HTMLPageAssetRenderedBuilder.SDK_EDITOR_SCRIPT_SOURCE);
+        assertTrue("Script should be injected for an upper-case closing body tag", scriptIdx != -1);
+        assertTrue("Script should be injected before </BODY>", scriptIdx < result.indexOf("</BODY>"));
+    }
+
+    /**
+     * The original implementation used {@code lastIndexOf}; the replacement must keep picking the
+     * last occurrence rather than the first.
+     */
+    @Test
+    public void shouldInjectBeforeTheLastClosingBodyTag() throws Exception {
+        final String html = "<html><body><p>first</body><p>second</body></html>";
+
+        final String result = invokeInjectUVEScript(createBuilder(), html, Collections.emptyList());
+
+        final int scriptIdx = result.indexOf(HTMLPageAssetRenderedBuilder.SDK_EDITOR_SCRIPT_SOURCE);
+        assertTrue("Script should be injected after the first </body>",
+                scriptIdx > result.indexOf("</body>"));
+        assertTrue("Closing tags should remain intact", result.endsWith("</body></html>"));
+    }
+
+    /**
+     * {@code String.toLowerCase()} with no argument uses {@code Locale.getDefault()}, and the set of
+     * code points that grow when lowercased is locale-dependent (none under {@code tr}, four under
+     * {@code lt}). The injection result must not depend on the JVM default locale.
+     */
+    @Test
+    public void shouldProduceIdenticalOutputAcrossDefaultLocales() throws Exception {
+        final Locale originalLocale = Locale.getDefault();
+        try {
+            final Set<String> outputs = new HashSet<>();
+            for (final String languageTag : new String[]{"en", "tr", "lt"}) {
+                Locale.setDefault(Locale.forLanguageTag(languageTag));
+                outputs.add(invokeInjectUVEScript(
+                        createBuilder(), htmlWithDottedCapitalI(9), Collections.emptyList()));
+            }
+            assertEquals("Injection result should not depend on the JVM default locale",
+                    1, outputs.size());
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 
 }


### PR DESCRIPTION
### Proposed Changes

Fixes #37072 — the UVE editor script was spliced into the middle of the closing tags on any page whose rendered HTML contains `İ` (U+0130), silently killing the page editor.

* **`HTMLPageAssetRenderedBuilder.injectUVEScript`** — locate `</body>` with a case-insensitive `Pattern` matched against the **original** HTML instead of `html.toLowerCase().lastIndexOf(...)`. Last-occurrence semantics preserved.
* **`HTMLPageAssetRenderedAPIImpl.injectJSCode`** — same correction against `<head>`. Also collapses a redundant double scan (`containsIgnoreCase` then `indexOf`) into one `Matcher.find()`, derives the trailing offset from `matcher.end()` instead of a hard-coded `6`, and guards a null page (previously produced the literal string `"…\nnull"`).
* Unit tests for U+0130 at 1 / 7 / 9 / 14 / 20 occurrences on both methods, plus mixed-case tags, last-of-multiple `</body>`, and locale-independence across `en` / `tr` / `lt`.

### Root cause

Both methods computed an index from `html.toLowerCase()` and then used it to slice the **original** string. That is only correct when lowercasing preserves length.

`İ` (U+0130) lowercases to **two** chars — `i` + U+0307 COMBINING DOT ABOVE — so every occurrence ahead of the anchor pushed the splice one position too far. This is a case-mapping issue, not a byte-encoding one: Java `String` indices are UTF-16 code units and `İ` is a single `char`, but `String.toLowerCase()` implements Unicode's *full* case mappings from `SpecialCasing.txt`, which may change length.

With 9 occurrences the emitted tail was:

```html
...</body></<script src="/ext/uve/dot-uve.js"></script>html>
```

The parser sees `</` followed by `<`, treats it as a bogus comment per spec, and swallows the entire script tag — so `window.dotUVE` never initializes. No console error, no failed request, no log entry. Past ~15 occurrences the shifted index exceeds the string length and `substring` throws `StringIndexOutOfBoundsException` → HTTP 500.

An exhaustive scan of all 1,114,112 code points confirms the trigger set and why it must not be special-cased — it is locale-dependent:

| Default locale | Code points whose `toLowerCase()` grows |
|---|---|
| `tr`, `az` | none — `İ` maps to a single `i`, bug does not fire |
| `lt` | `İ`, plus `Ì`, `Í`, `Ĩ` → 3 chars each |
| all others | `İ` only |

The fix removes the transformed-copy indirection entirely rather than filtering characters, so it is locale-independent by construction.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (see notes)

### Additional Info

**Testing.** `HTMLPageAssetRenderedBuilderUVEScriptTest` + `HTMLPageAssetRenderedAPIImplTest` — 21/21 pass. The 6 new behavioral tests were verified **failing against the pre-fix code** (stash the main sources, re-run) and passing after, so they genuinely pin the defect rather than the implementation. The locale test is the sharpest: pre-fix it reported `expected:<1> but was:<2>`, i.e. the old code produced different HTML under `tr` than under `en`/`lt` for identical input.

```
./mvnw test -pl :dotcms-core -Dmaven.build.cache.enabled=false \
  -Dtest=HTMLPageAssetRenderedBuilderUVEScriptTest,HTMLPageAssetRenderedAPIImplTest
```

**Existing integration coverage** (not run locally — will be exercised by the suite runs): `HTMLPageAssetRenderedAPIImplIntegrationTest` (`MainSuite3a`) covers both call sites, including `injectJSCodeWithHead`, which asserts exact string equality on the `<head>` insertion point. `PageResourceTest` and `HTMLPageAssetRenderedTest` (`MainSuite1b`) assert on `SDK_EDITOR_SCRIPT_SOURCE` in rendered output. None of them exercise non-ASCII input, which is why the regression coverage was added at the unit layer.

**On the magic `6`.** The old code's two offsets were `indexOf + HTML_HEAD.length()` and `indexOf + 6`; since `"<head>".length() == 6` these were always identical for ASCII input. The duplication was latent, not an active bug — removing it is a readability fix. The only behavioral changes in `injectJSCode` are the Unicode correction and the null guard.

**Behavior changes worth reviewer attention.** `injectJSCode` now returns just the JS code for null/empty input rather than `jsCode + "\n" + null`; the parameter was renamed `JsCode` → `jsCode`.

**Deliberately unchanged.** The patterns match `</body>` / `<head>` exactly, so `</body >` with whitespace still falls through to append-at-end exactly as today. Broadening to `\s*` would be a behavior change beyond this defect — happy to fold it in if reviewers want it.

**Out of scope.** The other `toLowerCase().indexOf()` call sites in core (`DotCMSMacroWebAPI`, `UserAjax`, `AjaxDirectorServlet`, `InodeFactory`, `MysqlQueryTokenizer`) use the result only as a boolean test and never slice the original string. They are correct as written and were left alone.

**Security.** No auth, encryption, schema, dependency, or public-API surface touched; both methods are private. No change to escaping or to what gets injected — only to *where* it lands.

**Not verified by automated tests.** The acceptance criteria requiring a live editor — drop targets present, contentlet draggable from the palette, `typeof window.dotUVE === "object"` in the `about:srcdoc` iframe — need a manual UVE pass on a page carrying `İ`. Unit tests can only prove the script lands before an intact `</body>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37072