### PR TITLE
docs(speckit): add a Spec-Kit quick start for developers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@ When editing ANY code, improve incrementally:
 ## Spec-Driven Development (Spec-Kit)
 
 This repo uses [GitHub Spec-Kit](https://github.com/github/spec-kit) for spec-driven work,
-customized for dotCMS. Full details + upgrade re-apply notes: [.specify/CUSTOMIZATIONS.md](.specify/CUSTOMIZATIONS.md).
+customized for dotCMS. How to run it: [Spec-Kit Quick Start](docs/core/SPEC_KIT_QUICK_START.md).
+How it's built + upgrade re-apply notes: [.specify/CUSTOMIZATIONS.md](.specify/CUSTOMIZATIONS.md).
 
 - **Flow**: `/speckit-specify` (new feature) **or** `/speckit-specify-fix` (issue/bug resolution) → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`.
 - **Constitution**: [.specify/memory/constitution.md](.specify/memory/constitution.md) — legacy-awareness + Critical Rules; loaded by every skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ This repo uses [GitHub Spec-Kit](https://github.com/github/spec-kit) for spec-dr
 customized for dotCMS. How to run it: [Spec-Kit Quick Start](docs/core/SPEC_KIT_QUICK_START.md).
 How it's built + upgrade re-apply notes: [.specify/CUSTOMIZATIONS.md](.specify/CUSTOMIZATIONS.md).
 
-- **Flow**: `/speckit-specify` (new feature) **or** `/speckit-specify-fix` (issue/bug resolution) → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`.
+- **Flow**: `/speckit-specify` (new feature) **or** `/speckit-specify-fix` (issue/bug resolution) → **PR 1 (spec) approved** → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement` → PR 2 (implementation).
+- **Two PRs, gated on approval — not merge**: PR 1 carries `spec.md` **alone** and another dev must **approve** it before `/speckit-plan` runs. Do **not** wait for PR 1 to merge — branch off the spec branch (the spec isn't on `main` yet) and open PR 2 with the implementation. If the spec changes after sign-off, get it re-approved. See [Quick Start §3](docs/core/SPEC_KIT_QUICK_START.md).
 - **Constitution**: [.specify/memory/constitution.md](.specify/memory/constitution.md) — legacy-awareness + Critical Rules; loaded by every skill.
 - **TDD (Principle V, non-negotiable)**: no implementation code before tests are written, **dev-approved**, and confirmed **failing (Red)**. If a test type can't be done, the dev must say so and why. Enforced in the constitution + `tasks-template` `[GATE]` tasks + plan Test Strategy.
 - **ADRs**: live only in the private repo `dotCMS/platform-adrs`. `/speckit-plan` **always consults** relevant ADRs (auto `before_plan` hook → `/speckit-adr-context`, read-only via `gh`). Spec-Kit **never creates ADRs** — it only *proposes* them; ADRs are authored in `platform-adrs` via its `new-adr.sh`.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -303,6 +303,9 @@ Ask Claude *"what skills can help with X?"* if you're unsure.
 
 - Architecture: [`docs/core/ARCHITECTURE_OVERVIEW.md`](docs/core/ARCHITECTURE_OVERVIEW.md)
 - Git workflows: [`docs/core/GIT_WORKFLOWS.md`](docs/core/GIT_WORKFLOWS.md)
+- Spec-driven development (Spec-Kit): [`docs/core/SPEC_KIT_QUICK_START.md`](docs/core/SPEC_KIT_QUICK_START.md)
+  — how we take non-trivial features and bugs from issue to merged code: the spec ships
+  and is reviewed as its own PR before any implementation starts
 - CI/CD: [`docs/core/CICD_PIPELINE.md`](docs/core/CICD_PIPELINE.md)
 - Security: [`docs/core/SECURITY_PRINCIPLES.md`](docs/core/SECURITY_PRINCIPLES.md)
 - Backend (Java/Maven): [`docs/backend/`](docs/backend/) — start with

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Standards that apply to all development:
 - **ARCHITECTURE_OVERVIEW.md** - System architecture and integration points
 - **SECURITY_PRINCIPLES.md** - Security rules and patterns
 - **PROGRESSIVE_ENHANCEMENT.md** - Legacy vs modern pattern guidance
+- **[SPEC_KIT_QUICK_START.md](core/SPEC_KIT_QUICK_START.md)** - Running spec-driven development: sizing the flow, the two-PR review protocol, the TDD and ADR gates
 
 ### `/docs/backend/` - Java/Maven Development
 Backend-specific patterns and standards:

--- a/docs/core/SPEC_KIT_QUICK_START.md
+++ b/docs/core/SPEC_KIT_QUICK_START.md
@@ -313,39 +313,89 @@ If `git add tasks.md` seems to do nothing, this is why.
 |---------|-------------------|
 | `/speckit-clarify` | Tier 2 work — resolve open questions in the spec before planning |
 | `/speckit-checklist` | Tier 2 work — a domain-specific review checklist (security, a11y, performance) |
-| `/speckit-analyze` | Tier 2 work — spec, plan, and tasks have drifted apart; cross-checks them, changes nothing |
-| `/speckit-converge` | You've built ahead of the tasks (or by hand) and want the gap appended to `tasks.md` |
-| `/speckit-taskstoissues` | The work needs to be split across people as GitHub issues |
-| `/speckit-adr-context` | You want an ADR lookup outside the plan phase |
-| `/speckit-constitution` | You're amending project law — rare, and it's a team decision |
+| `/speckit-analyze` | After `/speckit-tasks` — audit spec, plan and tasks against each other |
+| `/speckit-converge` | Code has run ahead of `tasks.md` and you want to know what's left |
+| `/speckit-taskstoissues` | The work needs splitting across people as GitHub issues |
+| `/speckit-adr-context` | An ADR lookup outside the plan phase — usually automatic |
+| `/speckit-constitution` | You're amending project law — rare, and a team decision |
 
-Continuing the Roles API example from §5. They all take plain English; `/speckit-analyze` and
-`/speckit-converge` read the current feature and need no arguments:
+The two spec helpers take plain English. Continuing the Roles API example from §5:
 
 ```
-# Before planning — pin down what the spec left open
-/speckit-clarify pagination defaults, whether filter searches email as well as
-name, and what happens when roleId doesn't exist
+/speckit-clarify pagination defaults, whether filter searches email as well
+as name, and what happens when roleId doesn't exist
 
-# Before planning — the response carries user PII, so review it as such
 /speckit-checklist security: PII exposure, authorization gates, and what an
 unauthenticated or under-privileged caller sees
-
-# Before implementing — did spec, plan and tasks drift apart?
-/speckit-analyze
-
-# After building ahead of the tasks — append whatever is still missing
-/speckit-converge
-
-# Split the work across the team
-/speckit-taskstoissues label them Team : Modernization and link back to #37070
-
-# ADR lookup outside the plan phase
-/speckit-adr-context rest pagination user PII
 ```
 
-`/speckit-constitution` is deliberately absent from that list — amending project law is a team
-decision, not something to try mid-feature.
+The other four are worth explaining properly.
+
+### `/speckit-analyze` — audit the artifacts against each other
+
+Reads `spec.md`, `plan.md`, `tasks.md` and the constitution, then runs six detection passes:
+duplication, ambiguity, underspecification, constitution alignment, **coverage gaps**, and
+inconsistency. Coverage is the one that earns its keep — it maps every task back to a
+requirement and tells you which `FR-###` has no task covering it at all.
+
+Output is a severity-graded findings list (CRITICAL / HIGH / MEDIUM / LOW, capped at 50).
+**Strictly read-only** — it never edits a file. It will offer a remediation plan, but you have
+to approve that before anything acts on it.
+
+Needs `tasks.md` to exist, so it slots between `/speckit-tasks` and `/speckit-implement`.
+
+```
+/speckit-analyze
+```
+
+### `/speckit-converge` — find what the code still doesn't do
+
+Reads the same three artifacts *and the actual codebase*, then classifies every gap it finds:
+
+| Class | Meaning |
+|-------|---------|
+| `missing` | the required work is absent from the code entirely |
+| `partial` | it exists but doesn't yet satisfy the requirement |
+| `contradicts` | the code conflicts with stated intent or a constitution MUST |
+| `unrequested` | code that nothing in the spec, plan, or tasks asked for |
+
+It shows you the graded findings first and writes nothing. Then it **appends** a new
+`## Phase N: Convergence` section to the end of `tasks.md`, numbering from the highest existing
+task ID and putting constitution violations first. Append-only: it never rewrites or deletes
+existing tasks, and it never deletes code — even `unrequested` findings are just surfaced.
+
+Reach for it when the code and the task list have drifted apart: you hand-wrote a chunk, or
+picked up someone else's half-finished branch, and want the gap turned back into tasks
+`/speckit-implement` can finish.
+
+```
+/speckit-converge
+```
+
+### `/speckit-taskstoissues` — one GitHub issue per task
+
+Reads `tasks.md`, checks `git remote`, and refuses outright if the remote isn't GitHub. For each
+task it opens an issue titled `T001: <description>`. Re-running is safe — it scans existing issue
+titles for `T###` and skips any already filed.
+
+> ⚠️ **This needs the GitHub MCP server, which is not configured in this repo.** It calls the MCP
+> `list_issues` / `create_issue` tools, not the `gh` CLI, so today it will not run. Weigh the
+> output before wiring it up, too: *one issue per task* can mean dozens of issues for a single
+> Tier 2 feature. It suits work genuinely being split across people, not routine features.
+
+### `/speckit-adr-context` — look up the binding decisions
+
+You rarely run this yourself: `/speckit-plan` fires it automatically as a `before_plan` hook
+(§7). Run it manually when you want the decisions in hand *before* committing to an approach.
+
+With no arguments it derives keywords from the current spec; with arguments it uses yours. It
+queries `dotCMS/platform-adrs` through `gh`, treats **accepted** ADRs as binding and *proposed*
+ones as directional, and hands `/speckit-plan` a summary for the ADR Alignment gate. Read-only,
+and it never creates, edits, or commits an ADR.
+
+```
+/speckit-adr-context rest pagination user PII
+```
 
 ---
 

--- a/docs/core/SPEC_KIT_QUICK_START.md
+++ b/docs/core/SPEC_KIT_QUICK_START.md
@@ -146,26 +146,31 @@ continues anyway — so a missing grant is silent. Check it now, not later.
 
 ## 5. A worked example — implementing a feature
 
-One feature, all four commands, start to finish. Fixing a bug follows the same shape with a
-different entry command — §6, next.
+Running example: [**#37070**](https://github.com/dotCMS/core/issues/37070) — a new Roles API
+endpoint returning the users directly granted a role. It adds a public REST contract, so by the
+ladder in §2 it's **Tier 2**. Fixing a bug follows the same shape with a different entry
+command — §6, next.
 
 ### `/speckit-specify` — write the contract
 
 ```
-/speckit-specify Add a changelog panel to the site publish dialog so editors
-can see what changed before pushing
+/speckit-specify Add GET /v1/roles/{roleid}/users returning the users directly
+granted a role — paginated, filterable, and carrying emailAddress. Reuse the
+User shape that /v1/users/filter already returns. Inheritance is out of scope:
+clients walk the ancestor chain themselves. Details in dotCMS/core#37070
 ```
 
 Creates a branch and `specs/<n>-<short-name>/spec.md`, then interviews you about anything
-ambiguous. The spec is **what and why** — user stories with priorities, acceptance
-scenarios, success criteria, and a **Legacy Considerations** section. No implementation
-detail.
+ambiguous. The spec is **what and why** — user stories with priorities, acceptance scenarios,
+success criteria, and a **Legacy Considerations** section.
 
-Real example to read before your first run:
-[`specs/36605-changelog-site-publish/spec.md`](../../specs/36605-changelog-site-publish/spec.md)
-— note the directory is named for the **GitHub issue number**, not Spec-Kit's default
-zero-padded `001-`. Working from an issue? Use its number, so the branch matches what
-everyone else is reading (`create-new-feature.sh --help` for `--number` / `--short-name`).
+Keep implementation out of it. *"Returns the users granted this role, with their email"* belongs
+in the spec; *`RoleResource#loadUsersByRoleId`* does not. The bar: a reviewer should be able to
+disagree with the spec without reading any code.
+
+Name the directory for the **GitHub issue number** — `37070-roles-users-endpoint`, not Spec-Kit's
+default zero-padded `001-` — so the branch matches the issue everyone else is reading
+(`create-new-feature.sh --help` for `--number` / `--short-name`).
 
 **Stop here.** Open PR 1 with the spec alone and get it **approved** (§3). Everything below
 happens after that — you don't need to wait for it to merge.
@@ -178,8 +183,13 @@ happens after that — you don't need to wait for it to merge.
 
 Reads your spec and produces `plan.md`: architecture, **Test Strategy**, **Constitution
 Check**, **Legacy Impact**, and **ADR Alignment**. This is where the two automated gates live —
-see §7. Takes optional guidance (`/speckit-plan use the existing WorkflowAPI rather than a new
-service`).
+see §7. Takes optional steering:
+
+```
+/speckit-plan reuse the paginator behind /v1/users/filter rather than adding
+a second one, and gate the endpoint on requiredPortlet("roles") — the payload
+carries user PII
+```
 
 ### `/speckit-tasks` — break it down
 
@@ -204,11 +214,20 @@ stops for your approval, stops again to show you they fail, and only then writes
 
 ## 6. A worked example — fixing a bug
 
-Most bug fixes are Tier 1 — lean flow, no `clarify`/`checklist`/`analyze`.
+Running example: [**#36958**](https://github.com/dotCMS/core/issues/36958) — the
+`Languagevariable` content type is created with `system = false`, so nothing stops anyone
+deleting it, and losing it breaks i18n site-wide.
+
+Most bug fixes are Tier 1. **This one isn't.** The fix ships a startup task that writes to the
+database, which is rollback-unsafe — so by the ladder in §2 it sizes up to Tier 2. *"It's a bug"
+doesn't decide the tier; what the fix touches does.*
 
 ```
-/speckit-specify-fix Site publish dialog shows a stale changelog after a
-second publish — repro in dotCMS/core#12345
+/speckit-specify-fix The Languagevariable content type is created with
+system=false, so the delete guard in ContentTypeFactoryImpl never fires and
+the type can be removed. Losing it breaks i18n site-wide and degrades
+quietly — language variables fall back to emitting the raw key. Full
+analysis, repro and proposed fix in dotCMS/core#36958
 ```
 
 1. **Reproduce it**, then run `/speckit-specify-fix` to write the defect spec: observed vs.
@@ -224,6 +243,12 @@ The spec is defect-framed rather than story-framed: **Problem Statement, Reprodu
 of Investigation, Root-Cause Hypothesis, Fix Scope & Non-Goals, Regression Risk, Acceptance &
 Verification**. *Fix Scope & Non-Goals* is the one that earns its keep — it's what stops a
 bounded fix from becoming a legacy rewrite.
+
+*Regression Risk* is where #36958 gets interesting:
+`Task240306MigrateLegacyLanguageVariablesTest` **deliberately deletes this content type** to
+prove the upgrade task recreates it. Protect the type and that test starts failing. Surfacing
+that in the spec is what keeps it from being a surprise in PR 2 — and it's exactly the kind of
+thing a reviewer catches in natural language but misses in a diff.
 
 > **Urgent incident?** The order inverts, not the count. Ship the fix first, then send the
 > short defect spec as its own PR right after. The goal is never to leave a behavior change
@@ -294,6 +319,34 @@ If `git add tasks.md` seems to do nothing, this is why.
 | `/speckit-adr-context` | You want an ADR lookup outside the plan phase |
 | `/speckit-constitution` | You're amending project law — rare, and it's a team decision |
 
+Continuing the Roles API example from §5. They all take plain English; `/speckit-analyze` and
+`/speckit-converge` read the current feature and need no arguments:
+
+```
+# Before planning — pin down what the spec left open
+/speckit-clarify pagination defaults, whether filter searches email as well as
+name, and what happens when roleId doesn't exist
+
+# Before planning — the response carries user PII, so review it as such
+/speckit-checklist security: PII exposure, authorization gates, and what an
+unauthenticated or under-privileged caller sees
+
+# Before implementing — did spec, plan and tasks drift apart?
+/speckit-analyze
+
+# After building ahead of the tasks — append whatever is still missing
+/speckit-converge
+
+# Split the work across the team
+/speckit-taskstoissues label them Team : Modernization and link back to #37070
+
+# ADR lookup outside the plan phase
+/speckit-adr-context rest pagination user PII
+```
+
+`/speckit-constitution` is deliberately absent from that list — amending project law is a team
+decision, not something to try mid-feature.
+
 ---
 
 ## 10. Troubleshooting
@@ -315,7 +368,7 @@ If `git add tasks.md` seems to do nothing, this is why.
 
 - Install, customizations, upgrade notes: [`.specify/CUSTOMIZATIONS.md`](../../.specify/CUSTOMIZATIONS.md)
 - Project law: [`.specify/memory/constitution.md`](../../.specify/memory/constitution.md)
-- Example spec: [`specs/36605-changelog-site-publish/spec.md`](../../specs/36605-changelog-site-publish/spec.md)
+- Worked examples: [#37070](https://github.com/dotCMS/core/issues/37070) (feature, §5) and [#36958](https://github.com/dotCMS/core/issues/36958) (bug, §6)
 - Branching & PRs: [`GIT_WORKFLOWS.md`](GIT_WORKFLOWS.md)
 - Testing: [`docs/testing/`](../testing/) — [`INTEGRATION_TESTS.md`](../testing/INTEGRATION_TESTS.md)
 - Legacy vs modern: [`PROGRESSIVE_ENHANCEMENT.md`](PROGRESSIVE_ENHANCEMENT.md)

--- a/docs/core/SPEC_KIT_QUICK_START.md
+++ b/docs/core/SPEC_KIT_QUICK_START.md
@@ -1,7 +1,7 @@
 # Spec-Kit Quick Start
 
 Get from an issue to merged code using spec-driven development in this repo — two PRs: the
-spec first, the implementation second. Sections 1-4 are the ones to actually read (~5 min);
+spec is approved first, the implementation follows. Sections 1-4 are the ones to actually read (~5 min);
 the rest is reference you consult when you hit it.
 
 > **See also:** [`.specify/memory/constitution.md`](../../.specify/memory/constitution.md)
@@ -74,39 +74,45 @@ process to the work. **When in doubt, size up** — and ask a teammate rather th
 
 ---
 
-## 3. Two PRs: the spec is reviewed and merged first
+## 3. Two PRs: the spec is approved before you build
 
-**Spec-Kit work ships as two pull requests, not one.**
+**Spec-Kit work ships as two pull requests, not one.** The gate is **approval, not merge** —
+once a reviewer approves the spec, start planning. Don't wait on the merge queue.
 
 | | What's in it | Reviewed for | Then |
 |---|---|---|---|
-| **PR 1 — the spec** | `spec.md`, nothing else | Is this the right problem, scoped right, with measurable criteria? | Approved and **merged** before any planning starts |
-| **PR 2 — the implementation** | Code, tests, and any durable design artifacts | Does it do what the merged spec said? | Merged as usual |
+| **PR 1 — the spec** | `spec.md`, nothing else | Is this the right problem, scoped right, with measurable criteria? | **Approved** → you start planning. It merges whenever the queue gets to it. |
+| **PR 2 — the implementation** | Code, tests, and any durable design artifacts | Does it do what the approved spec said? | Merged as usual |
 
 The sequence:
 
 1. `/speckit-specify` (or `/speckit-specify-fix`) writes the spec on your feature branch.
 2. Push it and open **PR 1 with the spec alone.** Ask for feedback, iterate on the wording,
-   get it approved, and **merge it.**
-3. Branch again from `main`. The approved spec now lives there, so you, your reviewer, and
-   the agent all read the same contract.
+   get it **approved.** Leave it in the queue — you're not blocked on it merging.
+3. Branch off **your spec branch** (not `main` — the spec isn't there yet) and keep working.
 4. `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`.
 5. Open **PR 2** with the implementation, linking back to PR 1.
+
+> Until PR 1 merges, PR 2's diff also shows the spec commit — it's the shared ancestor, not a
+> duplicate. Once PR 1 lands, PR 2 collapses to just the implementation on its own.
 
 Why we work this way: reviewing a large diff means reconstructing intent from code — slow, and
 it catches the wrong class of problem. Reviewing a spec means reading intent directly, in
 natural language, while changing course is still cheap. We're deliberately moving the effort
 upstream. **Planning is our bottleneck now, not PR review. Better input produces better
-output.**
+output** — and gating on approval rather than merge keeps the queue from becoming the new
+bottleneck.
 
 In practice:
 
-- **Don't run `/speckit-plan` until PR 1 is merged.** The approval is a real gate — it's just
-  a human one, enforced on the PR rather than by a script.
+- **Don't run `/speckit-plan` until PR 1 is approved.** The approval is a real gate — it's
+  just a human one, enforced on the PR rather than by a script.
 - **A spec that's hard to review isn't ready.** If a reviewer can't tell what "done" looks
   like from the acceptance criteria, that's the finding — fix the spec, not the review.
 - **Review it like a spec, not like code.** Is the problem stated? Are the success criteria
   measurable? What's explicitly *out* of scope? Reviewers: push back on vagueness, not style.
+- **If the spec changes after approval**, say so on PR 1 and get a re-approval. The whole
+  point is that the contract everyone read is the contract you built.
 
 > Branching again doesn't lose your place. Spec-Kit locates the spec through the local
 > `.specify/feature.json` pointer (or `SPECIFY_FEATURE_DIRECTORY`), **not** the branch name,
@@ -117,7 +123,7 @@ Three different approvals happen in a Spec-Kit run — don't confuse them:
 
 | Approval | Who gives it | Where |
 |----------|--------------|-------|
-| **The spec** | Another dev | On PR 1, before it merges |
+| **The spec** | Another dev | On PR 1, before you start planning |
 | **The tests** | You | In-session, at the TDD gate (§7) |
 | **ADR alignment** | Automated consult, you resolve conflicts | Inside `/speckit-plan` |
 
@@ -161,8 +167,8 @@ Real example to read before your first run:
 zero-padded `001-`. Working from an issue? Use its number, so the branch matches what
 everyone else is reading (`create-new-feature.sh --help` for `--number` / `--short-name`).
 
-**Stop here.** Open PR 1 with the spec alone and get it merged (§3). Everything below
-happens after that.
+**Stop here.** Open PR 1 with the spec alone and get it **approved** (§3). Everything below
+happens after that — you don't need to wait for it to merge.
 
 ### `/speckit-plan` — decide the approach
 
@@ -207,8 +213,8 @@ second publish — repro in dotCMS/core#12345
 
 1. **Reproduce it**, then run `/speckit-specify-fix` to write the defect spec: observed vs.
    expected behavior, and the repro.
-2. **Open PR 1 with that spec alone**, get it approved, and merge it (§3).
-3. **Branch from `main`, then write a failing regression test** that captures the expected
+2. **Open PR 1 with that spec alone** and get it approved (§3) — no need to wait for the merge.
+3. **Branch off your spec branch, then write a failing regression test** that captures the expected
    behavior — it's your first acceptance criterion, and it's the Red gate from §7.
 4. **Let the agent fix the code** until that test and the suite pass.
 5. **Open PR 2 with the fix**, linking PR 1 (and any ADR, if the root cause touches a prior

--- a/docs/core/SPEC_KIT_QUICK_START.md
+++ b/docs/core/SPEC_KIT_QUICK_START.md
@@ -69,8 +69,13 @@ process to the work. **When in doubt, size up** — and ask a teammate rather th
 | Tier | Typical change | Flow |
 |------|----------------|------|
 | **0 — Trivial** | Typos, copy, config, true no-op refactors | No spec. Keep tests green. |
-| **1 — Standard** | Most bug fixes; small changes inside an existing interface | **Lean** — `specify` → `plan` → `tasks` → `implement` |
-| **2 — Significant** | New features, new or changed interfaces, data-model changes, cross-team or security-sensitive work | **Full** — `specify` → (`clarify`) → (`checklist`) → `plan` → `tasks` → (`analyze`) → `implement` |
+| **1 — Standard** | Most bug fixes; small changes inside an existing interface | **Lean** — `specify` / `specify-fix` → `plan` → `tasks` → `implement` |
+| **2 — Significant** | New features, new or changed interfaces, data-model changes, cross-team or security-sensitive work | **Full** — `specify` / `specify-fix` → (`clarify`) → (`checklist`) → `plan` → `tasks` → (`analyze`) → `implement` |
+
+The entry command is a separate question from the tier: `specify` for new behavior,
+`specify-fix` for broken behavior (§1). **Tier decides how much process; new-vs-broken decides
+where you start.** A bug can be Tier 2 — §6's example is one — and a small non-bug change
+inside an existing interface is Tier 1 but still starts at `specify`.
 
 **Steps in parentheses are optional.** They are judgment calls, not required stages — nothing
 blocks or complains if you skip them. The four unparenthesized commands are the flow; the rest

--- a/docs/core/SPEC_KIT_QUICK_START.md
+++ b/docs/core/SPEC_KIT_QUICK_START.md
@@ -1,0 +1,320 @@
+# Spec-Kit Quick Start
+
+Get from an issue to merged code using spec-driven development in this repo — two PRs: the
+spec first, the implementation second. Sections 1-4 are the ones to actually read (~5 min);
+the rest is reference you consult when you hit it.
+
+> **See also:** [`.specify/memory/constitution.md`](../../.specify/memory/constitution.md)
+> — the project law every `/speckit-*` command loads. If a command pushes back on you,
+> it's almost always quoting this file.
+
+---
+
+## 1. What it is
+
+**Your first decision is the only branch in the whole flow:** are you adding behavior that
+doesn't exist yet, or fixing behavior that's broken? That picks your entry command. Everything
+after it is the same for both.
+
+```
+   Adding NEW behavior           Fixing BROKEN behavior
+    /speckit-specify              /speckit-specify-fix
+            │                               │
+            └───────────────┬───────────────┘
+                            ▼
+                      /speckit-plan     ← ADR + Legacy gates
+                            │
+                            ▼
+                     /speckit-tasks
+                            │
+                            ▼
+                   /speckit-implement   ← TDD gates, halts for you
+```
+
+You run these in Claude Code; each writes files into `specs/<your-feature>/` and hands off to
+the next. Because both entry points converge at `/speckit-plan`, a bug fix gets exactly the
+same ADR and legacy scrutiny as a feature.
+
+---
+
+## 2. Match the flow to the change
+
+The full pipeline is heavy for tiny changes, and Spec-Kit is honest about that. Size the
+process to the work. **When in doubt, size up** — and ask a teammate rather than guessing.
+
+```
+              A change to make
+                      │
+                      ▼
+  ┌───────────────────────────────────────┐
+  │ Does it change observable behavior?   │──── No ────→ TIER 0
+  └───────────────────┬───────────────────┘
+                      │ Yes
+                      ▼
+  ┌───────────────────────────────────────┐
+  │ New/changed interface, cross-team,    │──── Yes ───→ TIER 2
+  │ or security-sensitive?                │
+  └───────────────────┬───────────────────┘
+                      │ No
+                      ▼
+  ┌───────────────────────────────────────┐
+  │ Bug fix or small change inside        │──── Yes ───→ TIER 1
+  │ an existing interface?                │
+  └───────────────────┬───────────────────┘
+                      │ No
+                      ▼
+                   TIER 2
+```
+
+| Tier | Typical change | Flow |
+|------|----------------|------|
+| **0 — Trivial** | Typos, copy, config, true no-op refactors | No spec. Keep tests green. |
+| **1 — Standard** | Most bug fixes; small changes inside an existing interface | Lean: `specify` → `plan` → `tasks` → `implement` |
+| **2 — Significant** | New features, new or changed interfaces, data-model changes, cross-team or security-sensitive work | Full: add `clarify` + `checklist` before planning, `analyze` before implementing |
+
+---
+
+## 3. Two PRs: the spec is reviewed and merged first
+
+**Spec-Kit work ships as two pull requests, not one.**
+
+| | What's in it | Reviewed for | Then |
+|---|---|---|---|
+| **PR 1 — the spec** | `spec.md`, nothing else | Is this the right problem, scoped right, with measurable criteria? | Approved and **merged** before any planning starts |
+| **PR 2 — the implementation** | Code, tests, and any durable design artifacts | Does it do what the merged spec said? | Merged as usual |
+
+The sequence:
+
+1. `/speckit-specify` (or `/speckit-specify-fix`) writes the spec on your feature branch.
+2. Push it and open **PR 1 with the spec alone.** Ask for feedback, iterate on the wording,
+   get it approved, and **merge it.**
+3. Branch again from `main`. The approved spec now lives there, so you, your reviewer, and
+   the agent all read the same contract.
+4. `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`.
+5. Open **PR 2** with the implementation, linking back to PR 1.
+
+Why we work this way: reviewing a large diff means reconstructing intent from code — slow, and
+it catches the wrong class of problem. Reviewing a spec means reading intent directly, in
+natural language, while changing course is still cheap. We're deliberately moving the effort
+upstream. **Planning is our bottleneck now, not PR review. Better input produces better
+output.**
+
+In practice:
+
+- **Don't run `/speckit-plan` until PR 1 is merged.** The approval is a real gate — it's just
+  a human one, enforced on the PR rather than by a script.
+- **A spec that's hard to review isn't ready.** If a reviewer can't tell what "done" looks
+  like from the acceptance criteria, that's the finding — fix the spec, not the review.
+- **Review it like a spec, not like code.** Is the problem stated? Are the success criteria
+  measurable? What's explicitly *out* of scope? Reviewers: push back on vagueness, not style.
+
+> Branching again doesn't lose your place. Spec-Kit locates the spec through the local
+> `.specify/feature.json` pointer (or `SPECIFY_FEATURE_DIRECTORY`), **not** the branch name,
+> and that file is local and untracked — leave it out of both PRs. If a command can't find the
+> feature, `export SPECIFY_FEATURE_DIRECTORY=specs/<your-dir>`.
+
+Three different approvals happen in a Spec-Kit run — don't confuse them:
+
+| Approval | Who gives it | Where |
+|----------|--------------|-------|
+| **The spec** | Another dev | On PR 1, before it merges |
+| **The tests** | You | In-session, at the TDD gate (§7) |
+| **ADR alignment** | Automated consult, you resolve conflicts | Inside `/speckit-plan` |
+
+---
+
+## 4. Before your first run
+
+```bash
+gh auth status   # must be authenticated AND have access to dotCMS/platform-adrs
+```
+
+The plan phase automatically looks up Architecture Decision Records in the **private**
+`dotCMS/platform-adrs` repo. Without access the lookup returns nothing and planning
+continues anyway — so a missing grant is silent. Check it now, not later.
+
+> ⚠️ Your first run will prompt you to approve scripts under `.specify/scripts/bash/`.
+> That's expected — they're the Spec-Kit helpers, and they're read-only at this stage.
+
+---
+
+## 5. A worked example — implementing a feature
+
+One feature, all four commands, start to finish. Fixing a bug follows the same shape with a
+different entry command — §6, next.
+
+### `/speckit-specify` — write the contract
+
+```
+/speckit-specify Add a changelog panel to the site publish dialog so editors
+can see what changed before pushing
+```
+
+Creates a branch and `specs/<n>-<short-name>/spec.md`, then interviews you about anything
+ambiguous. The spec is **what and why** — user stories with priorities, acceptance
+scenarios, success criteria, and a **Legacy Considerations** section. No implementation
+detail.
+
+Real example to read before your first run:
+[`specs/36605-changelog-site-publish/spec.md`](../../specs/36605-changelog-site-publish/spec.md)
+— note the directory is named for the **GitHub issue number**, not Spec-Kit's default
+zero-padded `001-`. Working from an issue? Use its number, so the branch matches what
+everyone else is reading (`create-new-feature.sh --help` for `--number` / `--short-name`).
+
+**Stop here.** Open PR 1 with the spec alone and get it merged (§3). Everything below
+happens after that.
+
+### `/speckit-plan` — decide the approach
+
+```
+/speckit-plan
+```
+
+Reads your spec and produces `plan.md`: architecture, **Test Strategy**, **Constitution
+Check**, **Legacy Impact**, and **ADR Alignment**. This is where the two automated gates live —
+see §7. Takes optional guidance (`/speckit-plan use the existing WorkflowAPI rather than a new
+service`).
+
+### `/speckit-tasks` — break it down
+
+```
+/speckit-tasks
+```
+
+Produces `tasks.md`: dependency-ordered tasks grouped by user story. Every story is ordered
+**Tests → `[GATE]` approval → `[GATE]` Red → Implementation**. Skim it before implementing —
+this is the cheapest moment to catch a wrong decomposition.
+
+### `/speckit-implement` — build it
+
+```
+/speckit-implement
+```
+
+Works through `tasks.md` in order and **halts at every `[GATE]`**. It writes tests first,
+stops for your approval, stops again to show you they fail, and only then writes code.
+
+---
+
+## 6. A worked example — fixing a bug
+
+Most bug fixes are Tier 1 — lean flow, no `clarify`/`checklist`/`analyze`.
+
+```
+/speckit-specify-fix Site publish dialog shows a stale changelog after a
+second publish — repro in dotCMS/core#12345
+```
+
+1. **Reproduce it**, then run `/speckit-specify-fix` to write the defect spec: observed vs.
+   expected behavior, and the repro.
+2. **Open PR 1 with that spec alone**, get it approved, and merge it (§3).
+3. **Branch from `main`, then write a failing regression test** that captures the expected
+   behavior — it's your first acceptance criterion, and it's the Red gate from §7.
+4. **Let the agent fix the code** until that test and the suite pass.
+5. **Open PR 2 with the fix**, linking PR 1 (and any ADR, if the root cause touches a prior
+   decision).
+
+The spec is defect-framed rather than story-framed: **Problem Statement, Reproduction, Scope
+of Investigation, Root-Cause Hypothesis, Fix Scope & Non-Goals, Regression Risk, Acceptance &
+Verification**. *Fix Scope & Non-Goals* is the one that earns its keep — it's what stops a
+bounded fix from becoming a legacy rewrite.
+
+> **Urgent incident?** The order inverts, not the count. Ship the fix first, then send the
+> short defect spec as its own PR right after. The goal is never to leave a behavior change
+> with no record of intent — not to slow down an outage.
+
+---
+
+## 7. The two gates that stop the run
+
+Both are deliberate halts. Neither is a bug.
+
+### TDD (Constitution Principle V — non-negotiable)
+
+No implementation code is written before three things happen:
+
+1. **Tests are written** — layer-appropriate: unit, integration, Postman, Karate, or e2e.
+2. **You approve them.** Explicitly. If a test type genuinely can't be written, *you* say
+   which and why, and the reason gets recorded. Silence is not consent, and "no tests" is
+   never the default.
+3. **Tests are confirmed failing (Red)** for the right reason — not a compile error.
+
+So when `/speckit-implement` appears to stall, read the last message: it's almost always
+waiting on gate 2. Reply with your review — approve, or ask for different tests.
+
+### ADR Alignment
+
+`/speckit-plan` auto-runs `/speckit-adr-context` before planning (a mandatory `before_plan`
+hook in [`.specify/extensions.yml`](../../.specify/extensions.yml)). It searches
+`dotCMS/platform-adrs` and pulls relevant decisions into the plan as **binding** input. A
+plan that conflicts with an **accepted** ADR must resolve the conflict or justify it.
+
+> ⚠️ **Spec-Kit never creates ADRs.** It only *proposes* them, under "Proposed ADRs" in the
+> plan. Real ADRs are authored in `dotCMS/platform-adrs` via its own `new-adr.sh`. Discuss
+> in `#eng-adrs`.
+
+To search ADRs by hand at any point:
+`.specify/scripts/bash/adr-context.sh "workflow" "elasticsearch"`
+
+---
+
+## 8. What gets committed, and to which PR
+
+One test: **durable reference vs. process artifact.** Would a reviewer or a future dev want
+this *after* the PR merges, without re-reading the code?
+
+| Artifact | Goes in | Why |
+|----------|---------|-----|
+| `spec.md` | **PR 1**, alone | the reviewed contract (FRs, user stories, success criteria) |
+| `data-model.md` | **PR 2**, when it carries verified contracts | concrete entity→field/type, relationships, validation rules, real payload/DB shapes confirmed while building |
+| `contracts/` | **PR 2**, same test as `data-model.md` | committed API specs are durable; scaffolding is not |
+| `plan.md`, `research.md`, `tasks.md`, `quickstart.md`, `checklists/` | Neither — never committed | pure process — how / what-order / decisions-in-flight |
+
+The never-commit set is enforced by [`.gitignore`](../../.gitignore). Those files still live
+on disk and keep working — `/speckit-implement` and `/speckit-converge` read them normally.
+If `git add tasks.md` seems to do nothing, this is why.
+
+---
+
+## 9. The other commands
+
+| Command | Reach for it when |
+|---------|-------------------|
+| `/speckit-clarify` | Tier 2 work — resolve open questions in the spec before planning |
+| `/speckit-checklist` | Tier 2 work — a domain-specific review checklist (security, a11y, performance) |
+| `/speckit-analyze` | Tier 2 work — spec, plan, and tasks have drifted apart; cross-checks them, changes nothing |
+| `/speckit-converge` | You've built ahead of the tasks (or by hand) and want the gap appended to `tasks.md` |
+| `/speckit-taskstoissues` | The work needs to be split across people as GitHub issues |
+| `/speckit-adr-context` | You want an ADR lookup outside the plan phase |
+| `/speckit-constitution` | You're amending project law — rare, and it's a team decision |
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Run seems hung after `/speckit-implement` | It's parked at a `[GATE]` waiting on you | Read the last message; approve the tests or say what to change |
+| ADR section says no ADRs found, always | No `gh` access to the private `platform-adrs` | `gh auth status`, then request access in `#eng-adrs` |
+| `git add tasks.md` does nothing | Gitignored by design (§8) | Nothing to fix — it's a process artifact |
+| "Feature directory already exists" | Number collision with an unmerged branch | Rerun with `--number N`, or `--timestamp` for a collision-free name |
+| Implementation ignores the test order | `[GATE]` tasks were edited out of `tasks.md` | Regenerate with `/speckit-tasks`; never delete gate tasks |
+| Plan skipped the ADR step | The `before_plan` hook didn't fire | Run `.specify/scripts/bash/adr-context.sh` yourself and fill in the ADR Alignment section |
+| Commands can't find the feature after you branch again | `.specify/feature.json` is missing or stale | `export SPECIFY_FEATURE_DIRECTORY=specs/<your-dir>` — the pointer is local and untracked, never committed |
+| Reviewer says the spec is too vague to approve | The spec is doing implementation, or the criteria aren't measurable | Rewrite the acceptance criteria as observable outcomes; `/speckit-clarify` helps |
+
+---
+
+## Reference
+
+- Install, customizations, upgrade notes: [`.specify/CUSTOMIZATIONS.md`](../../.specify/CUSTOMIZATIONS.md)
+- Project law: [`.specify/memory/constitution.md`](../../.specify/memory/constitution.md)
+- Example spec: [`specs/36605-changelog-site-publish/spec.md`](../../specs/36605-changelog-site-publish/spec.md)
+- Branching & PRs: [`GIT_WORKFLOWS.md`](GIT_WORKFLOWS.md)
+- Testing: [`docs/testing/`](../testing/) — [`INTEGRATION_TESTS.md`](../testing/INTEGRATION_TESTS.md)
+- Legacy vs modern: [`PROGRESSIVE_ENHANCEMENT.md`](PROGRESSIVE_ENHANCEMENT.md)
+
+---
+
+*Maintained by the Engineering Team. Spot something stale or wrong? Open a PR against this
+file and ping `#eng`. ADR questions go to `#eng-adrs`.*

--- a/docs/core/SPEC_KIT_QUICK_START.md
+++ b/docs/core/SPEC_KIT_QUICK_START.md
@@ -69,8 +69,20 @@ process to the work. **When in doubt, size up** — and ask a teammate rather th
 | Tier | Typical change | Flow |
 |------|----------------|------|
 | **0 — Trivial** | Typos, copy, config, true no-op refactors | No spec. Keep tests green. |
-| **1 — Standard** | Most bug fixes; small changes inside an existing interface | Lean: `specify` → `plan` → `tasks` → `implement` |
-| **2 — Significant** | New features, new or changed interfaces, data-model changes, cross-team or security-sensitive work | Full: add `clarify` + `checklist` before planning, `analyze` before implementing |
+| **1 — Standard** | Most bug fixes; small changes inside an existing interface | **Lean** — `specify` → `plan` → `tasks` → `implement` |
+| **2 — Significant** | New features, new or changed interfaces, data-model changes, cross-team or security-sensitive work | **Full** — `specify` → (`clarify`) → (`checklist`) → `plan` → `tasks` → (`analyze`) → `implement` |
+
+**Steps in parentheses are optional.** They are judgment calls, not required stages — nothing
+blocks or complains if you skip them. The four unparenthesized commands are the flow; the rest
+are tools you pick up when they help:
+
+- `clarify` — the spec still has open questions you'd rather resolve before planning
+- `checklist` — the change is security-, privacy-, or accessibility-sensitive and deserves a
+  domain review pass
+- `analyze` — spec, plan, and tasks may have drifted apart, and you want that checked before
+  writing code
+
+§9 covers what each of them actually does.
 
 ---
 


### PR DESCRIPTION
Resolves #37110

## What

Adds `docs/core/SPEC_KIT_QUICK_START.md` — a developer-facing walkthrough for running Spec-Kit in this repo — and links it from `ONBOARDING.md`.

## Why

The only Spec-Kit prose we have is [`.specify/CUSTOMIZATIONS.md`](https://github.com/dotCMS/core/blob/main/.specify/CUSTOMIZATIONS.md), which is a maintenance record for whoever owns the install: the six customizations, the upgrade re-apply matrix, the commit policy. It never tells a developer what to type, in what order, or what happens when a run stops and waits for them.

Searching `speckit|spec-kit|spec-driven` across `docs/`, `.github/`, `README.md`, `CONTRIBUTING.md`, and `ONBOARDING.md` returns zero hits. The only other mention is a 9-line section in `CLAUDE.md`, written for the agent rather than a human.

## What's in it

- The two entry commands (`/speckit-specify` vs `/speckit-specify-fix`) and where they converge
- **Tiering** — size the process to the change instead of applying the full pipeline to typos
- **The two-PR review protocol** — the spec is reviewed and merged on its own PR before any planning; the implementation follows in a second PR
- Worked examples for a feature and for a bug fix
- The **TDD** and **ADR** gates that halt a run, and what releases them
- Which artifacts belong in which PR, and which are never committed

## Accuracy

Every `/speckit-*` name is verified against `.claude/skills/` (all 12 exist). Each behavioral claim traces to a source in the repo — the constitution for Principle V, `.specify/extensions.yml` for the `before_plan` ADR hook, `.gitignore` for the never-commit set, `CUSTOMIZATIONS.md` for the commit-policy table. All relative links resolve on this branch.

## Not in this PR

- A facilitator run-of-show for teaching this in a session — kept separate so this doc stays developer-facing.
- Index entries in `CLAUDE.md` and `docs/README.md`. Happy to add them here if reviewers would rather they land together.

## Review note

Worth reading as a newcomer would: if anything leaves you unsure what to type next, that's the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)