### PR TITLE
fix(block-editor): keep embedded contentlet selectable when text precedes it

### DIFF
--- a/core-web/libs/new-block-editor/src/lib/editor/editor.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/editor.component.ts
@@ -52,12 +52,13 @@ import { DotUploadService } from './services/dot-upload.service';
 import { EditorModalService } from './services/editor-modal.service';
 import { EditorPopoverService } from './services/editor-popover.service';
 import { EditorStore } from './store/editor.store';
+import { stripDocStats } from './utils/doc-stats.utils';
 import { loadRemoteExtensions, parseCustomBlocksField } from './utils/remote-extensions.loader';
 import { preserveUnknownBlockNodes, restoreUnknownBlockNodes } from './utils/unknown-block.utils';
 
 /** Stringifies the editor document for form output (plain ProseMirror JSON, no extra attrs). */
 function editorDocumentJsonText(editor: Editor): string {
-    return JSON.stringify(editor.getJSON());
+    return JSON.stringify(stripDocStats(editor.getJSON()));
 }
 
 /**
@@ -146,7 +147,7 @@ function editorContentMatchesParsed(editor: Editor, parsed: string | JSONContent
         const trimmed = parsed.trimStart();
         if (trimmed.startsWith('{')) {
             try {
-                return JSON.stringify(JSON.parse(parsed)) === currentJson;
+                return JSON.stringify(stripDocStats(JSON.parse(parsed))) === currentJson;
             } catch {
                 return false;
             }
@@ -154,8 +155,9 @@ function editorContentMatchesParsed(editor: Editor, parsed: string | JSONContent
         return parsed === editor.getHTML();
     }
     return (
-        JSON.stringify(preserveUnknownNodesInDocument(parsed, getKnownNodeNames(editor))) ===
-        currentJson
+        JSON.stringify(
+            stripDocStats(preserveUnknownNodesInDocument(parsed, getKnownNodeNames(editor)))
+        ) === currentJson
     );
 }
 

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/contentlet/contentlet.component.spec.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/contentlet/contentlet.component.spec.ts
@@ -1,0 +1,87 @@
+import { Spectator, createComponentFactory, mockProvider } from '@openng/spectator/jest';
+
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+import { Editor } from '@tiptap/core';
+
+import { DotMessageService } from '@dotcms/data-access';
+
+import { DotContentletNodeViewComponent } from './contentlet.component';
+
+import { EditorStore } from '../../../store/editor.store';
+
+/** Fluent mock of `editor.chain().focus().setNodeSelection(pos).run()`. */
+function mockEditor() {
+    const chain = {
+        focus: jest.fn(() => chain),
+        setNodeSelection: jest.fn(() => chain),
+        run: jest.fn(() => true)
+    };
+    const editor = { chain: jest.fn(() => chain) } as unknown as Editor;
+
+    return { editor, chain };
+}
+
+const NODE = { attrs: { data: { title: 'Cross-country Skiing', identifier: 'id-1' } } };
+
+describe('DotContentletNodeViewComponent — click-to-select (#36985)', () => {
+    let spectator: Spectator<DotContentletNodeViewComponent>;
+
+    const createComponent = createComponentFactory({
+        component: DotContentletNodeViewComponent,
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        providers: [
+            mockProvider(DotMessageService, { get: (key: string) => key }),
+            {
+                provide: EditorStore,
+                useValue: { languageIso: () => 'en', languageId: () => 1 }
+            }
+        ]
+    });
+
+    /** Creates the node view with the required ngx-tiptap inputs, `getPos` returning `pos`. */
+    function create(pos: number | undefined, editor: Editor) {
+        spectator = createComponent({
+            props: {
+                editor,
+                node: NODE,
+                getPos: () => pos,
+                decorations: [],
+                innerDecorations: {},
+                view: {},
+                selected: false,
+                extension: {},
+                HTMLAttributes: {},
+                updateAttributes: jest.fn(),
+                deleteNode: jest.fn()
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any
+        });
+    }
+
+    it('selects the node on mousedown using its own getPos()', () => {
+        const { editor, chain } = mockEditor();
+        create(7, editor);
+
+        const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+        const preventDefault = jest.spyOn(event, 'preventDefault');
+        spectator.element.dispatchEvent(event);
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(chain.setNodeSelection).toHaveBeenCalledWith(7);
+        expect(chain.run).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when getPos() is unresolved', () => {
+        const { editor, chain } = mockEditor();
+        create(undefined, editor);
+
+        const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+        const preventDefault = jest.spyOn(event, 'preventDefault');
+        spectator.element.dispatchEvent(event);
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        expect(editor.chain).not.toHaveBeenCalled();
+        expect(chain.setNodeSelection).not.toHaveBeenCalled();
+    });
+});

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/contentlet/contentlet.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/contentlet/contentlet.component.ts
@@ -120,6 +120,9 @@ export class DotContentletNodeViewComponent extends AngularNodeViewComponent {
      */
     protected selectNode(event: MouseEvent): void {
         const pos = this.getPos()();
+        // Nullish-only guard on purpose: `getPos()` returns `number | undefined`, and a contentlet
+        // that is the first block resolves to position 0. `!pos` would treat that 0 as "no position"
+        // and skip selecting the first-block card — the exact only-contentlets case from #36985.
         if (pos == null) {
             return;
         }

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/contentlet/contentlet.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/contentlet/contentlet.component.ts
@@ -19,7 +19,8 @@ import { EditorStore } from '../../../store/editor.store';
         '[attr.data-identifier]': 'identifierAttr()',
         '[attr.data-language-id]': 'languageIdAttr()',
         '[attr.data-inode]': 'inodeAttr()',
-        '[attr.data-content-type]': 'contentTypeAttr()'
+        '[attr.data-content-type]': 'contentTypeAttr()',
+        '(mousedown)': 'selectNode($event)'
     },
     template: `
         @if (data(); as d) {
@@ -103,4 +104,27 @@ export class DotContentletNodeViewComponent extends AngularNodeViewComponent {
         const ct = this.data()?.contentType;
         return ct ? String(ct) : null;
     });
+
+    /**
+     * Select the embedded contentlet card on mousedown.
+     *
+     * The card is an `atom` rendered through this Angular node view. When text or another block
+     * precedes it, the browser's default mousedown drops a text caret into that preceding block
+     * before the `click` fires — so ProseMirror resolves the click to a text position, never to
+     * the atom, and the card gets no NodeSelection (no selection ring; the toolbar contentlet
+     * actions, gated on a `dotContent` NodeSelection, stay unreachable) — #36985.
+     *
+     * Selecting the node by its own position (`getPos()`, always accurate regardless of what
+     * surrounds it) and suppressing the default mousedown fixes click-to-select in every layout.
+     * Reordering is unaffected: it runs off the block-gutter drag handle, a separate element.
+     */
+    protected selectNode(event: MouseEvent): void {
+        const pos = this.getPos()();
+        if (pos == null) {
+            return;
+        }
+
+        event.preventDefault();
+        this.editor().chain().focus().setNodeSelection(pos).run();
+    }
 }

--- a/core-web/libs/new-block-editor/src/lib/editor/utils/doc-stats.utils.spec.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/utils/doc-stats.utils.spec.ts
@@ -1,0 +1,64 @@
+import { type JSONContent } from '@tiptap/core';
+
+import { stripDocStats } from './doc-stats.utils';
+
+describe('stripDocStats', () => {
+    it('drops the attrs key entirely when only stats are present', () => {
+        const input: JSONContent = {
+            type: 'doc',
+            attrs: { charCount: 6, wordCount: 2, readingTime: 1 },
+            content: [{ type: 'paragraph' }]
+        };
+
+        expect(stripDocStats(input)).toEqual({
+            type: 'doc',
+            content: [{ type: 'paragraph' }]
+        });
+    });
+
+    it('matches a plain editor.getJSON() shape after a stats round-trip', () => {
+        const editorJson: JSONContent = { type: 'doc', content: [{ type: 'paragraph' }] };
+        const emitted: JSONContent = {
+            type: 'doc',
+            attrs: { charCount: 6, wordCount: 2, readingTime: 1 },
+            content: [{ type: 'paragraph' }]
+        };
+
+        // The whole point of the guard fix (#36985): the round-tripped value must compare equal.
+        expect(JSON.stringify(stripDocStats(emitted))).toBe(
+            JSON.stringify(stripDocStats(editorJson))
+        );
+    });
+
+    it('keeps non-stat attrs and removes only the stats', () => {
+        const input: JSONContent = {
+            type: 'doc',
+            attrs: { charCount: 6, wordCount: 2, readingTime: 1, custom: 'keep' },
+            content: []
+        };
+
+        expect(stripDocStats(input)).toEqual({
+            type: 'doc',
+            attrs: { custom: 'keep' },
+            content: []
+        });
+    });
+
+    it('returns the input untouched when there are no attrs', () => {
+        const input: JSONContent = { type: 'doc', content: [{ type: 'paragraph' }] };
+
+        expect(stripDocStats(input)).toBe(input);
+    });
+
+    it('does not mutate the input object', () => {
+        const input: JSONContent = {
+            type: 'doc',
+            attrs: { charCount: 6, wordCount: 2, readingTime: 1 },
+            content: []
+        };
+
+        stripDocStats(input);
+
+        expect(input.attrs).toEqual({ charCount: 6, wordCount: 2, readingTime: 1 });
+    });
+});

--- a/core-web/libs/new-block-editor/src/lib/editor/utils/doc-stats.utils.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/utils/doc-stats.utils.ts
@@ -1,0 +1,38 @@
+import { type JSONContent } from '@tiptap/core';
+
+/** Root-level document-stat attrs stamped onto the emitted value for legacy-parity output. */
+export const DOC_STAT_ATTRS = ['charCount', 'wordCount', 'readingTime'] as const;
+
+/**
+ * Strips the document-stat attrs (`charCount` / `wordCount` / `readingTime`) that the editor stamps
+ * onto its emitted value for legacy parity.
+ *
+ * `editor.getJSON()` never carries these root attrs, so a round-tripped value would otherwise never
+ * compare equal to the editor's own document — making the "did the value actually change?" guard
+ * permanently false once there is any text. That fires a `setContent` on every value round-trip,
+ * which rebuilds the doc and clobbers the current selection (e.g. a just-clicked contentlet card,
+ * #36985). Comparing on the stats-free shape keeps the guard symmetric with what is emitted.
+ *
+ * Returns the input untouched when there are no root attrs; drops the `attrs` key entirely when only
+ * stats were present, so the shape matches a plain `editor.getJSON()`.
+ */
+export function stripDocStats(json: JSONContent): JSONContent {
+    const attrs = json?.attrs;
+    if (!attrs) {
+        return json;
+    }
+
+    const rest = { ...attrs };
+    for (const key of DOC_STAT_ATTRS) {
+        delete rest[key];
+    }
+
+    const next = { ...json };
+    if (Object.keys(rest).length > 0) {
+        next.attrs = rest;
+    } else {
+        delete next.attrs;
+    }
+
+    return next;
+}


### PR DESCRIPTION
## Proposed Changes

Fixes #36985 — in the new Block Editor, an embedded contentlet card (`dotContent`) could not be selected with the mouse when any text or other block preceded it. Without a `NodeSelection` the card showed no selection ring and could not be deleted, reordered, or edited (the toolbar's contentlet actions are gated on a `dotContent` NodeSelection).

### Root cause (two parts)

1. **No click-to-select path on the atom's Angular node view.** The `dotContent` node view (`contentlet.component.ts`) was passive, so selection depended entirely on ProseMirror's default click handling.
2. **The selection was immediately clobbered.** The emitted value carries root document-stat attrs (`charCount` / `wordCount` / `readingTime`) via `withDocStats`, but the change guard (`editorContentMatchesParsed`) compared the round-tripped value against `editor.getJSON()`, which has **no** root attrs. So once there was any text the guard was permanently `false`, firing a `setContent` on every value round-trip that rebuilt the document and reset the selection.

Diagnosed with a live ProseMirror `dispatch` trace: click created the NodeSelection, then a full-document (byte-identical) `setContent` transaction reset it.

### Changes

- Add a `mousedown` handler on the contentlet node view that selects the node by its own `getPos()` — mirrors the existing `dotImage` atom pattern.
- Extract `stripDocStats` to `utils/doc-stats.utils.ts` and compare on the stats-free shape on **both** sides of `editorContentMatchesParsed`, so the guard is symmetric with what is emitted. This stops the spurious `setContent` (and the per-keystroke doc churn it caused).
- Unit tests for `stripDocStats`.

## Checklist

- [x] Tests: `pnpm nx test new-block-editor` — 62/62 pass (incl. new `doc-stats.utils.spec.ts`)
- [x] Lint + Prettier clean
- [ ] Manually verified in the Block Editor (new): click-to-select an embedded contentlet with text before it; delete/reorder/edit reachable; typing and two-way `[value]`/`valueChange` unaffected

## Video

https://github.com/user-attachments/assets/89d84647-4b18-4ff3-84c6-141e70e756a8


## Notes

Separate, pre-existing issue spotted while debugging (not in scope here): picking slash-menu "Text" can leave a literal `/` paragraph behind. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36985