### PR TITLE
DO NOT MERGE: #34154: refactor(java25): scoped values for reindex + config guard, flexible constructor for ISODateParam

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/param/ISODateParam.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/param/ISODateParam.java
@@ -7,12 +7,41 @@ import java.util.Date;
 
 /**
  * Encapsulates the logic to parse a ISO String date into a {@link Date}
+ *
+ * <p>Used as a JAX-RS parameter binder, so the string it receives is untrusted request input — see
+ * {@code BundleResource.deleteBundlesOlderThan}, which takes it as a {@code @PathParam}.</p>
+ *
+ * <p><b>Why the validation sits before {@code super(...)}.</b> {@link DateUtil#parseISO(String)}
+ * signals "unusable input" by returning {@code null} rather than by throwing, and
+ * {@code UtilMethods.isSet} — the check it uses — rejects {@code null}, blank text <i>and the
+ * literal four characters {@code "null"}</i>. A client that interpolates an unset variable into the
+ * URL therefore sends a value that parses to {@code null}. Until Java 25 nothing was allowed to
+ * precede an explicit constructor invocation, so the only available spelling was
+ * {@code super(DateUtil.parseISO(stringDate).getTime())} — which dereferences that {@code null}
+ * inside the argument list and fails with a {@link NullPointerException} carrying no indication of
+ * which parameter was at fault. Flexible constructor bodies (JEP 513) allow a prologue to run
+ * first, so the check can finally live in the type that owns the invariant.</p>
+ *
  * @author jsanca
  */
 public class ISODateParam extends Date {
 
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Parses an ISO-8601 date.
+     *
+     * @param stringDate an ISO-8601 date, either {@code yyyy-MM-dd} or a full offset date-time
+     * @throws ParseException if the value is missing, blank, the literal text {@code "null"}, or
+     *                        not a parseable ISO-8601 date
+     */
     public ISODateParam(final String stringDate) throws ParseException {
 
-        super(DateUtil.parseISO (stringDate).getTime());
+        final Date parsedDate = DateUtil.parseISO(stringDate);
+        if (null == parsedDate) {
+            throw new ParseException("Expected an ISO-8601 date, got: " + stringDate, 0);
+        }
+
+        super(parsedDate.getTime());
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/util/ThreadContext.java
+++ b/dotCMS/src/main/java/com/dotcms/util/ThreadContext.java
@@ -2,25 +2,23 @@ package com.dotcms.util;
 
 /**
  * Encapsulates Thread Local context information
+ *
+ * <p>What is left here is deliberately narrow: a single mutable flag that travels <b>callee to
+ * caller</b>. Code deep in the stack records that the deferred reindex must include dependencies
+ * (see {@code ThreadContextUtil.ifReindex}), and code higher up reads it afterwards to decide how
+ * to index (see {@code WorkflowAPIImpl.fireWorkflowPostCheckin}).</p>
+ *
+ * <p>That direction of travel is why this is still a thread local rather than a
+ * {@link ScopedValue}: a scoped binding is immutable, so a callee cannot use one to hand a value
+ * back to its caller. The reindex flag, which does descend from caller to callee, is a scoped value
+ * in {@link ThreadContextUtil}.</p>
+ *
  * @author jsanca
  */
 public class ThreadContext {
 
-    // by default the api will reindex, set to false if do not want to reindex in an api call.
-    private boolean reindex = true;
-
     // when the reindex happens later, the api call can set this to true in order to tell at the end of the thread process to do reindex including dependencies
     private boolean includeDependencies = false;
-
-    private String tag;
-
-    public boolean isReindex() {
-        return reindex;
-    }
-
-    public void setReindex(boolean reindex) {
-        this.reindex = reindex;
-    }
 
     public boolean isIncludeDependencies() {
         return includeDependencies;
@@ -28,13 +26,5 @@ public class ThreadContext {
 
     public void setIncludeDependencies(boolean includeDependencies) {
         this.includeDependencies = includeDependencies;
-    }
-
-    public String getTag() {
-        return tag;
-    }
-
-    public void setTag(String tag) {
-        this.tag = tag;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/util/ThreadContextUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/ThreadContextUtil.java
@@ -7,14 +7,46 @@ import com.dotmarketing.util.UtilMethods;
 
 /**
  * Thread Context Util provides methods to handle reindex stuff and other thread local context things
+ *
+ * <p><b>Two mechanisms, on purpose.</b> The two pieces of state here flow in opposite directions,
+ * so they are held differently:</p>
+ *
+ * <ul>
+ *   <li>{@code reindex} travels <b>caller to callee</b>: an API call declares "do not index inline
+ *       while I run" and everything underneath reads it. That is a dynamically scoped binding, and
+ *       it is held in a {@link ScopedValue} — bounded by the call, immutable, and restored on exit
+ *       whether the delegate returns or throws.</li>
+ *   <li>{@code includeDependencies} travels <b>callee to caller</b>: code deep in the stack records
+ *       that the eventual deferred reindex must include dependencies, and code higher up reads it
+ *       afterwards to decide how to index. A scoped value cannot express that — its bindings are
+ *       immutable by design — so this one stays in the mutable {@link ThreadContext} held by a
+ *       thread local. See {@code WorkflowAPIImpl.fireWorkflowPostCheckin}, which consumes what
+ *       {@code ESContentletAPIImpl} recorded.</li>
+ * </ul>
+ *
+ * <p>Reaching for a scoped value for the second one would be the classic mistake: the mechanism is
+ * a better thread local only for context that genuinely descends.</p>
+ *
  * @author jsancas
  */
 public class ThreadContextUtil {
+
+    /**
+     * Whether API calls on this thread should index inline. Unbound means yes, which is the default
+     * the platform relies on.
+     */
+    private static final ScopedValue<Boolean> REINDEX = ScopedValue.newInstance();
 
     private static ThreadLocal<ThreadContext> contextLocal = new ThreadLocal<>();
 
     /**
      * Get the context from the current thread
+     *
+     * <p>Only {@code includeDependencies} still lives here; the reindex flag is a
+     * {@link ScopedValue}. Note that this method <i>installs</i> a context on first use, so callers
+     * that merely want to read the reindex flag should use {@link #isReindex()} instead of coming
+     * through here.</p>
+     *
      * @return {@link ThreadContext}
      */
     public static ThreadContext getOrCreateContext() {
@@ -34,8 +66,7 @@ public class ThreadContextUtil {
      */
     public static boolean isReindex () {
 
-        final ThreadContext context = getOrCreateContext();
-        return context.isReindex();
+        return REINDEX.orElse(Boolean.TRUE);
     }
 
     /**
@@ -76,20 +107,11 @@ public class ThreadContextUtil {
      */
     public static void wrapVoidNoReindex (final VoidDelegate delegate) {
 
-        final ThreadContext threadContext = getOrCreateContext();
-        final boolean reindex = threadContext.isReindex();
+        wrapReturnNoReindex(() -> {
 
-        try {
-
-            threadContext.setReindex(false);
             delegate.execute();
-        } catch(Throwable e) {
-
-            throw new DotRuntimeException(e);
-        } finally {
-
-            threadContext.setReindex(reindex);
-        }
+            return null;
+        });
     }
 
 
@@ -100,19 +122,12 @@ public class ThreadContextUtil {
      */
     public  static <T> T wrapReturnNoReindex (final ReturnableDelegate<T> delegate) {
 
-        final ThreadContext threadContext = getOrCreateContext();
-        final boolean reindex = threadContext.isReindex();
-
         try {
 
-            threadContext.setReindex(false);
-            return delegate.execute();
+            return ScopedValue.where(REINDEX, Boolean.FALSE).call(delegate::execute);
         } catch(Throwable e) {
 
             throw new DotRuntimeException(e);
-        } finally {
-
-            threadContext.setReindex(reindex);
         }
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -6,7 +6,6 @@ import com.dotcms.util.ConfigurationInterpolator;
 import com.dotcms.util.FileWatcherAPI;
 import com.dotcms.util.ReflectionUtils;
 import com.dotcms.util.SystemEnvironmentConfigurationInterpolator;
-import com.dotcms.util.ThreadContextUtil;
 import com.dotcms.util.transform.StringToEntityTransformer;
 import com.dotmarketing.business.APILocator;
 import com.google.common.annotations.VisibleForTesting;
@@ -56,6 +55,22 @@ public class Config {
     private static final Set<String> environmentSetKeys = ConcurrentHashMap.newKeySet();
 
     private static SystemTableConfigSource systemTableConfigSource = null;
+
+    /**
+     * Marks that this thread is already inside a system-table property lookup.
+     *
+     * <p>Reading a property can consult the system table, and consulting the system table reads
+     * properties in order to reach the database — so the lookup has to be able to tell that it is
+     * re-entering itself. Being <i>bound</i> is the whole signal, so the value carried is
+     * irrelevant.</p>
+     *
+     * <p>This replaces a mutable {@code tag} string kept on the per-thread {@code ThreadContext}.
+     * The binding is released when the lookup returns or throws, without a {@code finally} that has
+     * to remember what to put back, and nothing is retained on the thread afterwards — the previous
+     * spelling installed a {@code ThreadContext} in a thread local for every thread that ever read
+     * a property, and only a reflective shutdown task ever cleared it.</p>
+     */
+    private static final ScopedValue<Boolean> IN_SYSTEM_TABLE_LOOKUP = ScopedValue.newInstance();
 
     @VisibleForTesting
     public static boolean enableSystemTableConfigSource = "true".equalsIgnoreCase(EnvironmentVariablesService.getInstance().getenv().getOrDefault("DOT_ENABLE_SYSTEM_TABLE_CONFIG_SOURCE", "true"));
@@ -377,15 +392,12 @@ public class Config {
 
         if (null != names && null != systemTableConfigSource && enableSystemTableConfigSource) {
 
-            final String tag = ThreadContextUtil.getOrCreateContext().getTag();
-            if (UtilMethods.isSet(tag) && "ConfigSystemTable".equals(tag)) {
+            if (IN_SYSTEM_TABLE_LOOKUP.isBound()) {
                 // we are already in the system table, so do not need to check inner system table calls (avoid recursion)
                 return null;
             }
 
-            try {
-
-                ThreadContextUtil.getOrCreateContext().setTag("ConfigSystemTable");
+            return ScopedValue.where(IN_SYSTEM_TABLE_LOOKUP, Boolean.TRUE).call(() -> {
 
                 for (final String name : names) {
                     final String value = Try.of(() -> systemTableConfigSource.getValue(name)).getOrNull();
@@ -394,10 +406,8 @@ public class Config {
                     }
                 }
 
-            } finally {
-                // the result is done, do not need more the barrier tag
-                ThreadContextUtil.getOrCreateContext().setTag(null);
-            }
+                return null;
+            });
         }
 
         return null;

--- a/dotCMS/src/test/java/com/dotcms/rest/param/ISODateParamTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/param/ISODateParamTest.java
@@ -1,0 +1,143 @@
+package com.dotcms.rest.param;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ISODateParam}, the JAX-RS parameter binder used by
+ * {@code BundleResource.deleteBundlesOlderThan} to turn a path segment into a {@link Date}.
+ *
+ * <p>The class delegates to {@code DateUtil.parseISO}, which returns {@code null} — not an
+ * exception — whenever {@code UtilMethods.isSet(String)} rejects the input. {@code isSet} rejects
+ * {@code null}, blank strings <b>and the literal text {@code "null"}</b>, so a client that
+ * interpolates an unset variable into the URL (producing {@code /olderthan/null}) reaches that
+ * path. Before Java 25 the constructor could not guard against it: nothing was allowed to precede
+ * {@code super(...)}, so {@code parseISO(...).getTime()} dereferenced the null inside the argument
+ * list of the superclass call.</p>
+ *
+ * <p>These tests pin the contract that the constructor rejects unusable input with a
+ * {@link ParseException} that names the offending value.</p>
+ */
+public class ISODateParamTest {
+
+    /**
+     * The realistic case: a client interpolates an unset variable and sends the four characters
+     * {@code null}. {@code UtilMethods.isSet} treats that text as unset, so {@code parseISO}
+     * returns {@code null}.
+     */
+    @Test
+    public void test_literalNullText_throwsParseException() {
+        assertRejected("null");
+    }
+
+    /**
+     * {@code UtilMethods.isSet} trims before measuring, so a whitespace-only segment is unset.
+     */
+    @Test
+    public void test_blankString_throwsParseException() {
+        assertRejected(" ");
+    }
+
+    @Test
+    public void test_emptyString_throwsParseException() {
+        assertRejected("");
+    }
+
+    @Test
+    public void test_nullString_throwsParseException() {
+        assertRejected(null);
+    }
+
+    /**
+     * The rejection message must name the value, otherwise the caller cannot tell which path
+     * segment was wrong.
+     */
+    @Test
+    public void test_rejectionMessageNamesTheOffendingValue() throws Exception {
+        try {
+            new ISODateParam("null");
+            fail("Expected a ParseException for the literal text 'null'");
+        } catch (final ParseException e) {
+            assertNotNull("ParseException must carry a message", e.getMessage());
+            if (!e.getMessage().contains("null")) {
+                fail("Message must name the offending value, was: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * A short ISO date must still parse to the same instant as the plain formatter, so the fix
+     * cannot have changed the happy path.
+     */
+    @Test
+    public void test_shortIsoDate_parses() throws Exception {
+        final ISODateParam param = new ISODateParam("2026-08-18");
+        final Date expected = new SimpleDateFormat("yyyy-MM-dd").parse("2026-08-18");
+        assertEquals("Short ISO date must parse to the same instant", expected.getTime(),
+                param.getTime());
+    }
+
+    /**
+     * A full offset date-time must parse as well: this is the form the endpoint documents.
+     */
+    @Test
+    public void test_offsetDateTime_parses() throws Exception {
+        final ISODateParam param = new ISODateParam("2026-08-18T10:15:30+00:00");
+        assertEquals("Offset date-time must parse to the expected epoch milli",
+                java.time.OffsetDateTime.parse("2026-08-18T10:15:30+00:00").toInstant()
+                        .toEpochMilli(),
+                param.getTime());
+    }
+
+    /**
+     * Garbage that is short enough to reach {@code SimpleDateFormat} must surface as a
+     * {@link ParseException}. This already worked before the fix and must keep working.
+     */
+    @Test
+    public void test_shortGarbage_throwsParseException() {
+        assertRejected("not-a-date");
+    }
+
+    /**
+     * Garbage long enough to reach {@code OffsetDateTime.parse} surfaces as an unchecked
+     * {@link DateTimeParseException}. Documented rather than changed: normalising it would alter
+     * the behaviour of a live endpoint, which is outside the scope of this fix.
+     */
+    @Test
+    public void test_longGarbage_throwsDateTimeParseException() {
+        try {
+            new ISODateParam("this-is-definitely-not-a-date");
+            fail("Expected the long-garbage branch to throw");
+        } catch (final DateTimeParseException expected) {
+            // Documented current behaviour of DateUtil.parseISO for inputs longer than 10 chars.
+        } catch (final ParseException e) {
+            fail("Long garbage is routed to OffsetDateTime.parse, expected DateTimeParseException"
+                    + " but got ParseException: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Asserts that the constructor rejects the value with a {@link ParseException} rather than a
+     * {@link NullPointerException}.
+     *
+     * @param value the path-segment text under test
+     */
+    private void assertRejected(final String value) {
+        try {
+            new ISODateParam(value);
+            fail("Expected a ParseException for input: " + value);
+        } catch (final ParseException expected) {
+            // The contract under test.
+        } catch (final NullPointerException e) {
+            fail("Input '" + value + "' produced a NullPointerException instead of a"
+                    + " ParseException — the constructor is not validating before super(...)");
+        }
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/util/ThreadContextUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/ThreadContextUtilTest.java
@@ -1,0 +1,164 @@
+package com.dotcms.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ThreadContextUtil}, which scopes the "should this API call reindex?" flag
+ * around a delegate.
+ *
+ * <p>These tests pin the semantics that matter and that a hand-written save/rebind/restore is easy
+ * to get wrong:</p>
+ *
+ * <ul>
+ *   <li>the flag defaults to {@code true} when nothing has bound it;</li>
+ *   <li>a wrap makes it {@code false} for the delegate only;</li>
+ *   <li>a nested wrap restores the <b>enclosing</b> value on exit, not the default;</li>
+ *   <li>the value is restored even when the delegate throws.</li>
+ * </ul>
+ *
+ * <p>The last one is the regression test for the whole class of bug: an exception path that skips
+ * the restore leaves every later call on that thread believing it must not reindex.</p>
+ */
+public class ThreadContextUtilTest {
+
+    /**
+     * Nothing bound: an API call must reindex. This is the default the platform relies on.
+     */
+    @Test
+    public void test_isReindex_defaultsToTrue() {
+        assertTrue("With nothing bound, isReindex() must default to true",
+                ThreadContextUtil.isReindex());
+    }
+
+    @Test
+    public void test_wrapVoidNoReindex_bindsFalseForTheDelegateOnly() {
+        final AtomicBoolean seenInside = new AtomicBoolean(true);
+
+        ThreadContextUtil.wrapVoidNoReindex(() -> seenInside.set(ThreadContextUtil.isReindex()));
+
+        assertFalse("Inside the wrap, isReindex() must be false", seenInside.get());
+        assertTrue("After the wrap, isReindex() must be back to true",
+                ThreadContextUtil.isReindex());
+    }
+
+    @Test
+    public void test_wrapReturnNoReindex_returnsValueAndBindsFalse() {
+        final String result = ThreadContextUtil.wrapReturnNoReindex(
+                () -> "reindex=" + ThreadContextUtil.isReindex());
+
+        assertEquals("The delegate's value must be returned unchanged", "reindex=false", result);
+        assertTrue("After the wrap, isReindex() must be back to true",
+                ThreadContextUtil.isReindex());
+    }
+
+    /**
+     * The nesting case. An inner wrap must restore whatever the outer wrap had bound, not the
+     * global default — this is precisely what a {@code finally} that assigns a constant gets wrong.
+     */
+    @Test
+    public void test_nestedWrap_restoresTheEnclosingValueNotTheDefault() {
+        final AtomicReference<String> trace = new AtomicReference<>("");
+
+        ThreadContextUtil.wrapVoidNoReindex(() -> {
+            trace.set(trace.get() + "outer=" + ThreadContextUtil.isReindex() + ";");
+
+            ThreadContextUtil.wrapVoidNoReindex(
+                    () -> trace.set(trace.get() + "inner=" + ThreadContextUtil.isReindex() + ";"));
+
+            trace.set(trace.get() + "afterInner=" + ThreadContextUtil.isReindex() + ";");
+        });
+
+        assertEquals("The inner wrap must not leak the default back into the outer scope",
+                "outer=false;inner=false;afterInner=false;", trace.get());
+        assertTrue("After both wraps, isReindex() must be back to true",
+                ThreadContextUtil.isReindex());
+    }
+
+    /**
+     * The regression test: a delegate that throws must still leave the flag restored. If the
+     * restore is skipped, every subsequent operation on this thread silently stops reindexing.
+     */
+    @Test
+    public void test_wrapVoidNoReindex_restoresFlagWhenDelegateThrows() {
+        try {
+            ThreadContextUtil.wrapVoidNoReindex(() -> {
+                throw new DotDataException("boom");
+            });
+            fail("The delegate's failure must not be swallowed");
+        } catch (final DotRuntimeException expected) {
+            // The documented contract: checked failures are wrapped.
+        }
+
+        assertTrue("A throwing delegate must not leave isReindex() stuck at false",
+                ThreadContextUtil.isReindex());
+    }
+
+    @Test
+    public void test_wrapReturnNoReindex_restoresFlagWhenDelegateThrows() {
+        try {
+            ThreadContextUtil.wrapReturnNoReindex(() -> {
+                throw new DotDataException("boom");
+            });
+            fail("The delegate's failure must not be swallowed");
+        } catch (final DotRuntimeException expected) {
+            // The documented contract: checked failures are wrapped.
+        }
+
+        assertTrue("A throwing delegate must not leave isReindex() stuck at false",
+                ThreadContextUtil.isReindex());
+    }
+
+    /**
+     * {@code ifReindex} runs its delegate when the flag is set.
+     */
+    @Test
+    public void test_ifReindex_runsDelegateWhenReindexing() throws Exception {
+        final AtomicBoolean ran = new AtomicBoolean(false);
+
+        ThreadContextUtil.ifReindex(() -> ran.set(true));
+
+        assertTrue("ifReindex must run the delegate when isReindex() is true", ran.get());
+    }
+
+    /**
+     * ...and skips it inside a no-reindex wrap.
+     */
+    @Test
+    public void test_ifReindex_skipsDelegateInsideWrap() {
+        final AtomicBoolean ran = new AtomicBoolean(false);
+
+        ThreadContextUtil.wrapVoidNoReindex(() -> ThreadContextUtil.ifReindex(() -> ran.set(true)));
+
+        assertFalse("ifReindex must skip the delegate when isReindex() is false", ran.get());
+    }
+
+    /**
+     * The two-argument {@code ifReindex} is the deferral channel: when the call is not reindexing,
+     * it records that the eventual reindex must include dependencies. That value travels
+     * <b>callee to caller</b> — the code that consumes it runs after the code that sets it — so it
+     * is deliberately <b>not</b> a scoped value, which is immutable by design. This test pins that
+     * the out-channel still works.
+     */
+    @Test
+    public void test_ifReindex_recordsIncludeDependenciesForTheDeferredReindex() {
+        ThreadContextUtil.wrapVoidNoReindex(() -> {
+            try {
+                ThreadContextUtil.ifReindex(() -> fail("Must not index inline inside a wrap"), true);
+            } catch (final Exception e) {
+                throw new DotRuntimeException(e);
+            }
+
+            assertTrue("The callee must be able to record includeDependencies for the caller",
+                    ThreadContextUtil.getOrCreateContext().isIncludeDependencies());
+        });
+    }
+}

--- a/dotCMS/src/test/java/com/dotmarketing/util/ConfigSystemTableRecursionGuardTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/ConfigSystemTableRecursionGuardTest.java
@@ -1,0 +1,174 @@
+package com.dotmarketing.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import com.dotcms.config.SystemTableConfigSource;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the re-entrancy guard around {@code Config.getSystemTableValue}.
+ *
+ * <p>Reading a property can consult the system table, and consulting the system table reads
+ * properties in order to reach the database — so without a guard the lookup recurses. The guard
+ * therefore has to answer one question: <em>am I already inside a system-table lookup on this
+ * thread?</em></p>
+ *
+ * <p>These tests install a {@link SystemTableConfigSource} that deliberately re-enters
+ * {@code Config} and pin three properties of the guard:</p>
+ *
+ * <ul>
+ *   <li>the nested lookup does not reach the source (no recursion);</li>
+ *   <li>the guard is released once the outer lookup returns, so an independent later lookup is
+ *       served normally;</li>
+ *   <li>the guard is released even when the source throws.</li>
+ * </ul>
+ */
+public class ConfigSystemTableRecursionGuardTest {
+
+    private static final String PROBE_KEY = "DOT_GUARD_PROBE_KEY";
+    private static final String NESTED_KEY = "DOT_GUARD_NESTED_KEY";
+
+    private Object previousSource;
+    private boolean previousEnabled;
+
+    @Before
+    public void before() throws Exception {
+        this.previousSource = sourceField().get(null);
+        this.previousEnabled = Config.enableSystemTableConfigSource;
+        Config.enableSystemTableConfigSource = true;
+    }
+
+    @After
+    public void after() throws Exception {
+        sourceField().set(null, this.previousSource);
+        Config.enableSystemTableConfigSource = this.previousEnabled;
+    }
+
+    /**
+     * A nested lookup must not reach the config source at all.
+     *
+     * <p>Note the outer count: one property lookup consults the source <b>twice</b>, because
+     * {@code getSystemTableValue} is handed both the environment-style key and the raw name and
+     * tries them in turn. So two outer hits and zero nested hits is the passing shape.</p>
+     */
+    @Test
+    public void test_nestedLookupDoesNotReachTheSource() throws Exception {
+        final AtomicInteger outerHits = new AtomicInteger();
+        final AtomicInteger nestedHits = new AtomicInteger();
+
+        install(name -> {
+            countHit(name, outerHits, nestedHits);
+            // Re-enter Config from inside the source, the way reaching the database does.
+            Config.getStringProperty(NESTED_KEY, null);
+            return null;
+        });
+
+        Config.getStringProperty(PROBE_KEY, null);
+
+        assertEquals("The nested lookup must never reach the source", 0, nestedHits.get());
+        assertEquals("The outer lookup tries both the env key and the raw name", 2,
+                outerHits.get());
+    }
+
+    /**
+     * Once the outer lookup returns, the guard must be released: a later, unrelated lookup is a
+     * new outer call and must reach the source again.
+     */
+    @Test
+    public void test_guardIsReleasedAfterTheOuterLookupReturns() throws Exception {
+        final AtomicInteger outerHits = new AtomicInteger();
+        final AtomicInteger nestedHits = new AtomicInteger();
+
+        install(name -> {
+            countHit(name, outerHits, nestedHits);
+            Config.getStringProperty(NESTED_KEY, null);
+            return null;
+        });
+
+        Config.getStringProperty(PROBE_KEY, null);
+        Config.getStringProperty(PROBE_KEY, null);
+
+        assertEquals("The guard must not survive the outer lookup", 4, outerHits.get());
+        assertEquals("The nested lookup must never reach the source", 0, nestedHits.get());
+    }
+
+    /**
+     * The regression test: if the source throws, the guard must still be released. A guard left set
+     * would silently disable the system-table config source for the rest of that thread's life —
+     * and on a pooled request thread, for every request it serves afterwards.
+     */
+    @Test
+    public void test_guardIsReleasedWhenTheSourceThrows() throws Exception {
+        final AtomicInteger outerHits = new AtomicInteger();
+        final AtomicInteger nestedHits = new AtomicInteger();
+
+        install(name -> {
+            countHit(name, outerHits, nestedHits);
+            throw new IllegalStateException("system table unavailable");
+        });
+
+        // Config swallows source failures (Try.of(...).getOrNull()), so neither call throws here.
+        Config.getStringProperty(PROBE_KEY, null);
+        Config.getStringProperty(PROBE_KEY, null);
+
+        assertEquals("A failing source must not leave the guard set and block later lookups",
+                4, outerHits.get());
+        assertEquals("The nested lookup must never reach the source", 0, nestedHits.get());
+    }
+
+    /**
+     * Attributes a source hit to the outer or the nested lookup by property name.
+     */
+    private static void countHit(final String propertyName, final AtomicInteger outerHits,
+            final AtomicInteger nestedHits) {
+        if (null != propertyName && propertyName.contains("NESTED")) {
+            nestedHits.incrementAndGet();
+        } else {
+            outerHits.incrementAndGet();
+        }
+    }
+
+    /**
+     * Sanity check that the probe key really is absent, so a non-null result in the tests above
+     * could only have come from the installed source.
+     */
+    @Test
+    public void test_probeKeyIsNotOtherwiseSet() {
+        assertNull("The probe key must not be configured by any other source",
+                Config.getStringProperty(PROBE_KEY, null));
+    }
+
+    /**
+     * Installs a config source whose {@code getValue} runs the supplied body.
+     *
+     * @param body what the source should do when consulted
+     */
+    private void install(final SourceBody body) throws Exception {
+        sourceField().set(null, new SystemTableConfigSource() {
+            @Override
+            public String getValue(final String propertyName) {
+                return body.apply(propertyName);
+            }
+        });
+    }
+
+    /**
+     * @return the private static {@code Config.systemTableConfigSource} field, made accessible
+     */
+    private static Field sourceField() throws Exception {
+        final Field field = Config.class.getDeclaredField("systemTableConfigSource");
+        field.setAccessible(true);
+        return field;
+    }
+
+    @FunctionalInterface
+    private interface SourceBody {
+        String apply(String propertyName);
+    }
+}


### PR DESCRIPTION
## What

Applies three Java 25 features to places where the codebase already had the problem they solve. Material came out of the Java 21→25 tech talk (#34154): rather than illustrate the features with invented examples, these are the real call sites the features were designed for.

Each change is small, local, and covered by new unit tests. No behaviour change is intended except the `ISODateParam` fix.

## 1. `ISODateParam` — flexible constructor bodies (JEP 513)

`DateUtil.parseISO` signals unusable input by **returning `null`**, and `UtilMethods.isSet` rejects `null`, blank text **and the literal four characters `"null"`** — which is what a client sends when it interpolates an unset variable into a URL (`/olderthan/null`).

The constructor was:

```java
public ISODateParam(final String stringDate) throws ParseException {
    super(DateUtil.parseISO(stringDate).getTime());
}
```

`.getTime()` is called on that `null` **inside the argument list of `super(...)`**, so those inputs produced a `NullPointerException` that named no parameter. The author could not have fixed it: before Java 25 nothing was allowed to precede an explicit constructor invocation, so there was no place in the constructor to put the check.

A prologue now validates first and throws a `ParseException` naming the offending value. This class is a JAX-RS `@PathParam` binder used by `BundleResource.deleteBundlesOlderThan`, so the string is untrusted request input.

The prologue is visible in the bytecode — the null check completes before `invokespecial Date.<init>`:

```
 1: invokestatic  DateUtil.parseISO
 7: if_acmpne     25
24: athrow                      // ParseException
30: invokespecial Date."<init>":(J)V
```

## 2. `ThreadContextUtil` — scoped value for the reindex flag (JEP 506)

`wrapVoidNoReindex` / `wrapReturnNoReindex` were a hand-written dynamically scoped binding — read the old value, rebind, run the delegate, restore in a `finally` — duplicated across both methods. That is precisely what `ScopedValue.where(...).call(...)` does, so the two copies collapse into one and the restore can no longer be skipped.

**`includeDependencies` is deliberately *not* migrated.** It travels **callee to caller**: `ESContentletAPIImpl` records it deep in the stack and `WorkflowAPIImpl.fireWorkflowPostCheckin` consumes it afterwards. A scoped binding is immutable by design, so it cannot express an out-channel — it stays in the mutable `ThreadContext`. Both classes now document why the two pieces of state use different mechanisms.

Verified that no `wrap*` call site crosses an executor before the flag is read; `ScopedValue` does not propagate through `DotSubmitter`.

## 3. `Config` — re-entrancy guard via `ScopedValue.isBound()`

Reading a property can consult the system table, and consulting the system table reads properties in order to reach the database — so the lookup must detect re-entry. The guard was a mutable `tag` string on the per-thread `ThreadContext` whose `finally` assigned `null` rather than restoring the previous value.

**To be clear, this is not a live defect** — the nested call returns before the `try`, so two levels never coexist, and a test in this PR confirms the existing guard blocks recursion correctly. What the change buys:

- `isBound()` makes that class of mistake unwritable: a single shared slot used as a one-deep stack, with an exit path that assumes it was empty on entry.
- It drops a per-thread allocation. `getOrCreateContext()` **installs** a `ThreadContext` in a thread local for every thread that ever reads a config property, cleared only by `ThreadLocalCleanupShutdownTask` — which reaches into private static fields by reflection to do it.

This was the sole user of `ThreadContext.tag`, and the reindex flag was the sole user of `ThreadContext.reindex`, so both fields are removed. **`ThreadContext` goes from three fields to one.**

## Testing

22 new unit tests: 9 for `ISODateParam`, 9 for `ThreadContextUtil`, 4 for the `Config` guard.

- The four `ISODateParam` null-input tests were **confirmed failing with `NullPointerException`** before the fix (Red), then green.
- The `ThreadContextUtil` tests pass **before and after by design** — they are the regression net proving the rewrite preserves behaviour, including that a throwing delegate still restores the flag and that a nested wrap restores the *enclosing* value rather than the default.
- The `Config` guard tests pin that a nested lookup never reaches the source, that the guard is released after the outer lookup returns, and that it is released when the source throws.

Full `dotcms-core` unit suite green: **3463 tests, 0 failures, 0 errors**, 17 skipped.

Integration tests were not run. These are pure unit tests and register in no suite, but `ESContentletAPIImpl` and `WorkflowAPIImpl` exercise the reindex flag in ITs — worth a workflow/contentlet battery before merge.

## Notes for the reviewer

- Requires the Java 25 compile target, which is already the default (`dotcms.core.compiler.release`). Neither `ScopedValue` nor flexible constructor bodies is a preview feature in 25, so no `--enable-preview` is needed for these.
- Adjacent finding **not** addressed here: `includeDependencies` is never cleared between workflow fires, so on a pooled thread it stays `true` after the first deferred reindex. That over-indexes rather than under-indexes, and changing it could reduce indexing where someone relies on it — flagging rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34154
