### PR TITLE
fix(security): upgrade Bouncy Castle 1.84 → 1.85 (CVE-2026-59638)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -21,7 +21,7 @@
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.18.1</bytebuddy.version>
         <batik.version>1.17</batik.version>
-        <bouncy-castle.version>1.84</bouncy-castle.version>
+        <bouncy-castle.version>1.85</bouncy-castle.version>
         <awaitility.version>4.0.0</awaitility.version>
         <shedlock.version>4.33.0</shedlock.version>
         <jackson.version>2.17.2</jackson.version>

--- a/independent-projects/core-plugins/tika-plugin/pom.xml
+++ b/independent-projects/core-plugins/tika-plugin/pom.xml
@@ -14,6 +14,7 @@
         <osgi.core.version>8.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
         <tika.version>3.3.1</tika.version>
+        <bouncy-castle.version>1.85</bouncy-castle.version>
         <skip.rewrite>true</skip.rewrite>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -21,6 +22,39 @@
         <!-- Pinned to Java 11 for OSGi/portability; preview features cannot be enabled at release 11. -->
         <maven.compiler.enablePreview>false</maven.compiler.enablePreview>
     </properties>
+
+    <!--
+        Tika drags BouncyCastle in transitively (bcjmail -> bcpkix -> bcutil, plus bcprov) and
+        this module does NOT import bom/application/pom.xml, so <bouncy-castle.version> there does
+        not govern what the bundle embeds. Pin the versions here instead of moving to Tika 3.3.2:
+        that release also makes the SAX-based OOXML parsers the default, which would change text
+        extraction for every docx/pptx/xlsx.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcjmail-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>

--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.dotcms.samlbundle</groupId>
             <artifactId>com.dotcms.samlbundle</artifactId>
-            <version>26.03.17</version>
+            <version>26.08.21</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
### Proposed Changes

Raises BouncyCastle from 1.84 to 1.85 for #37085. Three files, all poms:

* `bom/application/pom.xml` — `<bouncy-castle.version>` 1.84 → 1.85. The artifactIds are already `jdk18on` (renamed by #35897), so this is a pure version change.
* `independent-projects/core-plugins/tika-plugin/pom.xml` — pin the four BouncyCastle artifacts the Tika OSGi bundle embeds at the same version, via a local `dependencyManagement` block.
* `osgi-base/system-bundles/pom.xml` — move `com.dotcms.samlbundle` from `26.03.17` to `26.08.21`, the release that carries BouncyCastle 1.85 inside the SAML bundle.

That is all three BouncyCastle locations #37085 tracks, up to the two exclusions noted below.

### Why the tika-plugin needs its own pin

`independent-projects/pom.xml` and `independent-projects/core-plugins/pom.xml` import no BOM, so `<bouncy-castle.version>` never reached that module. Before this change the bundle embedded, resolved through Tika's own parent pom:

```
+- org.bouncycastle:bcjmail-jdk18on:jar:1.84:runtime
|  \- org.bouncycastle:bcpkix-jdk18on:jar:1.84:runtime
|     \- org.bouncycastle:bcutil-jdk18on:jar:1.84:runtime
\- org.bouncycastle:bcprov-jdk18on:jar:1.84:runtime
```

A BOM-only bump would have left a 1.84 scanner finding in place.

### Why pin rather than move to Tika 3.3.2

Tika 3.3.2 pins BC 1.85 upstream, which would be the tidier route, but the same patch release also ports the 4.x SAX-based OOXML parsers to 3.x **and makes SAX the default**. `TikaProxy` uses a stock `AutoDetectParser` + `BodyContentHandler` and there is no `tika-config` anywhere in the repo, so nothing would hold the old behavior — text extraction would change for every docx/pptx/xlsx/vsdx a customer uploads. The BouncyCastle delta is a patch release and inside Tika only touches encrypted PDFs and signed documents, so pinning has the smaller blast radius. Trade-off accepted: BC 1.85 with Tika 3.3.1 is a combination Apache did not test.

Happy to switch to the Tika bump instead if reviewers prefer the upstream-tested pairing over holding the parser behavior.

### Why the samlbundle change is only a pointer

The SAML plugin is a prebuilt OSGi bundle that embeds its own BouncyCastle copy inside the bundle jar, at `libs/bcprov-*.jar`. That copy is out of reach of `bom/application/pom.xml` entirely, so no property in this repo governs it — the fix had to happen in the plugin repo and be released.

dotCMS/com.dotcms.dotsaml#24 did that: `bcprov-jdk15on:1.54` → `bcprov-jdk18on:1.85`. Note it is an artifactId migration, not only a version bump — the `jdk15on` coordinates are frozen at 1.70, so 1.85 only exists as `jdk18on`. That PR also had to move its `provided` `dotcms-core` dep to `26.03.27-01` (the plugin's `main` did not compile without it, because `#34700` had introduced a `com.dotcms.saml.SamlNameID` reference against an older pin), and it cut plugin release `26.08.21`.

Until this one line moves, core keeps shipping the **1.54** jar — by far the oldest BouncyCastle in the distribution — and the customer scanner keeps flagging it.

Only the one line needs to change. `maven-dependency-plugin` `copy-dependencies` pulls `provided`-scope deps into `target/bundle` by coordinate, so no filename is hardcoded in the build, and the other `samlbundle` references in the tree are all version-agnostic: `OSGIConstants.BUNDLE_NAME_DOTCMS_SAML` matches on symbolic name, and `GenericBundleActivatorIntegrationTest` and `OsgiVersion1.postman_collection.json` filter by symbolic name or substring. (`JSONToolTest` contains the literal `com.dotcms.samlbundle-21.03.1.jar`, but that is a hardcoded mock JSON payload for a parser test, not a version reference.)

### Why 1.85 and not 1.85.2

`bcprov-jdk18on` publishes a 1.85.2; `bcpkix-jdk18on`, `bcutil-jdk18on` and `bcjmail-jdk18on` do not. Both the BOM and the new pin drive every artifact from one shared property, so 1.85 is the highest version available across the whole set.

### CVE context

* CVE-2026-59638 — BC JSSE hostname verifier falls back to the certificate CN, CVSS 9.3, affects bcprov 1.61 up to but excluding 1.85. `main` shipped 1.84, i.e. inside the affected range.
* Reachability in dotCMS: none found. Core registers no `BouncyCastleProvider` and uses no BC JSSE. The only direct BC import is `XmlToolCache` (SHA1Digest + Base64 for a Velocity cache key). This unblocks a customer scanner rather than closing an exploitable path.
* The SAML bundle is likewise not reachable: the plugin has zero direct `org.bouncycastle` imports across its 69 source files and no TLS/JSSE code; the jar is embedded purely so OpenSAML can find it at runtime. Note its 1.54 predates the CVE's 1.61 floor, so that jar was never in the affected range for *this* CVE — it is upgraded because a decade-old crypto library is its own finding.
* Out of scope, documented in #37085: the 758-file vendored BC fork repackaged to `com.dotcms.enterprise.license.bouncycastle` under `dotCMS/src/enterprise/`. It carries no Maven coordinates, so no version property governs it.

### Verification

* Reactor-wide `./mvnw dependency:tree -Dincludes=org.bouncycastle`: all 24 modules resolve BouncyCastle at 1.85 — `dotcms-core`, `dotcms-integration`, `dotcms-reports` and the Tika bundle — none left on 1.84, no version conflict reported.
* All four 1.85 artifacts confirmed present on Maven Central and on `repo.dotcms.com/artifactory/libs-release`.
* `samlbundle:26.08.21` confirmed resolvable from `repo.dotcms.com` via `mvn dependency:get` before the pointer was moved. The resolved artifact carries `Bundle-Version: 26.08.21` and embeds `libs/bcprov-jdk18on-1.85.jar`, with no 1.54 residue.
* `com.dotcms.saml.SamlNameID` confirmed present on `main`, so the bundle's runtime dependency is satisfied — that was the one failure mode that would surface at runtime rather than at build time.
* The equivalent change on `release-25.07.10_lts` was built locally (`install -pl :dotcms-core --am`, JDK 21): green, and the assembled webapp carries `bcprov/bcpkix/bcutil-jdk18on-1.85.jar`.
* CI here is the real signal for the Tika pin — the Postman and E2E suites exercise file upload and metadata extraction, which is what the pin could plausibly break.

### Checklist
- [ ] Tests — no test changes; dependency versions only
- [ ] Translations — n/a
- [x] Security Implications Contemplated — raises a crypto library within a patch series. No API, algorithm, or provider-registration change on our side.

### Additional Info

An LTS backport of the BOM and Tika diff is staged for `release-25.07.10_lts` and will be opened once this PR is green, since PRs based on LTS branches run no build or tests.

**The samlbundle part cannot be backported as-is.** A bundle cut from the plugin's `main` cannot ship on the 25.07.10 LTS line: `main` uses `SamlNameID` in four files (both logout handlers, `OpenSamlAuthenticationServiceImpl`, `SamlUtils`), and `dotcms-core` `25.07.10_lts_v17` and `_v16` do not contain `com/dotcms/saml/SamlNameID.class` — it would fail with `NoClassDefFoundError` on the SAML authentication and logout paths. The LTS line needs its own plugin release cut from the `25.06.3` point, which predates the plugin's Gradle→Maven migration and declares BouncyCastle in `build.gradle` rather than a pom. Handled separately.

Related to #37085 — deliberately not `Fixes`, since the issue also covers the LTS line and should stay open until that lands.

This PR fixes: #37085

This PR fixes: #37085