### PR TITLE
fix(ui): prevent ng-event listener accumulation on iframe reload

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.spec.ts
@@ -219,7 +219,7 @@ describe('IframeComponent', () => {
             };
         });
 
-        it('should remove and add listener on load', () => {
+        it('should remove and add listener on load using the same stable function references', () => {
             iframeEl.triggerEventHandler('load', {
                 target: {
                     contentDocument: {
@@ -228,19 +228,26 @@ describe('IframeComponent', () => {
                 }
             });
 
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const keyDownRef = (comp as any).boundEmitKeyDown;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const customEventRef = (comp as any).boundEmitCustomEvent;
+
+            // remove must receive the exact same reference as add so the browser
+            // can actually deregister the handler instead of silently failing
             expect(
                 comp.iframeElement.nativeElement.contentWindow.removeEventListener
-            ).toHaveBeenCalledWith('keydown', expect.any(Function));
+            ).toHaveBeenCalledWith('keydown', keyDownRef);
             expect(
                 comp.iframeElement.nativeElement.contentWindow.document.removeEventListener
-            ).toHaveBeenCalledWith('ng-event', expect.any(Function));
+            ).toHaveBeenCalledWith('ng-event', customEventRef);
 
             expect(
                 comp.iframeElement.nativeElement.contentWindow.addEventListener
-            ).toHaveBeenCalledWith('keydown', expect.any(Function));
+            ).toHaveBeenCalledWith('keydown', keyDownRef);
             expect(
                 comp.iframeElement.nativeElement.contentWindow.document.addEventListener
-            ).toHaveBeenCalledWith('ng-event', expect.any(Function));
+            ).toHaveBeenCalledWith('ng-event', customEventRef);
         });
 
         it('should set the colors to the jsp on load', () => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.ts
@@ -76,6 +76,13 @@ export class IframeComponent implements OnInit, OnDestroy {
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
+    // Stable bound references required so removeEventListener can match the
+    // exact function object that was passed to addEventListener. Using
+    // .bind(this) inline creates a new object each call, making removal a
+    // no-op and causing listeners to accumulate on every iframe load event.
+    private readonly boundEmitKeyDown = this.emitKeyDown.bind(this);
+    private readonly boundEmitCustomEvent = this.emitCustonEvent.bind(this);
+
     ngOnInit(): void {
         this.iframeOverlayService.overlay
             .pipe(takeUntil(this.destroy$))
@@ -264,17 +271,11 @@ export class IframeComponent implements OnInit, OnDestroy {
     }
 
     private handleIframeEvents($event): void {
-        this.getIframeWindow().removeEventListener('keydown', this.emitKeyDown.bind(this));
-        this.getIframeWindow().document.removeEventListener(
-            'ng-event',
-            this.emitCustonEvent.bind(this)
-        );
+        this.getIframeWindow().removeEventListener('keydown', this.boundEmitKeyDown);
+        this.getIframeWindow().document.removeEventListener('ng-event', this.boundEmitCustomEvent);
 
-        this.getIframeWindow().addEventListener('keydown', this.emitKeyDown.bind(this));
-        this.getIframeWindow().document.addEventListener(
-            'ng-event',
-            this.emitCustonEvent.bind(this)
-        );
+        this.getIframeWindow().addEventListener('keydown', this.boundEmitKeyDown);
+        this.getIframeWindow().document.addEventListener('ng-event', this.boundEmitCustomEvent);
         this.charge.emit($event);
 
         const doc = this.getIframeDocument();


### PR DESCRIPTION
## Summary

Fixes #34534 — saving new content via a workflow action with **Allow Comments** enabled fails with a unique constraint error on URLTitle (and `identifier_pkey` at the DB level).

- **Root cause:** `IframeComponent.handleIframeEvents()` called `.bind(this)` inline for both `addEventListener` and `removeEventListener`. Each `.bind()` call creates a new function object, so `removeEventListener` never matched the previously registered handler — silently accumulating an extra `ng-event` listener on the iframe document on every `onLoad` event. With two listeners, the `workflow-wizard` custom event reached Angular twice, triggering two concurrent `ContentletAjax.saveContent` DWR calls. Both calls saw an empty inode (new content) and raced to `INSERT` the same deterministic identifier, the second losing with a unique constraint violation.
- **Fix:** Bind the handler references once as class fields (`boundEmitKeyDown`, `boundEmitCustomEvent`) so the same stable object is passed to both `addEventListener` and `removeEventListener`, ensuring each `onLoad` correctly replaces the listener instead of stacking a new one.
- **Test updated:** The existing spec now asserts the same function reference is used for both add and remove, which is the invariant the fix enforces.

## Test plan

- [ ] `pnpm nx test dotcms-ui --testPathPattern=iframe.component.spec` passes
- [ ] Open the content editor for a **new** contentlet
- [ ] Use a workflow action with **Allow Comments** enabled, enter a comment, and submit
- [ ] Confirm only **one** `ContentletAjax.saveContent` call appears in the Network tab (previously two)
- [ ] Confirm the content saves without a unique constraint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)