### PR TITLE
docs(speckit): link the quick start walkthrough video

### DIFF
--- a/docs/core/SPEC_KIT_QUICK_START.md
+++ b/docs/core/SPEC_KIT_QUICK_START.md
@@ -4,6 +4,9 @@ Get from an issue to merged code using spec-driven development in this repo — 
 spec is approved first, the implementation follows. Sections 1-4 are the ones to actually read (~5 min);
 the rest is reference you consult when you hit it.
 
+> 🎥 **New to this?** Watch the [walkthrough video](https://drive.google.com/file/d/1XhQBgbME2XejZ7PHc7-xNdFtaXUFOULL/view?usp=sharing) first — it covers the same
+> ground in a few minutes. This doc is what you come back to afterward.
+
 > **See also:** [`.specify/memory/constitution.md`](../../.specify/memory/constitution.md)
 > — the project law every `/speckit-*` command loads. If a command pushes back on you,
 > it's almost always quoting this file.
@@ -433,6 +436,7 @@ and it never creates, edits, or commits an ADR.
 
 ## Reference
 
+- Walkthrough video: [Spec-Kit quick start (Google Drive)](https://drive.google.com/file/d/1XhQBgbME2XejZ7PHc7-xNdFtaXUFOULL/view?usp=sharing)
 - Install, customizations, upgrade notes: [`.specify/CUSTOMIZATIONS.md`](../../.specify/CUSTOMIZATIONS.md)
 - Project law: [`.specify/memory/constitution.md`](../../.specify/memory/constitution.md)
 - Worked examples: [#37070](https://github.com/dotCMS/core/issues/37070) (feature, §5) and [#36958](https://github.com/dotCMS/core/issues/36958) (bug, §6)


### PR DESCRIPTION
## What

Adds the recorded walkthrough video to `docs/core/SPEC_KIT_QUICK_START.md`, in two places for the two ways people arrive at the doc:

- **Above the fold** — so someone meeting spec-driven development for the first time can watch before reading 440 lines.
- **In `## Reference`** — so it stays findable once you already know it exists.

Four added lines, nothing else touched. Follows #37094.

## Before merging

Please confirm the Google Drive link is shared with the whole org. A doc-linked video that 404s for the reader is worse than no link, and the sharing scope isn't something I can check. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)