### PR TITLE
fix(ci): stop unbounded apt-get from hanging release and PR pipelines

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-jfrog/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-jfrog/action.yml
@@ -40,11 +40,6 @@ runs:
   steps:
     - uses: actions/checkout@v4
 
-    - name: Install xmllint
-      run: |
-        sudo apt-get update && sudo apt-get install -y libxml2-utils
-      shell: bash
-
     - uses: ./.github/actions/core-cicd/maven-job
       with:
         github-token: ${{ inputs.github-token }}
@@ -153,7 +148,7 @@ runs:
         echo "NODE_TYPE=$NODE_TYPE"
 
         # Extract the repository URL from the POM file
-        REPO=$(xmllint --xpath "//*[local-name()='distributionManagement']/*[local-name()='$NODE_TYPE']/*[local-name()='url']/text()" "$POM_FILE" 2>/dev/null)
+        REPO=$(mvn -f "$POM_FILE" -N help:evaluate -Dexpression=project.distributionManagement.$NODE_TYPE.url -q -DforceStdout 2>/dev/null)
         
         if [[ "$REPO" =~ ^(https://[^/]+/[^/]+)/(.+)$ ]]; then
           SERVER_URL="${BASH_REMATCH[1]}"

--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -254,8 +254,11 @@ jobs:
       # The libvips image engine (IMAGE_API_USE_LIBVIPS) is exercised by VipsParityTest.
       # Install native libvips on the JVM unit-test runner so those tests run instead of
       # self-skipping. Ubuntu 24.04 libvips42 bundles the pdf/heif/svg/webp/jxl delegates.
+      # Bounded: a wedged Ubuntu mirror hung this class of step for hours (#37118).
+      # Normally ~12s, so 5m fails loud and fast instead of burning the job timeout.
       - name: Install native libvips (image engine parity tests)
         if: matrix.test_type == 'jvm'
+        timeout-minutes: 5
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libvips42 libheif-plugin-aomenc
 
       - name: Run ${{ matrix.name }}

--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -254,11 +254,13 @@ jobs:
       # The libvips image engine (IMAGE_API_USE_LIBVIPS) is exercised by VipsParityTest.
       # Install native libvips on the JVM unit-test runner so those tests run instead of
       # self-skipping. Ubuntu 24.04 libvips42 bundles the pdf/heif/svg/webp/jxl delegates.
-      # Bounded: a wedged Ubuntu mirror hung this class of step for hours (#37118).
-      # Normally ~12s, so 5m fails loud and fast instead of burning the job timeout.
+      # Bounded so a wedged Ubuntu mirror can't burn the job timeout (#37118).
+      # 15m, not tighter: measured median 21s but max 521s on a throttled mirror
+      # (198 kB/s) that still succeeded. The hang case ran 3h+, so 15m separates
+      # the two without tripping on slow-but-alive fetches.
       - name: Install native libvips (image engine parity tests)
         if: matrix.test_type == 'jvm'
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libvips42 libheif-plugin-aomenc
 
       - name: Run ${{ matrix.name }}


### PR DESCRIPTION
Two CI steps ran `sudo apt-get update` with nothing bounding it. When the Azure Ubuntu mirror wedged on 2026-08-19, apt fell back to `archive.ubuntu.com`, started the `InRelease` fetches, and then simply stopped making progress. A step that *hangs* sails straight past `set -e -o pipefail`, so nothing failed — the job just ran until a human cancelled it: 4h24m on [32264406479](https://github.com/dotCMS/core/actions/runs/32264406479), 3h26m on [32298005348](https://github.com/dotCMS/core/actions/runs/32298005348).

Both sites are fixed, by different means, because the dependency is different.

### 1. Release path — `deploy-jfrog/action.yml`: drop apt entirely

`xmllint` was called exactly once, to read `distributionManagement/<repository|snapshotRepository>/url` from `pom.xml`. Three sibling steps in the same action already read POM values with `mvn help:evaluate`, so use that and delete the install step. The release path now touches no Ubuntu package mirror at all.

Verified against `pom.xml` — identical to the `xmllint` xpath for both node types:

- `repository` → `https://repo.dotcms.com/artifactory/libs-release-local`
- `snapshotRepository` → `https://repo.dotcms.com/artifactory/libs-snapshot-local`

Composite-action steps can't carry `timeout-minutes`, so removing the dependency was the only real option here.

### 2. PR path — `cicd_comp_test-phase.yml`: bound it

`libvips42` / `libheif-plugin-aomenc` are genuine runtime deps for `VipsParityTest`, so this one keeps apt and gets a `timeout-minutes: 15`.

The cap is measured, not guessed. Sampling **41 successful runs** of that step across the PR, trunk, nightly and merge-queue callers:

| | |
|---|---|
| median | 18s |
| p90 | 117s |
| p95 | 216s |
| max | **521s (8m41s)** |

That max — run [32295540104](https://github.com/dotCMS/core/actions/runs/32295540104), 8m41s, conclusion `success` — is the load-bearing case, because its log says:

```
Fetched 11.4 MB in 58s (198 kB/s)
```

The mirror was **alive but throttled**, not wedged, and the install completed fine. An earlier revision of this PR used a 5m cap, which would have failed that run (2.4% of samples) and came within 36s of failing a merge-queue run at 264s ([32163267363](https://github.com/dotCMS/core/actions/runs/32163267363)) — a trip there blocks the queue, not just one PR. Since throughput degradation has no natural floor, a cap set near the slow end keeps tripping.

15m rather than 10m: the failure being caught ran 3h+, so both catch it identically, but 15m sits 1.7x above the worst real case instead of 1.2x.

Deliberately left fatal rather than `continue-on-error`: the parity tests self-skip when libvips is missing, so swallowing the failure would quietly drop that coverage instead of surfacing a retryable red X.

### Notes

Unrelated to #36807 (dev-image pgvector) — run -01 hung on this step at 15:41Z, over four hours before that PR merged at 20:05Z. What #36807 fixed was the dev-image build, which had been masking this hang further down the same job.

Ubuntu versions were not a factor: the runner was 24.04.4 on image `ubuntu-24.04` built 2026-08-10, and the Microsoft/Google third-party repos in the same `apt-get update` fetched fine in under a second.

Closes: #37118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX6GeNqyq1xRX1zzi1KtVn

