### PR TITLE
feat(ci): manual changelog site publish + fix release-notes auto-detect

### DIFF
--- a/.github/scripts/gather-release-data/src/github.test.ts
+++ b/.github/scripts/gather-release-data/src/github.test.ts
@@ -39,7 +39,15 @@ describe('extractPRNumbers', () => {
 });
 
 describe('findPreviousTag', () => {
-  const tags = ['v26.03.13-02', 'v26.03.13-01', 'v26.03.12-01', 'v26.03.11-01'];
+  const documented = (...tags: string[]) =>
+    tags.map((tag) => ({ tag, hasNotes: true }));
+
+  const tags = documented(
+    'v26.03.13-02',
+    'v26.03.13-01',
+    'v26.03.12-01',
+    'v26.03.11-01'
+  );
 
   it('finds the tag immediately before the given tag', () => {
     expect(findPreviousTag(tags, 'v26.03.13-02')).toBe('v26.03.13-01');
@@ -53,6 +61,35 @@ describe('findPreviousTag', () => {
 
   it('returns undefined for the oldest tag', () => {
     expect(findPreviousTag(tags, 'v26.03.11-01')).toBeUndefined();
+  });
+
+  // Regression: 26.08.19 shipped four attempts. -01/-02/-03 died before writing
+  // notes, so stopping at -03 described 1 of 19 commits.
+  it('skips undocumented releases', () => {
+    const withGhosts = [
+      { tag: 'v26.08.19-04', hasNotes: true },
+      { tag: 'v26.08.19-03', hasNotes: false },
+      { tag: 'v26.08.19-02', hasNotes: false },
+      { tag: 'v26.08.19-01', hasNotes: false },
+      { tag: 'v26.08.14-01', hasNotes: true },
+    ];
+    expect(findPreviousTag(withGhosts, 'v26.08.19-04')).toBe('v26.08.14-01');
+  });
+
+  it('still returns a same-day attempt that published notes', () => {
+    const sameDay = [
+      { tag: 'v26.08.12-02', hasNotes: true },
+      { tag: 'v26.08.12-01', hasNotes: true },
+    ];
+    expect(findPreviousTag(sameDay, 'v26.08.12-02')).toBe('v26.08.12-01');
+  });
+
+  it('returns undefined when every predecessor is undocumented', () => {
+    const allGhosts = [
+      { tag: 'v26.08.19-02', hasNotes: true },
+      { tag: 'v26.08.19-01', hasNotes: false },
+    ];
+    expect(findPreviousTag(allGhosts, 'v26.08.19-02')).toBeUndefined();
   });
 });
 

--- a/.github/scripts/gather-release-data/src/github.ts
+++ b/.github/scripts/gather-release-data/src/github.ts
@@ -27,44 +27,60 @@ export function parseRepo(fullRepo: string): { owner: string; repo: string } {
   return { owner, repo };
 }
 
+/** A published standard release, and whether its notes were ever written. */
+export interface ReleaseRef {
+  tag: string;
+  /** False when the release body is empty — a cut whose pipeline died before notes. */
+  hasNotes: boolean;
+}
+
 /**
- * List standard release tags (matching vYY.MM.DD-NN pattern), sorted by
- * creation date descending (newest first).
+ * List standard releases (matching vYY.MM.DD-NN pattern), newest first.
+ *
+ * Drafts are skipped: listReleases returns them first regardless of date, so they
+ * corrupt the ordering this function promises, and a draft may duplicate a real tag.
  */
 export async function listStandardReleaseTags(
   octokit: Octokit,
   owner: string,
   repo: string
-): Promise<string[]> {
-  const tags: string[] = [];
+): Promise<ReleaseRef[]> {
+  const releases: ReleaseRef[] = [];
   for await (const response of octokit.paginate.iterator(
     octokit.repos.listReleases,
     { owner, repo, per_page: 100 }
   )) {
     for (const release of response.data) {
+      if (release.draft) continue;
       if (STANDARD_RELEASE_PATTERN.test(release.tag_name)) {
-        tags.push(release.tag_name);
+        releases.push({
+          tag: release.tag_name,
+          hasNotes: (release.body ?? '').trim().length > 0,
+        });
       }
     }
   }
-  return tags;
+  return releases;
 }
 
 /**
- * Find the previous standard release tag before `currentTag`.
- * Tags are ordered newest-first from the API.
+ * Find the previous documented release before `currentTag`.
+ *
+ * Undocumented releases are skipped. A cut whose pipeline died before writing notes
+ * describes none of its commits, so those commits belong in this range — stopping at
+ * its tag would strand them. A same-day attempt that DID publish notes is a valid
+ * boundary and is returned normally.
  */
 export function findPreviousTag(
-  tags: string[],
+  releases: ReleaseRef[],
   currentTag: string
 ): string | undefined {
-  const idx = tags.indexOf(currentTag);
+  const idx = releases.findIndex((r) => r.tag === currentTag);
   if (idx === -1) {
     // Tag not found in release history — caller must handle
     return undefined;
   }
-  // Return the next tag after the current one (i.e., the one before it chronologically)
-  return tags[idx + 1];
+  return releases.slice(idx + 1).find((r) => r.hasNotes)?.tag;
 }
 
 /**

--- a/.github/scripts/gather-release-data/src/index.ts
+++ b/.github/scripts/gather-release-data/src/index.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
 
     // Validate that toTag is visible in the release list. If it's missing,
     // the GitHub releases API hasn't indexed the newly published release yet.
-    if (!tags.includes(args.toTag)) {
+    if (!tags.some((r) => r.tag === args.toTag)) {
       process.stderr.write(
         `Error: ${args.toTag} not found in GitHub releases API. ` +
           `The release may not have been published yet, or the API has not caught up. ` +

--- a/.github/workflows/cicd_comp_changelog-site-publish-phase.yml
+++ b/.github/workflows/cicd_comp_changelog-site-publish-phase.yml
@@ -33,6 +33,16 @@ on:
         description: 'Space-separated docker image tags produced by the deployment phase'
         required: true
         type: string
+      force:
+        description: 'Override human-edit protection and update in place. Manual operator use only — the release pipeline never sets this.'
+        required: false
+        type: boolean
+        default: false
+      released_date:
+        description: 'Availability date (yyyy-MM-dd). Defaults to today, which is correct for a live release; a manual backfill of an older release should pass that release''s own date.'
+        required: false
+        type: string
+        default: ''
       allow_failure:
         description: 'If true, job failures are non-blocking (used by release pipeline). Defaults to false.'
         required: false
@@ -109,10 +119,12 @@ jobs:
           DOTCMS_DEVSITE_URL: ${{ vars.DOTCMS_DEVSITE_URL }}
           # Read once by the tool; never echoed to logs / GITHUB_OUTPUT / step summary.
           DOTCMS_DEVSITE_RELEASENOTES_TOKEN: ${{ secrets.DOTCMS_DEVSITE_RELEASENOTES_TOKEN }}
-          # Service-account modUser id for human-edit protection (FR-011). --force is never
-          # passed here — override is a manual operator re-run only.
+          # Service-account modUser id for human-edit protection (FR-011). The release
+          # pipeline never sets force; only a manual operator re-run does.
           DOTCMS_DEVSITE_RELEASENOTES_ACCOUNT: ${{ vars.DOTCMS_DEVSITE_RELEASENOTES_ACCOUNT }}
           DOCKER_TAGS: ${{ inputs.docker_tags }}
+          FORCE: ${{ inputs.force }}
+          RELEASED_DATE: ${{ inputs.released_date }}
         run: |
           # Pick the sha-tagged dotcms/dotcms image (version_sha form, e.g.
           # dotcms/dotcms:26.07.10-01_84b0486). The `_` in the glob excludes the floating
@@ -130,13 +142,17 @@ jobs:
           # T005 contract (0 = success/skip via ::changelog-skip:: marker; non-zero = failure).
           # This step itself always exits 0 so the branch steps run and the release is never
           # blocked (FR-008); the job is also allow_failure as belt-and-suspenders.
+          # ponytail: empty force/released_date are the pipeline's path — same command as before.
+          FORCE_FLAG=""
+          [ "$FORCE" = "true" ] && FORCE_FLAG="--force"
+
           set +e
           OUTPUT=$(uv run changelog-publisher publish \
             --version "$RELEASE_VERSION" \
             --notes-file /tmp/site-release-notes.md \
             --docker-image "$DOCKER_IMAGE" \
-            --released-date "$(date -u +%F)" \
-            --apply 2>&1)
+            --released-date "${RELEASED_DATE:-$(date -u +%F)}" \
+            --apply $FORCE_FLAG 2>&1)
           RC=$?
           set -e
           echo "$OUTPUT"

--- a/.github/workflows/cicd_manual_changelog-site-publish.yml
+++ b/.github/workflows/cicd_manual_changelog-site-publish.yml
@@ -1,0 +1,87 @@
+#
+# Changelog Site Publish — Manual Trigger
+#
+# Standalone workflow for (re-)publishing a release's changelog to dev.dotcms.com.
+# Calls the same reusable component used by the release pipeline, so the credentials
+# (DOTCMS_DEVSITE_URL / _RELEASENOTES_TOKEN / _RELEASENOTES_ACCOUNT) stay in repo
+# vars+secrets — an operator needs only the release tag.
+#
+# Use cases:
+# - A release whose site publish never ran (deployment failed, so the phase was skipped)
+# - Re-syncing the site after hand-editing a GitHub release body
+# - Overriding human-edit protection (`force`) after a skip names a human editor
+#
+# Prerequisite: the GitHub release body must already hold the changelog. Generate it
+# first with cicd_ai-release-notes-backfill.yml — this workflow only copies, never writes.
+#
+
+name: 'Changelog Site Publish (Manual)'
+run-name: "Changelog Site: ${{ inputs.release_tag }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish (e.g., v26.08.19-04)'
+        required: true
+        type: string
+      force:
+        description: 'Override human-edit protection — only after a dry run names a human editor'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: changelog-site-publish-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  # The release pipeline gets release_version and docker_tags from upstream jobs. A manual
+  # run has neither, so derive both from the tag rather than making an operator hunt for a sha.
+  resolve:
+    name: Resolve Version and Image
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    outputs:
+      release_version: ${{ steps.r.outputs.release_version }}
+      docker_tags: ${{ steps.r.outputs.docker_tags }}
+      released_date: ${{ steps.r.outputs.released_date }}
+    steps:
+      - name: Resolve
+        id: r
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          GH_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          echo "release_version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          # Backfilling an older release must stamp that release's date, not today's.
+          PUBLISHED=$(gh release view "$RELEASE_TAG" --repo "$REPO" --json publishedAt --jq '.publishedAt[0:10]')
+          echo "released_date=${PUBLISHED}" >> "$GITHUB_OUTPUT"
+
+          # Prefer the sha-tagged image (e.g. 26.08.19-04_a0181f9) so a manual entry matches
+          # what the pipeline would have written. Hub is public; no auth needed.
+          TAG=$(curl -fsSL \
+            "https://hub.docker.com/v2/repositories/dotcms/dotcms/tags/?name=${VERSION}_&page_size=100" \
+            | jq -r --arg v "$VERSION" \
+                '[.results[].name | select(test("^" + $v + "_[0-9a-f]+$"))] | first // empty')
+          # ponytail: sha-less fallback keeps a publish possible if Hub paging ever changes shape.
+          echo "docker_tags=dotcms/dotcms:${TAG:-$VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${VERSION} -> dotcms/dotcms:${TAG:-$VERSION}"
+
+  publish:
+    name: Publish Site Changelog
+    needs: resolve
+    uses: ./.github/workflows/cicd_comp_changelog-site-publish-phase.yml
+    with:
+      release_tag: ${{ inputs.release_tag }}
+      release_version: ${{ needs.resolve.outputs.release_version }}
+      docker_tags: ${{ needs.resolve.outputs.docker_tags }}
+      released_date: ${{ needs.resolve.outputs.released_date }}
+      force: ${{ inputs.force }}
+    secrets:
+      DOTCMS_DEVSITE_RELEASENOTES_TOKEN: ${{ secrets.DOTCMS_DEVSITE_RELEASENOTES_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}

--- a/.github/workflows/cicd_manual_changelog-site-publish.yml
+++ b/.github/workflows/cicd_manual_changelog-site-publish.yml
@@ -71,9 +71,26 @@ jobs:
           echo "docker_tags=dotcms/dotcms:${TAG:-$VERSION}" >> "$GITHUB_OUTPUT"
           echo "Resolved ${VERSION} -> dotcms/dotcms:${TAG:-$VERSION}"
 
+  # This writes to the public docs site with a service-account token, and workflow_dispatch
+  # is open to every account with write access on this repo (45 today). Reviewer approval
+  # is the access control — same pattern as cicd_evergreen-tracks-promote.yml's apply gate.
+  # The environment must carry required_reviewers; GitHub auto-creates it UNPROTECTED on
+  # first use if it is missing, which would silently remove this gate.
+  gate:
+    name: Approve Site Publish
+    needs: resolve
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    environment: changelog-site-publish
+    steps:
+      - run: |
+          echo "Approved: publish ${{ inputs.release_tag }} to the changelog site"
+          echo "Image: ${{ needs.resolve.outputs.docker_tags }}"
+          echo "Date:  ${{ needs.resolve.outputs.released_date }}"
+          echo "Force: ${{ inputs.force }}"
+
   publish:
     name: Publish Site Changelog
-    needs: resolve
+    needs: [resolve, gate]
     uses: ./.github/workflows/cicd_comp_changelog-site-publish-phase.yml
     with:
       release_tag: ${{ inputs.release_tag }}


### PR DESCRIPTION
Closes: #37136
Closes: #37138

Two related changes: a manual publish path, and the auto-detect bug that made one necessary.

## 1. Manual trigger for changelog site publish (#37136)

Adds `cicd_manual_changelog-site-publish.yml`, a `workflow_dispatch` wrapper around the existing phase — the pattern `cicd_ai-release-notes-backfill.yml` already uses.

```bash
gh workflow run cicd_manual_changelog-site-publish.yml --repo dotCMS/core --ref main \
  -f release_tag=v26.08.19-04
```

**Why:** the phase is `workflow_call:` only and gated on `success()`, so any upstream failure or cancellation skips it with no CI path to recover. Today that means a local checkout plus three values that otherwise never leave GitHub — `DOTCMS_DEVSITE_URL`, `DOTCMS_DEVSITE_RELEASENOTES_TOKEN`, `DOTCMS_DEVSITE_RELEASENOTES_ACCOUNT`. The phase's comments also describe `--force` as "a manual operator re-run only", but no manual re-run path existed, so the flag was unreachable.

The wrapper derives what the pipeline would have passed:

| Input | Derived from |
|---|---|
| `release_version` | the tag, minus the `v` |
| `docker_tags` | Docker Hub public API, preferring the `version_sha` tag so a manual entry matches a pipeline-written one |
| `released_date` | the release's own `publishedAt`, so backfilling an older release does not stamp today's date |

The phase gains `force` and `released_date`, both defaulting to current behavior. **The release pipeline path is unchanged** — `cicd_6-release.yml` sets neither input.

### Access control

`workflow_dispatch` is limited to accounts with write access — never forks, never the public — but that is 45 accounts today, and this writes to the public docs site with a service-account token. So the publish job sits behind a no-op approval gate on the `changelog-site-publish` environment (`required_reviewers: dotDevelopers`), matching `cicd_evergreen-tracks-promote.yml`'s apply gate.

The environment has been created with that protection rule. It must keep it: GitHub auto-creates a missing environment **unprotected** on first use, which would silently remove the gate.

## 2. Auto-detect picks an undocumented tag (#37138)

`findPreviousTag()` returned `tags[idx + 1]` unconditionally. On a multi-attempt day that is another attempt at the same release, whose pipeline died before writing notes — so the changelog covers one attempt instead of the release.

This is what produced the 26.08.19-04 changelog: auto-detect resolved its predecessor to `v26.08.19-03`, and the release notes described 1 of 19 commits, publishing "contains internal maintenance only" for a release carrying Accessibility Studio, the Experiments portlet, three roles endpoints and nine fixes.

Three fixes in the same two functions:

- `listStandardReleaseTags()` returns `{ tag, hasNotes }` and **skips drafts**. `listReleases` returns drafts first regardless of date, corrupting the newest-first ordering the docstring promises — 6 drafts currently match the standard pattern, and one duplicates `v26.04.11-02`.
- `findPreviousTag()` walks back to the first release with notes, so an undocumented attempt's commits stay inside the range instead of being stranded behind its tag.
- `findIndex` on tag equality replaces `indexOf`, which returned the first match for a duplicated tag.

A same-day attempt that *did* publish notes is still a valid boundary — the skip is conditioned on missing notes, not on the date, and there is a test for exactly that (26.08.12-02 → 26.08.12-01).

## Verification

- `npx tsc --noEmit` clean; `npx jest` 35/35 passing, including three new `findPreviousTag` cases: skips undocumented predecessors, keeps a documented same-day attempt, returns undefined when every predecessor is undocumented.
- Both workflows parse as valid YAML.
- The resolve logic was run against a real tag and reproduces the manual publish exactly: docker tag → `26.08.19-04_a0181f9`, released date → `2026-08-20`, both matching the entry now live on the site.
- Draft counts above were measured against the live API, not assumed.

Not exercised end-to-end against the live site: the only release currently needing a publish was already published by hand, and re-running would trip human-edit protection. A run on the next release that needs it is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbgDBJuoBrpJxh5qLMPorL