### PR TITLE
37138 autodetect previous tag

### DIFF
--- a/.github/scripts/gather-release-data/src/github.test.ts
+++ b/.github/scripts/gather-release-data/src/github.test.ts
@@ -39,7 +39,15 @@ describe('extractPRNumbers', () => {
 });
 
 describe('findPreviousTag', () => {
-  const tags = ['v26.03.13-02', 'v26.03.13-01', 'v26.03.12-01', 'v26.03.11-01'];
+  const documented = (...tags: string[]) =>
+    tags.map((tag) => ({ tag, hasNotes: true }));
+
+  const tags = documented(
+    'v26.03.13-02',
+    'v26.03.13-01',
+    'v26.03.12-01',
+    'v26.03.11-01'
+  );
 
   it('finds the tag immediately before the given tag', () => {
     expect(findPreviousTag(tags, 'v26.03.13-02')).toBe('v26.03.13-01');
@@ -53,6 +61,35 @@ describe('findPreviousTag', () => {
 
   it('returns undefined for the oldest tag', () => {
     expect(findPreviousTag(tags, 'v26.03.11-01')).toBeUndefined();
+  });
+
+  // Regression: 26.08.19 shipped four attempts. -01/-02/-03 died before writing
+  // notes, so stopping at -03 described 1 of 19 commits.
+  it('skips undocumented releases', () => {
+    const withGhosts = [
+      { tag: 'v26.08.19-04', hasNotes: true },
+      { tag: 'v26.08.19-03', hasNotes: false },
+      { tag: 'v26.08.19-02', hasNotes: false },
+      { tag: 'v26.08.19-01', hasNotes: false },
+      { tag: 'v26.08.14-01', hasNotes: true },
+    ];
+    expect(findPreviousTag(withGhosts, 'v26.08.19-04')).toBe('v26.08.14-01');
+  });
+
+  it('still returns a same-day attempt that published notes', () => {
+    const sameDay = [
+      { tag: 'v26.08.12-02', hasNotes: true },
+      { tag: 'v26.08.12-01', hasNotes: true },
+    ];
+    expect(findPreviousTag(sameDay, 'v26.08.12-02')).toBe('v26.08.12-01');
+  });
+
+  it('returns undefined when every predecessor is undocumented', () => {
+    const allGhosts = [
+      { tag: 'v26.08.19-02', hasNotes: true },
+      { tag: 'v26.08.19-01', hasNotes: false },
+    ];
+    expect(findPreviousTag(allGhosts, 'v26.08.19-02')).toBeUndefined();
   });
 });
 

--- a/.github/scripts/gather-release-data/src/github.ts
+++ b/.github/scripts/gather-release-data/src/github.ts
@@ -27,44 +27,60 @@ export function parseRepo(fullRepo: string): { owner: string; repo: string } {
   return { owner, repo };
 }
 
+/** A published standard release, and whether its notes were ever written. */
+export interface ReleaseRef {
+  tag: string;
+  /** False when the release body is empty — a cut whose pipeline died before notes. */
+  hasNotes: boolean;
+}
+
 /**
- * List standard release tags (matching vYY.MM.DD-NN pattern), sorted by
- * creation date descending (newest first).
+ * List standard releases (matching vYY.MM.DD-NN pattern), newest first.
+ *
+ * Drafts are skipped: listReleases returns them first regardless of date, so they
+ * corrupt the ordering this function promises, and a draft may duplicate a real tag.
  */
 export async function listStandardReleaseTags(
   octokit: Octokit,
   owner: string,
   repo: string
-): Promise<string[]> {
-  const tags: string[] = [];
+): Promise<ReleaseRef[]> {
+  const releases: ReleaseRef[] = [];
   for await (const response of octokit.paginate.iterator(
     octokit.repos.listReleases,
     { owner, repo, per_page: 100 }
   )) {
     for (const release of response.data) {
+      if (release.draft) continue;
       if (STANDARD_RELEASE_PATTERN.test(release.tag_name)) {
-        tags.push(release.tag_name);
+        releases.push({
+          tag: release.tag_name,
+          hasNotes: (release.body ?? '').trim().length > 0,
+        });
       }
     }
   }
-  return tags;
+  return releases;
 }
 
 /**
- * Find the previous standard release tag before `currentTag`.
- * Tags are ordered newest-first from the API.
+ * Find the previous documented release before `currentTag`.
+ *
+ * Undocumented releases are skipped. A cut whose pipeline died before writing notes
+ * describes none of its commits, so those commits belong in this range — stopping at
+ * its tag would strand them. A same-day attempt that DID publish notes is a valid
+ * boundary and is returned normally.
  */
 export function findPreviousTag(
-  tags: string[],
+  releases: ReleaseRef[],
   currentTag: string
 ): string | undefined {
-  const idx = tags.indexOf(currentTag);
+  const idx = releases.findIndex((r) => r.tag === currentTag);
   if (idx === -1) {
     // Tag not found in release history — caller must handle
     return undefined;
   }
-  // Return the next tag after the current one (i.e., the one before it chronologically)
-  return tags[idx + 1];
+  return releases.slice(idx + 1).find((r) => r.hasNotes)?.tag;
 }
 
 /**

--- a/.github/scripts/gather-release-data/src/index.ts
+++ b/.github/scripts/gather-release-data/src/index.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
 
     // Validate that toTag is visible in the release list. If it's missing,
     // the GitHub releases API hasn't indexed the newly published release yet.
-    if (!tags.includes(args.toTag)) {
+    if (!tags.some((r) => r.tag === args.toTag)) {
       process.stderr.write(
         `Error: ${args.toTag} not found in GitHub releases API. ` +
           `The release may not have been published yet, or the API has not caught up. ` +

--- a/.github/scripts/release-qa-status/src/github.test.ts
+++ b/.github/scripts/release-qa-status/src/github.test.ts
@@ -1,0 +1,32 @@
+import { findPreviousTag } from './github';
+
+// Guards against drift from gather-release-data/src/github.ts, which resolves the
+// same release boundary. If these two disagree, the QA status and the changelog
+// report on different commit ranges for the same release.
+describe('findPreviousTag', () => {
+  it('skips undocumented releases', () => {
+    // 26.08.19 shipped four attempts; -01/-02/-03 died before writing notes.
+    const releases = [
+      { tag: 'v26.08.19-04', hasNotes: true },
+      { tag: 'v26.08.19-03', hasNotes: false },
+      { tag: 'v26.08.19-02', hasNotes: false },
+      { tag: 'v26.08.19-01', hasNotes: false },
+      { tag: 'v26.08.14-01', hasNotes: true },
+    ];
+    expect(findPreviousTag(releases, 'v26.08.19-04')).toBe('v26.08.14-01');
+  });
+
+  it('returns a same-day attempt that published notes', () => {
+    const releases = [
+      { tag: 'v26.08.12-02', hasNotes: true },
+      { tag: 'v26.08.12-01', hasNotes: true },
+    ];
+    expect(findPreviousTag(releases, 'v26.08.12-02')).toBe('v26.08.12-01');
+  });
+
+  it('returns undefined for an unknown tag or no documented predecessor', () => {
+    const releases = [{ tag: 'v26.08.19-01', hasNotes: true }];
+    expect(findPreviousTag(releases, 'v26.08.20-01')).toBeUndefined();
+    expect(findPreviousTag(releases, 'v26.08.19-01')).toBeUndefined();
+  });
+});

--- a/.github/scripts/release-qa-status/src/github.ts
+++ b/.github/scripts/release-qa-status/src/github.ts
@@ -28,32 +28,59 @@ export function parseRepo(fullRepo: string): { owner: string; repo: string } {
   return { owner, repo };
 }
 
+/** A published standard release, and whether its notes were ever written. */
+export interface ReleaseRef {
+  tag: string;
+  /** False when the release body is empty — a cut whose pipeline died before notes. */
+  hasNotes: boolean;
+}
+
+/**
+ * List standard releases (matching vYY.MM.DD-NN pattern), newest first.
+ *
+ * Kept in sync with gather-release-data/src/github.ts: both resolve the same release
+ * boundary, and a divergence puts the QA status and the changelog on different ranges.
+ *
+ * Drafts are skipped: listReleases returns them first regardless of date, so they
+ * corrupt the ordering this function promises, and a draft may duplicate a real tag.
+ */
 export async function listStandardReleaseTags(
   octokit: Octokit,
   owner: string,
   repo: string
-): Promise<string[]> {
-  const tags: string[] = [];
+): Promise<ReleaseRef[]> {
+  const releases: ReleaseRef[] = [];
   for await (const response of octokit.paginate.iterator(
     octokit.repos.listReleases,
     { owner, repo, per_page: 100 }
   )) {
     for (const release of response.data) {
+      if (release.draft) continue;
       if (STANDARD_RELEASE_PATTERN.test(release.tag_name)) {
-        tags.push(release.tag_name);
+        releases.push({
+          tag: release.tag_name,
+          hasNotes: (release.body ?? '').trim().length > 0,
+        });
       }
     }
   }
-  return tags;
+  return releases;
 }
 
+/**
+ * Find the previous documented release before `currentTag`.
+ *
+ * Undocumented releases are skipped: a cut whose pipeline died before writing notes
+ * never shipped a QA status either, so stopping at its tag would report on one attempt
+ * instead of the whole release.
+ */
 export function findPreviousTag(
-  tags: string[],
+  releases: ReleaseRef[],
   currentTag: string
 ): string | undefined {
-  const idx = tags.indexOf(currentTag);
+  const idx = releases.findIndex((r) => r.tag === currentTag);
   if (idx === -1) return undefined;
-  return tags[idx + 1];
+  return releases.slice(idx + 1).find((r) => r.hasNotes)?.tag;
 }
 
 export async function fetchCommitRange(

--- a/.github/scripts/release-qa-status/src/index.ts
+++ b/.github/scripts/release-qa-status/src/index.ts
@@ -204,18 +204,19 @@ async function main(): Promise<void> {
       );
       process.exit(1);
     }
-    if (tags.includes(args.toTag)) {
+    if (tags.some((r) => r.tag === args.toTag)) {
       fromTag = findPreviousTag(tags, args.toTag);
     } else {
       // The just-created release may not yet be indexed by the releases API
       // (eventual consistency). Fall back to the newest known tag as the
-      // predecessor — listReleases returns tags newest-first, so tags[0] is
-      // the previous standard release.
+      // predecessor — listReleases returns tags newest-first. Skip undocumented
+      // cuts here too, or a failed earlier attempt becomes the boundary.
+      const newest = tags.find((r) => r.hasNotes);
       process.stderr.write(
         `Note: ${args.toTag} not yet visible in releases API; ` +
-          `using newest indexed tag ${tags[0]} as previous.\n`
+          `using newest documented tag ${newest?.tag} as previous.\n`
       );
-      fromTag = tags[0];
+      fromTag = newest?.tag;
     }
     if (!fromTag) {
       process.stderr.write(


### PR DESCRIPTION
Closes: #37138

Bottom of stack #37143. Independent of the two PRs above it.

## Problem

`findPreviousTag()` returned `tags[idx + 1]` unconditionally — the tag immediately preceding the target. On a day with more than one release attempt, that preceding tag is another attempt at the *same* release, whose pipeline died before writing notes. The changelog then covers one attempt instead of one release.

This produced the 26.08.19-04 changelog: auto-detect resolved its predecessor to `v26.08.19-03`, so the notes described 1 of 19 commits and published "contains internal maintenance only" for a release carrying Accessibility Studio, the Experiments portlet, three roles endpoints and nine fixes.

## Three fixes in the same two functions

- `listStandardReleaseTags()` returns `{ tag, hasNotes }` and **skips drafts**. `listReleases` returns drafts first regardless of date, corrupting the newest-first ordering the docstring promises. Measured against the live API: 6 drafts currently match `STANDARD_RELEASE_PATTERN`, one duplicates `v26.04.11-02`, and the `v26.07.17-01` / `v26.07.27-01` drafts shadow real releases.
- `findPreviousTag()` walks back to the first release with notes, so an undocumented attempt's commits stay inside the range instead of being stranded behind its tag.
- `findIndex` on tag equality replaces `indexOf`, which returned the first match for that duplicated tag.

The skip is conditioned on **missing notes, not on the date** — a same-day attempt that did publish notes remains a valid boundary.

## Verification

`npx tsc --noEmit` clean. `npx jest` 35/35 passing, including three new cases: skips undocumented predecessors (the 26.08.19 shape), keeps a documented same-day attempt (`26.08.12-02` → `26.08.12-01`), and returns undefined when every predecessor is undocumented.

## Until this merges

Always pass `previous_tag` explicitly to `cicd_ai-release-notes-backfill.yml`. Never rely on auto-detect after a day with more than one attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbgDBJuoBrpJxh5qLMPorL

This PR fixes: #37138