### PR TITLE
fix(ci): gate the release notes backfill behind reviewer approval

### DIFF
--- a/.github/workflows/cicd_ai-release-notes-backfill.yml
+++ b/.github/workflows/cicd_ai-release-notes-backfill.yml
@@ -31,8 +31,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The phase's final step is `gh release edit --notes-file`, an unconditional replace on a
+  # public release body — it overwrites hand edits and cannot be undone from here.
+  # workflow_dispatch is open to every account with write access on this repo, so reviewer
+  # approval is the access control. Same pattern as cicd_evergreen-tracks-promote.yml.
+  # The environment must carry required_reviewers; GitHub auto-creates it UNPROTECTED on
+  # first use if it is missing, which would silently remove this gate.
+  gate:
+    name: Approve Notes Rewrite
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    environment: release-notes-backfill
+    steps:
+      - run: |
+          echo "Approved: rewrite release notes for ${{ inputs.release_tag }}"
+          echo "Previous tag: ${{ inputs.previous_tag || '(auto-detect)' }}"
+
   release-notes:
     name: Generate Notes
+    needs: gate
     uses: ./.github/workflows/cicd_comp_ai-release-notes-phase.yml
     with:
       release_tag: ${{ inputs.release_tag }}


### PR DESCRIPTION
Closes: #37139

Top of stack #37143. Based on #37141.

## Problem

`cicd_ai-release-notes-backfill.yml` ends in an unconditional replace on a public release body:

```
gh release edit "$RELEASE_TAG" --notes-file /tmp/release-notes.md
```

It overwrites hand edits and cannot be undone from the workflow.

`workflow_dispatch` is limited to accounts with write access — never forks, never anonymous users — but that is 45 accounts on this repo. Since this workflow shipped in March 2026 it has been an unreviewed write path to public release documentation, for any release tag, by any of those accounts.

## Fix

A no-op approval gate on the `release-notes-backfill` environment (`required_reviewers: dotDevelopers`), with the generate job `needs: gate`. Same pattern as `cicd_evergreen-tracks-promote.yml`'s apply gate and the `changelog-site-publish` gate in #37141.

The environment has been created with that rule. If it is ever removed, GitHub auto-creates a missing environment **unprotected** on first use, silently removing the gate — it fails open, not closed. The workflow comment says so at the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbgDBJuoBrpJxh5qLMPorL