### PR TITLE
fix(block-editor): register the Highlight mark and load array-shaped values

### DIFF
--- a/core-web/libs/new-block-editor/CLAUDE.md
+++ b/core-web/libs/new-block-editor/CLAUDE.md
@@ -180,6 +180,7 @@ What actions are available on each node type. **Slash** = appears in `/` menu (`
 | `code` | StarterKit | Inline code | any text |
 | `superscript` | `@tiptap/extension-superscript` | Sup | any text |
 | `subscript` | `@tiptap/extension-subscript` | Sub | any text |
+| `highlight` | `@tiptap/extension-highlight` | — (schema only; the legacy editor has no button either) | any text |
 | `link` | `@tiptap/extension-link` | Link popover | any text (gated by `link` allowed-block) |
 | `textAlign` | `@tiptap/extension-text-align` | Align L/C/R/Justify | configured for `paragraph` + `heading` only |
 

--- a/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
+++ b/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
@@ -644,6 +644,17 @@
     border-radius: 0.25rem;
 }
 
+/* ─── Highlight (mark) ──────────────────────────────────── */
+/* The Highlight extension renders a plain <mark>. Styled here rather than through the
+   extension's inline HTMLAttributes (which is what the legacy editor does) so the colour
+   stays with the rest of the editor's theme. Stored JSON is unaffected either way. */
+:host ::ng-deep .tiptap mark {
+    background-color: #fef08a;
+    color: inherit;
+    padding: 0.0625rem 0.125rem;
+    border-radius: 0.125rem;
+}
+
 /* ─── Upload placeholder ─────────────────────────────── */
 :host ::ng-deep .upload-placeholder {
     display: flex;

--- a/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
+++ b/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
@@ -645,11 +645,13 @@
 }
 
 /* ─── Highlight (mark) ──────────────────────────────────── */
-/* The Highlight extension renders a plain <mark>. Styled here rather than through the
-   extension's inline HTMLAttributes (which is what the legacy editor does) so the colour
-   stays with the rest of the editor's theme. Stored JSON is unaffected either way. */
+/* The Highlight extension renders a plain <mark>. Same colour as the legacy editor for
+   feature parity, so migrated content looks unchanged to authors — the legacy editor sets it
+   inline via `Highlight.configure({ HTMLAttributes: { style: 'background: #accef7;' } })`
+   (dot-block-editor.component.ts:737); here it lives with the rest of the editor's styles.
+   Either way it is editor chrome only: the stored JSON carries no colour attribute. */
 :host ::ng-deep .tiptap mark {
-    background-color: #fef08a;
+    background-color: #accef7;
     color: inherit;
     padding: 0.0625rem 0.125rem;
     border-radius: 0.125rem;

--- a/core-web/libs/new-block-editor/src/lib/editor/editor.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/editor.component.ts
@@ -54,7 +54,10 @@ import { EditorPopoverService } from './services/editor-popover.service';
 import { EditorStore } from './store/editor.store';
 import { stripDocStats } from './utils/doc-stats.utils';
 import { loadRemoteExtensions, parseCustomBlocksField } from './utils/remote-extensions.loader';
-import { preserveUnknownBlockNodes, restoreUnknownBlockNodes } from './utils/unknown-block.utils';
+import {
+    preserveUnknownNodesInDocument,
+    restoreUnknownBlockNodes
+} from './utils/unknown-block.utils';
 
 /** Stringifies the editor document for form output (plain ProseMirror JSON, no extra attrs). */
 function editorDocumentJsonText(editor: Editor): string {
@@ -128,16 +131,6 @@ function parseAllowedContentTypes(field: DotCMSContentTypeField | undefined): st
 
 function getKnownNodeNames(editor: Editor): Set<string> {
     return new Set(Object.keys(editor.schema.nodes));
-}
-
-function preserveUnknownNodesInDocument(
-    parsed: JSONContent,
-    knownNodeNames: Set<string>
-): JSONContent {
-    return {
-        ...parsed,
-        content: preserveUnknownBlockNodes(parsed.content, knownNodeNames)
-    };
 }
 
 /** True when {@link parsed} represents the same document already in {@link editor}. */

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.spec.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.spec.ts
@@ -1,6 +1,7 @@
 import type { Injector } from '@angular/core';
 
-import { Extension, flattenExtensions } from '@tiptap/core';
+import { Extension, flattenExtensions, getSchema } from '@tiptap/core';
+import { Node as PMNode } from '@tiptap/pm/model';
 
 import type { DotMessageService } from '@dotcms/data-access';
 
@@ -15,6 +16,11 @@ import type { SlashMenuService } from '../components/slash-menu/slash-menu.servi
  * feature depends on (#36646): the editor must register exactly one `link` / `underline`
  * (StarterKit v3 bundles both) and must drop remote extensions whose names collide with a
  * built-in instead of double-registering them.
+ *
+ * They also pin the mark inventory against the legacy editor (#37145). A mark the legacy
+ * editor registered but this one does not makes TipTap abort `Node.fromJSON` for the WHOLE
+ * document and fall back to an empty doc — the field renders blank even though the stored
+ * JSON is intact.
  */
 describe('createEditorExtensions', () => {
     // `allowedBlocks: ['link']` keeps DotLink but excludes table/codeBlock/image/etc., so the
@@ -62,5 +68,42 @@ describe('createEditorExtensions', () => {
 
     it('always registers the unsupported-block catch-all node', () => {
         expect(build()).toContain(UNKNOWN_BLOCK_NODE_NAME);
+    });
+
+    /**
+     * #37145 — the legacy editor registers Highlight
+     * (`libs/block-editor/.../dot-block-editor.component.ts` lines 35, 737), so content
+     * authored there can carry `highlight` marks. Without the extension here, that content
+     * cannot be deserialized at all.
+     */
+    it('registers the "highlight" mark at parity with the legacy editor', () => {
+        const names = build();
+
+        expect(names.filter((name) => name === 'highlight')).toHaveLength(1);
+    });
+
+    it('deserializes a legacy document containing highlight marks instead of emptying it', () => {
+        const schema = getSchema(
+            createEditorExtensions(menuService, ['link'], injector, messageService)
+        );
+        const legacyDoc = {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        {
+                            type: 'text',
+                            marks: [{ type: 'highlight' }, { type: 'bold' }],
+                            text: 'Good Credit History:'
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const doc = PMNode.fromJSON(schema, legacyDoc);
+
+        expect(doc.textContent).toBe('Good Credit History:');
     });
 });

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.ts
@@ -5,6 +5,7 @@ import type { Injector } from '@angular/core';
 import { flattenExtensions, type AnyExtension, type Extensions } from '@tiptap/core';
 import CharacterCount from '@tiptap/extension-character-count';
 import Emoji, { emojis } from '@tiptap/extension-emoji';
+import Highlight from '@tiptap/extension-highlight';
 import Placeholder from '@tiptap/extension-placeholder';
 import Subscript from '@tiptap/extension-subscript';
 import Superscript from '@tiptap/extension-superscript';
@@ -147,6 +148,10 @@ export function createEditorExtensions(
         IndentExtension,
         Superscript,
         Subscript,
+        // Legacy-compat + parity: the legacy editor registers Highlight, so stored content can
+        // carry `highlight` marks. Without it here TipTap aborts the whole document (#37145).
+        // Styled via `.tiptap mark` in editor.component.css rather than inline HTMLAttributes.
+        Highlight,
         createUploadPlaceholderExtension(uploadCopy),
         // Legacy-compat only: the new editor never creates `aiContent` nodes (AI Content
         // dialog inserts the generated HTML via `commands.insertContent` so it becomes

--- a/core-web/libs/new-block-editor/src/lib/editor/utils/unknown-block.utils.spec.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/utils/unknown-block.utils.spec.ts
@@ -2,6 +2,7 @@ import { JSONContent } from '@tiptap/core';
 
 import {
     preserveUnknownBlockNodes,
+    preserveUnknownNodesInDocument,
     restoreUnknownBlockNodes,
     UNKNOWN_BLOCK_NODE_NAME
 } from './unknown-block.utils';
@@ -107,5 +108,74 @@ describe('unknown-block.utils', () => {
         ];
 
         expect(restoreUnknownBlockNodes(input)).toEqual(input);
+    });
+});
+
+/**
+ * dotCMS stores a Block Editor field as either a `{ type: 'doc', content: [...] }` document
+ * or — through some hosts, notably the UVE side panel — a bare array of nodes. Both shapes
+ * reach `setContent`, and the legacy editor branches on `Array.isArray` before preserving
+ * unknown nodes (`dot-block-editor.component.ts:773`).
+ *
+ * Spreading an array into an object turns it into `{ 0: node, 1: node, ..., content: undefined }`,
+ * which loses the document `type` and makes TipTap throw `RangeError: Unknown node type:
+ * undefined` — the field renders blank for ANY content, regardless of marks (#37145).
+ */
+describe('preserveUnknownNodesInDocument', () => {
+    const known = new Set(['doc', 'paragraph', 'text']);
+
+    it('keeps a bare array of nodes as an array', () => {
+        const input: JSONContent[] = [
+            { type: 'paragraph', content: [{ type: 'text', text: 'first' }] },
+            { type: 'paragraph', content: [{ type: 'text', text: 'second' }] }
+        ];
+
+        const result = preserveUnknownNodesInDocument(input, known);
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toEqual(input);
+    });
+
+    it('never turns an array into a plain object carrying an undefined content', () => {
+        const input: JSONContent[] = [{ type: 'paragraph' }];
+
+        const result = preserveUnknownNodesInDocument(input, known);
+
+        // The spread bug produced `{ 0: node, content: undefined }`: still an object, and the
+        // stray `content` key is what made TipTap throw `Unknown node type: undefined`.
+        expect(Array.isArray(result)).toBe(true);
+        expect(Object.prototype.hasOwnProperty.call(result, 'content')).toBe(false);
+    });
+
+    it('still preserves unknown nodes inside a bare array', () => {
+        const unknown: JSONContent = { type: 'customGallery', attrs: { layout: 'single' } };
+
+        const result = preserveUnknownNodesInDocument([unknown], known) as JSONContent[];
+
+        expect(result[0].type).toBe(UNKNOWN_BLOCK_NODE_NAME);
+        expect(result[0].attrs).toEqual({
+            originalType: 'customGallery',
+            originalNode: unknown,
+            originalNodeRaw: null
+        });
+    });
+
+    it('keeps handling a doc-shaped document', () => {
+        const doc: JSONContent = {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'keep me' }] }]
+        };
+
+        expect(preserveUnknownNodesInDocument(doc, known)).toEqual(doc);
+    });
+
+    it('preserves sibling document attrs such as the doc stats', () => {
+        const doc: JSONContent = {
+            type: 'doc',
+            attrs: { charCount: 7, wordCount: 2, readingTime: 1 },
+            content: [{ type: 'paragraph' }]
+        };
+
+        expect(preserveUnknownNodesInDocument(doc, known)).toEqual(doc);
     });
 });

--- a/core-web/libs/new-block-editor/src/lib/editor/utils/unknown-block.utils.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/utils/unknown-block.utils.ts
@@ -1,3 +1,7 @@
+import type { JSONContent } from '@tiptap/core';
+
+import { preserveUnknownBlockNodes } from '@dotcms/dotcms-models';
+
 export {
     createUnknownBlockNodeAttrs,
     parseUnknownBlockOriginalNode,
@@ -6,3 +10,28 @@ export {
     restoreUnknownBlockNodes,
     UNKNOWN_BLOCK_NODE_NAME
 } from '@dotcms/dotcms-models';
+
+/**
+ * Replaces unknown nodes with the `dotUnsupportedBlock` placeholder, for either shape a
+ * Block Editor value can arrive in: a `{ type: 'doc', content: [...] }` document, or a bare
+ * array of nodes — which is what some hosts pass, notably the UVE side panel.
+ *
+ * The array branch is not cosmetic. Spreading an array into an object yields
+ * `{ 0: node, 1: node, ..., content: undefined }`, dropping the document `type` and making
+ * TipTap throw `RangeError: Unknown node type: undefined`, so the field renders blank for
+ * ANY content (#37145). The legacy editor branches the same way — see
+ * `dot-block-editor.component.ts:773`.
+ */
+export function preserveUnknownNodesInDocument(
+    parsed: JSONContent | JSONContent[],
+    knownNodeNames: Set<string>
+): JSONContent | JSONContent[] {
+    if (Array.isArray(parsed)) {
+        return preserveUnknownBlockNodes(parsed, knownNodeNames);
+    }
+
+    return {
+        ...parsed,
+        content: preserveUnknownBlockNodes(parsed.content, knownNodeNames)
+    };
+}


### PR DESCRIPTION
## Proposed Changes

Two defects that both surface as a **blank Block Editor field**, found while fixing and then QA'ing the first one.

1. The **Highlight** mark was never registered, so content carrying `highlight` marks could not be deserialized.
2. `preserveUnknownNodesInDocument` spread **array-shaped** values into an object, so the UVE side panel blanked the field for *any* content.

Plus one parity follow-up: the highlight colour now matches the legacy editor.

---

## 1. Highlight mark not registered

TipTap parses a document **atomically**, so one mark missing from the schema aborts `Node.fromJSON` for the *whole* doc — and with `enableContentCheck` at its default (off), TipTap silently falls back to an **empty document**:

```
[tiptap warn]: Invalid content. Passed value: {type: 'doc', attrs: {…}, content: Array(19)}
Error: RangeError: There is no mark type highlight in this schema
```

The field renders blank over stored JSON that is perfectly intact — and because the editor then holds an empty doc, any subsequent edit + Save persists that empty body over the real one.

### Where the marks come from

Not paste, as first assumed. The **legacy editor's link popover** applies the mark as a temporary selection indicator while its search input holds focus:

```ts
// libs/block-editor/.../dot-link-editor-popover.component.ts:372
private focusSearchInput() {
    this.editor().commands.setHighlight();   // paints the selection
    this.searchInput?.nativeElement.focus();
}
```

If `unsetHighlight()` never runs — popover closed unexpectedly, or the contentlet saved while it was open — the mark is persisted. The reporting customer's JSON shows exactly this: a `highlight` run sitting immediately beside a `link` run. Two consequences:

- These marks are **UI residue, not authorial intent**. Nobody chose to highlight anything.
- **The legacy editor is still producing this content today**, so more contentlets will hit this as customers migrate.

The new editor solved the same UI problem correctly, with ProseMirror `Decoration`s (view-only, never serialized) in `SelectionPreserveExtension` — which is why it has no need for the mark itself.

### Fix

- **`editor-extensions.ts`** — registers `@tiptap/extension-highlight` (already a dependency at `core-web/package.json:107`). Unconditional, like Superscript/Subscript: `allowedBlocks` gates blocks, not marks.
- **`CLAUDE.md`** — adds `highlight` to the marks inventory.

### Why no toolbar button

Deliberate, and it differs from #36574 (a UI-only change for a mark already in the schema):

1. The legacy editor never exposed a Highlight button either — there is no `toggleHighlight` anywhere in the codebase. Given the marks are UI residue, a button would be a **new authoring feature**, not parity.
2. The SDK renderers have **no `highlight` case** (Angular `text.component.ts:125`, React `Texts.tsx:128`). Both fall to a default that returns the bare text and stops recursing, so an author-applied highlight would not render on the front end — and would drop every mark after it. Shipping a button for a mark the delivery layer cannot paint would be a new defect.

Authors can still remove existing highlights with the toolbar's clear-formatting button, and `Cmd/Ctrl+Shift+H` comes with the extension.

---

## 2. Array-shaped values blank the field

Found while QA'ing the above: opening the same contentlet through the **UVE side panel** still blanked it, with a *different* error.

```
[tiptap warn]: Invalid content. Passed value: {0: {…}, 1: {…}, … 15: {…}, content: undefined}
Error: RangeError: Unknown node type: undefined
```

Note the shape — numeric keys plus `content: undefined`. That is an **array spread into an object**. A Block Editor value reaches `setContent` either as a `{ type: 'doc', content: [...] }` document *or* as a bare array of nodes; the UVE side panel passes the latter, and the helper spread unconditionally:

```ts
return {
    ...parsed,                                              // array → { 0: node, 1: node, … }
    content: preserveUnknownBlockNodes(parsed.content, ...)  // array.content → undefined
};
```

Spreading drops the document `type`, so TipTap throws. **This is independent of Highlight** — it is deterministic for any array-shaped value, whatever marks the content carries; the two defects share only the symptom. The legacy editor branches on the shape first (`dot-block-editor.component.ts:773`); the new editor had lost that branch.

### Fix

`preserveUnknownNodesInDocument` now branches on `Array.isArray`, and moved from `editor.component.ts` to **`utils/unknown-block.utils.ts`**. It is a pure JSON transform over unknown blocks with no component dependencies, it now sits beside the helpers it wraps (`preserveUnknownBlockNodes` / `restoreUnknownBlockNodes`), and — since the component has no spec of its own — moving it is what made the fix testable at all.

---

## 3. Highlight colour: parity with the legacy editor

`#accef7`, the same colour the legacy editor sets inline via `Highlight.configure({ HTMLAttributes: { style: 'background: #accef7;' } })`, so migrated content looks unchanged to authors. Applied as a CSS rule on `.tiptap mark` rather than inline HTMLAttributes, so it lives with the rest of the editor's styles. Editor chrome only either way — the stored JSON carries no colour attribute.

---

## Testing

7 new tests, all confirmed **Red** first.

**`editor-extensions.spec.ts`** — the second failed with the exact `RangeError` from the customer's console:
- `highlight` is registered exactly once, at parity with the legacy editor.
- A legacy document with `marks: [highlight, bold]` deserializes and keeps its text.

**`unknown-block.utils.spec.ts`** — all five failed with `is not a function`:
- a bare array stays an array;
- an array is never turned into a plain object carrying an undefined `content`;
- unknown nodes inside a bare array are still preserved as placeholders;
- doc-shaped documents keep working;
- sibling doc attrs (the doc stats) survive.

## Checklist

- [x] `nx test new-block-editor` — 12 suites / 94 tests green, no regressions
- [x] `tsc --noEmit` on the lib clean
- [x] `nx lint new-block-editor` clean
- [x] `nx format:write` clean
- [x] Manually verified in Edit Content: content loads, highlight painted
- [ ] Manual re-check of the UVE side panel after the array fix (the bundle is deployed; not yet confirmed in the browser)

## Notes for reviewers

**Scope.** An earlier revision also added a generic unknown-*mark* sanitizer, so that any future missing mark would degrade gracefully instead of blanking the field. It was **split out and dropped**: ~82% of the diff, fixing nothing that was reported, and putting a permanent transform on every content-load path. Both defects here are reproduced, user-visible failures.

**Manual testing note.** The legacy JSP edit screen loads `/dotcms-block-editor/main.js` from the webapp, *not* from `nx serve` — verifying there requires building `dotcms-block-editor` and deploying the bundle into the container. Only the new Edit Content screen renders `<dot-block-editor>` from the dev server.

**Out of scope, worth its own issue:** the SDK renderers drop every mark following an unknown one, so `marks: [highlight, bold]` currently renders unbolded on the front end, and a `highlight` never paints at all. Text survives; formatting after the unknown mark does not.

Fixes #37145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37145