### PR TITLE
#37109: fix(users): honor empty roles array on PUT /v1/users

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleHelper.java
@@ -336,9 +336,10 @@ public class RoleHelper {
     }
 
     /**
-     * Bulk-removes users from a role with PARTIAL-SUCCESS semantics: once the role resolves,
-     * the batch never fails as a whole — every removable direct membership is removed and every
-     * non-removable entry is reported in the result's {@code skipped} list (see #36938):
+     * Bulk-removes users from a role with PARTIAL-SUCCESS semantics: once the role resolves
+     * and passes the {@code editUsers} gate, the batch never fails as a whole — every removable
+     * direct membership is removed and every non-removable entry is reported in the result's
+     * {@code skipped} list (see #36938):
      * <ul>
      *   <li>{@code not_found} — no user matches the id</li>
      *   <li>{@code inherited} — the user is not a DIRECT member (holds the role only through
@@ -347,6 +348,13 @@ public class RoleHelper {
      *       portlet only offered checkboxes on direct rows — same outcome, now reported</li>
      *   <li>{@code error} — unexpected per-user failure, logged server-side</li>
      * </ul>
+     *
+     * Like the grant endpoint, the whole request is rejected with 403 when the role is not
+     * user-assignable ({@code editUsers = false}, see #37109): memberships of such roles — the
+     * user's individual role, system roles — are system-managed and were never removable through
+     * the legacy Roles portlet either (it hides the removal controls for them). Assignability is
+     * a property of the role, not of each user, so this is a request-level rejection rather than
+     * a per-user {@code skipped} reason.
      *
      * DELIBERATELY NOT {@code @WrapInTransaction}: partial-success semantics require per-user
      * commits — each {@code roleAPI.removeRoleFromUser} call is already transactional, and a
@@ -363,6 +371,12 @@ public class RoleHelper {
         final Role role = this.roleAPI.loadRoleById(roleId);
         if (null == role || !UtilMethods.isSet(role.getId())) {
             throw new DoesNotExistException("Role not found: " + roleId);
+        }
+
+        if (!role.isEditUsers()) {
+            throw new DotSecurityException(
+                    String.format("Users cannot be removed from role '%s' (%s): the role does not allow membership changes",
+                            role.getName(), role.getId()));
         }
 
         final List<String> removedUserIds = new ArrayList<>();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/role/RoleResource.java
@@ -547,8 +547,9 @@ public class RoleResource implements Serializable {
 	 * Bulk-removes users from a role with partial-success semantics: removable direct
 	 * memberships are removed, everything else is reported in {@code skipped} with a reason
 	 * ({@code not_found}, {@code inherited}, {@code error}) — the batch never fails as a whole
-	 * once the role resolves. The caller must be a backend user with access to the Roles
-	 * portlet and the CMS Administrator role.
+	 * once the role resolves and passes the {@code editUsers} gate (non-user-assignable roles
+	 * are rejected with 403, mirroring the grant endpoint). The caller must be a backend user
+	 * with access to the Roles portlet and the CMS Administrator role.
 	 */
 	@Operation(
 		operationId = "removeUsersFromRole",
@@ -561,7 +562,10 @@ public class RoleResource implements Serializable {
 				"the role hierarchy, or the user is not a member at all; inherited membership can " +
 				"only be revoked by removing the user from the ancestor role that grants it), or " +
 				"error (unexpected per-user failure, logged server-side). Removals are committed " +
-				"per user, so entries already processed stay removed regardless of later entries."
+				"per user, so entries already processed stay removed regardless of later entries. " +
+				"Only user-assignable roles (editUsers=true) accept membership changes: a role " +
+				"whose editUsers flag is false — e.g. a user's individual role or a system role — " +
+				"is rejected with 403 for the whole request, mirroring the grant endpoint."
 	)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200",
@@ -575,7 +579,7 @@ public class RoleResource implements Serializable {
 					description = "Unauthorized - authentication required",
 					content = @Content(mediaType = "application/json")),
 		@ApiResponse(responseCode = "403",
-					description = "Forbidden - admin permissions required",
+					description = "Forbidden - admin permissions required, or the role's editUsers flag is false",
 					content = @Content(mediaType = "application/json")),
 		@ApiResponse(responseCode = "404",
 					description = "Role not found",

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserForm.java
@@ -3,11 +3,9 @@ package com.dotcms.rest.api.v1.user;
 import javax.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.NotBlank;
 import com.dotcms.rest.api.Validated;
-import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +52,10 @@ public final class UserForm extends Validated implements LanguageSupport  {
         this.timeZoneId = builder.timeZoneId;
         this.password = builder.password;
         this.additionalInfo = builder.additionalInfo;
-        this.roles = UtilMethods.isSet(builder.roles)?builder.roles: Collections.emptyList();
+        // a null list (field absent from the payload) and an empty list (explicitly sent as [])
+        // carry different meanings on update: null = leave roles untouched, [] = remove all
+        // user-assignable roles. Do not collapse one into the other here.
+        this.roles = builder.roles;
         this.userId = builder.userId;
 
         checkValid();
@@ -112,6 +113,10 @@ public final class UserForm extends Validated implements LanguageSupport  {
         return additionalInfo;
     }
 
+    /**
+     * Role keys sent in the payload. {@code null} means the field was not sent at all;
+     * an empty list means it was explicitly sent as {@code []}.
+     */
     public List<String> getRoles() {
         return roles;
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResource.java
@@ -1050,7 +1050,16 @@ public class UserResource implements Serializable {
 	 * @throws Exception
 	 */
 	@Operation(operationId = "updateUser", summary = "Update an existing user.",
-			description = "Updates an existing user's information including personal details, roles, and account settings. Only admin users or users with appropriate portlet access can perform this operation.",
+			description = "Updates an existing user's information including personal details, roles, and account settings. " +
+					"Only admin users or users with appropriate portlet access can perform this operation. " +
+					"The optional roles list carries role KEYS and is the user's complete desired set of " +
+					"user-assignable roles (editUsers=true): omit the field to leave roles untouched, send a " +
+					"non-empty list to replace the user-assignable role set, or send an empty list to remove " +
+					"all of the user's user-assignable roles. System-managed memberships (e.g. the user's " +
+					"individual role) are never modified, keys that resolve to no role are ignored, and null " +
+					"or blank entries are rejected with 400. Note that roles without a key cannot be " +
+					"expressed in this list — manage those through the role-centric /v1/roles/{roleId}/users " +
+					"endpoints instead.",
 			responses = {
 					@ApiResponse(
 							responseCode = "200",
@@ -1085,7 +1094,9 @@ public class UserResource implements Serializable {
 	public final Response update(@Context final HttpServletRequest httpServletRequest,
 								 @Context final HttpServletResponse httpServletResponse,
 								 @io.swagger.v3.oas.annotations.parameters.RequestBody(
-								         description = "User update data including personal information, roles, and account settings",
+								         description = "User update data including personal information, roles, and account settings. " +
+								                 "The roles list (role keys) is the complete desired set of user-assignable roles: " +
+								                 "absent = untouched, empty = remove all user-assignable roles, non-empty = replace.",
 								         required = true,
 								         content = @Content(schema = @Schema(implementation = UserForm.class)))
 								 final UserForm createUserForm) throws DotDataException, IncorrectPasswordException, SystemException, DotSecurityException, ParseException, PortalException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
@@ -1373,21 +1384,66 @@ public class UserResource implements Serializable {
 		return userToSave;
 	}
 
+    /**
+     * Reconciles the user's role memberships against the {@code roles} key list sent in the
+     * payload, mirroring the legacy Users portlet behavior (DWR {@code UserAjax#updateUserRoles}):
+     * only user-assignable roles ({@code editUsers = true}) are added or removed. System-managed
+     * memberships — the user's individual role, the default role — are never touched.
+     *
+     * A {@code null} list (field absent from the payload) leaves roles untouched; an empty list
+     * removes all of the user's user-assignable roles; a non-empty list becomes the user's
+     * complete user-assignable role set. Keys that resolve to no role are ignored; null or
+     * blank entries are rejected with 400.
+     */
     private void processRoles(final UserForm updateUserForm, final User userToSave) throws DotDataException {
 
-        if (UtilMethods.isSet(updateUserForm.getRoles())) {
-
-            final List<String> roleKeys = updateUserForm.getRoles();
-
-            this.helper.removeRoles(userToSave);  // the source of true is whatever is coming from the payload
-
-            for (final String roleKey : roleKeys) {
-
-                UserHelper.getInstance().addRole(userToSave, roleKey, false	, false);
-            }
-        } else {
+        final List<String> roleKeys = updateUserForm.getRoles();
+        if (null == roleKeys) {
 
             Logger.debug(this, ()-> "Not roles sent at all, nothing has been modified in terms of roles");
+            return;
+        }
+
+        // Jackson accepts null elements in a JSON array bound to List<String>; reject them up
+        // front (400) like RoleUsersForm does on the role-side membership endpoints, instead of
+        // silently treating garbage as an unknown key. Thrown inside @WrapInTransaction, so the
+        // whole update rolls back.
+        if (roleKeys.stream().anyMatch(key -> !UtilMethods.isSet(key))) {
+            throw new BadRequestException("roles must not contain null or blank entries");
+        }
+
+        final List<Role> desiredRoles = new ArrayList<>();
+        for (final String roleKey : roleKeys) {
+
+            final Role role = this.roleAPI.loadRoleByKey(roleKey);
+            if (null != role) {
+                desiredRoles.add(role);
+            } else {
+                Logger.debug(this, ()-> "Role with key '" + roleKey + "' does NOT exist in dotCMS. Ignoring it...");
+            }
+        }
+
+        // the payload is the source of truth for user-assignable roles: remove the ones not sent
+        final Set<String> desiredRoleIds = desiredRoles.stream().map(Role::getId).collect(Collectors.toSet());
+        for (final Role currentRole : this.roleAPI.loadRolesForUser(userToSave.getUserId(), false)) {
+
+            if (currentRole.isEditUsers() && !desiredRoleIds.contains(currentRole.getId())) {
+
+                this.roleAPI.removeRoleFromUser(currentRole, userToSave);
+                SecurityLogger.logInfo(this.getClass(), "Removing role:'" + currentRole.getName()
+                        + "' from user:" + userToSave.getUserId() + " email:" + userToSave.getEmailAddress());
+            }
+        }
+
+        // ...and add the missing ones (addRoleToUser no-ops when the role is already held)
+        for (final Role desiredRole : desiredRoles) {
+
+            if (desiredRole.isEditUsers()) {
+                this.roleAPI.addRoleToUser(desiredRole, userToSave);
+            } else {
+                Logger.debug(this, ()-> "Role '" + desiredRole.getName()
+                        + "' is not user-assignable. Ignoring it...");
+            }
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/user/UserResourceHelper.java
@@ -446,10 +446,19 @@ public class UserResourceHelper implements Serializable {
 	}
 
     /**
-     * Remove the roles associated to the user
+     * Removes ALL of the user's role memberships, with no {@code editUsers} gate: this includes
+     * system-managed memberships such as the user's individual role (the anchor for
+     * individually-granted permissions and workflow task assignment), which the system only
+     * re-links lazily on the next {@code RoleAPI#getUserRole} call.
+     *
      * @param user User
+     * @deprecated no longer used by the user endpoints — {@code UserResource#processRoles}
+     * reconciles memberships and never touches non-user-assignable roles ({@code editUsers =
+     * false}). Kept only for binary compatibility with external callers of this OSGi-exported
+     * package; use {@link com.dotmarketing.business.RoleAPI} membership methods instead.
      */
-    public void removeRoles(User user) throws DotDataException {
+    @Deprecated
+    public void removeRoles(final User user) throws DotDataException {
 
         Logger.debug(this, ()-> "removing the roles for the user:" + user.getUserId());
         APILocator.getRoleAPI().removeAllRolesFromUser(user);

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -15494,7 +15494,10 @@ paths:
         \ all; inherited membership can only be revoked by removing the user from\
         \ the ancestor role that grants it), or error (unexpected per-user failure,\
         \ logged server-side). Removals are committed per user, so entries already\
-        \ processed stay removed regardless of later entries."
+        \ processed stay removed regardless of later entries. Only user-assignable\
+        \ roles (editUsers=true) accept membership changes: a role whose editUsers\
+        \ flag is false — e.g. a user's individual role or a system role — is rejected\
+        \ with 403 for the whole request, mirroring the grant endpoint."
       operationId: removeUsersFromRole
       parameters:
       - description: Id of the role to remove users from
@@ -15529,7 +15532,8 @@ paths:
         "403":
           content:
             application/json: {}
-          description: Forbidden - admin permissions required
+          description: "Forbidden - admin permissions required, or the role's editUsers\
+            \ flag is false"
         "404":
           content:
             application/json: {}
@@ -18194,7 +18198,15 @@ paths:
     put:
       description: "Updates an existing user's information including personal details,\
         \ roles, and account settings. Only admin users or users with appropriate\
-        \ portlet access can perform this operation."
+        \ portlet access can perform this operation. The optional roles list carries\
+        \ role KEYS and is the user's complete desired set of user-assignable roles\
+        \ (editUsers=true): omit the field to leave roles untouched, send a non-empty\
+        \ list to replace the user-assignable role set, or send an empty list to remove\
+        \ all of the user's user-assignable roles. System-managed memberships (e.g.\
+        \ the user's individual role) are never modified, keys that resolve to no\
+        \ role are ignored, and null or blank entries are rejected with 400. Note\
+        \ that roles without a key cannot be expressed in this list — manage those\
+        \ through the role-centric /v1/roles/{roleId}/users endpoints instead."
       operationId: updateUser
       requestBody:
         content:
@@ -18202,7 +18214,9 @@ paths:
             schema:
               $ref: "#/components/schemas/UserForm"
         description: "User update data including personal information, roles, and\
-          \ account settings"
+          \ account settings. The roles list (role keys) is the complete desired set\
+          \ of user-assignable roles: absent = untouched, empty = remove all user-assignable\
+          \ roles, non-empty = replace."
         required: true
       responses:
         "200":

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/role/RoleResourceIntegrationTest.java
@@ -1244,6 +1244,35 @@ public class RoleResourceIntegrationTest {
     }
 
     /**
+     * Given Scenario: The role's editUsers flag is false — its memberships are system-managed
+     * (a user's individual role, system roles). The legacy Roles portlet never allowed this
+     * removal (it renders no selection checkboxes and hides the Remove button for such roles),
+     * and the grant endpoint already rejects these roles with 403. See #37109.
+     * Expected Result: DotSecurityException (403) for the whole request, mirroring the grant
+     * endpoint; the membership is intact.
+     */
+    @Test
+    public void testRemoveUsersFromRole_editUsersFalse_forbidden() throws Exception {
+        final Role role = new RoleDataGen().editUsers(true).nextPersisted();
+        final User member = UserTestUtil.getUser("frozenrm" + uniq(), false, true);
+        roleAPI.addRoleToUser(role, member);
+        assertTrue(isDirectMember(role, member));
+
+        role.setEditUsers(false);
+        roleAPI.save(role);
+
+        try {
+            resource.removeUsersFromRole(adminRequest(), new MockHttpResponse().response(),
+                    role.getId(), new RoleUsersForm(Set.of(member.getUserId())));
+            fail("Should have thrown DotSecurityException for an editUsers=false role");
+        } catch (final DotSecurityException e) {
+            // expected
+        }
+
+        assertTrue("membership must be intact", isDirectMember(role, member));
+    }
+
+    /**
      * Given Scenario: An anonymous caller (no session user, no Authorization header).
      * Expected Result: rejected by the InitBuilder's rejectWhenNoUser gate (401); the
      * membership is intact.

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/user/UserResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/user/UserResourceIntegrationTest.java
@@ -1,7 +1,13 @@
 package com.dotcms.rest.api.v1.user;
 
+import com.dotcms.datagen.RoleDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TestUserUtils;
+import com.dotmarketing.business.Role;
+import com.dotmarketing.business.RoleAPI;
+import com.liferay.portal.ejb.UserTestUtil;
+import java.util.Collections;
+import java.util.List;
 import com.dotcms.rest.ErrorResponseHelper;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.api.DotRestInstanceProvider;
@@ -110,5 +116,153 @@ public class UserResourceIntegrationTest {
         assertEquals(adminUser.getUserId(),request.getSession().getAttribute(WebKeys.USER_ID));
         assertNull(request.getSession().getAttribute(WebKeys.USER));
         assertNull(request.getSession().getAttribute(WebKeys.PRINCIPAL_USER_ID));
+    }
+
+    // ==================== PUT /v1/users — roles reconcile (#37109) ====================
+
+    private static String uniq() {
+        return Long.toString(System.nanoTime());
+    }
+
+    /**
+     * Builds the minimal valid update form for the given user: same names and email,
+     * no password, no roles (call {@code .roles(...)} to send the field).
+     */
+    private static UserForm.Builder updateFormFor(final User target) {
+        return new UserForm.Builder()
+                .userId(target.getUserId())
+                .firstName(target.getFirstName())
+                .lastName(target.getLastName())
+                .email(target.getEmailAddress());
+    }
+
+    /**
+     * Method to test: {@link UserResource#update(HttpServletRequest, HttpServletResponse, UserForm)}
+     * Given Scenario: A user holds two user-assignable roles and an admin sends an update with
+     * an explicit empty roles array — legacy parity with DWR UserAjax#updateUserRoles(userId, []).
+     * Expected Result: 200; every user-assignable role is removed; the user's individual role
+     * (editUsers=false, the anchor for individually-granted permissions) is preserved.
+     */
+    @Test
+    public void test_update_emptyRolesArray_removesAllUserAssignableRoles() throws Exception {
+        final RoleAPI roleAPI = APILocator.getRoleAPI();
+        final User target = UserTestUtil.getUser("emptyroles" + uniq(), false, true);
+        final Role roleA = new RoleDataGen().key("emptyrolesa" + uniq()).nextPersisted();
+        final Role roleB = new RoleDataGen().key("emptyrolesb" + uniq()).nextPersisted();
+        roleAPI.addRoleToUser(roleA, target);
+        roleAPI.addRoleToUser(roleB, target);
+        final Role individualRole = roleAPI.getUserRole(target);
+
+        final Response resourceResponse = resource.update(mockRequest(), response,
+                updateFormFor(target).roles(Collections.emptyList()).build());
+        assertEquals(Status.OK.getStatusCode(), resourceResponse.getStatus());
+
+        final List<Role> remaining = roleAPI.loadRolesForUser(target.getUserId(), false);
+        assertTrue("all user-assignable roles must be gone",
+                remaining.stream().noneMatch(Role::isEditUsers));
+        assertTrue("the user's individual role must be preserved",
+                remaining.stream().anyMatch(role -> individualRole.getId().equals(role.getId())));
+        assertFalse(roleAPI.doesUserHaveRole(target, roleA));
+        assertFalse(roleAPI.doesUserHaveRole(target, roleB));
+    }
+
+    /**
+     * Given Scenario: A user holds a user-assignable role and an admin sends an update WITHOUT
+     * the roles field at all.
+     * Expected Result: 200; the user's roles are untouched.
+     */
+    @Test
+    public void test_update_rolesFieldAbsent_leavesRolesUntouched() throws Exception {
+        final RoleAPI roleAPI = APILocator.getRoleAPI();
+        final User target = UserTestUtil.getUser("norolesfield" + uniq(), false, true);
+        final Role roleA = new RoleDataGen().key("norolesfielda" + uniq()).nextPersisted();
+        roleAPI.addRoleToUser(roleA, target);
+
+        final Response resourceResponse = resource.update(mockRequest(), response,
+                updateFormFor(target).build());
+        assertEquals(Status.OK.getStatusCode(), resourceResponse.getStatus());
+
+        assertTrue("roles must be untouched when the field is absent",
+                roleAPI.doesUserHaveRole(target, roleA));
+    }
+
+    /**
+     * Given Scenario: A user holds roles A and B; an admin sends roles [B, C] (role keys).
+     * Expected Result: 200; the payload is the complete desired set — A removed, B kept,
+     * C added.
+     */
+    @Test
+    public void test_update_nonEmptyRoles_replacesUserAssignableSet() throws Exception {
+        final RoleAPI roleAPI = APILocator.getRoleAPI();
+        final User target = UserTestUtil.getUser("swaproles" + uniq(), false, true);
+        final Role roleA = new RoleDataGen().key("swaprolesa" + uniq()).nextPersisted();
+        final Role roleB = new RoleDataGen().key("swaprolesb" + uniq()).nextPersisted();
+        final Role roleC = new RoleDataGen().key("swaprolesc" + uniq()).nextPersisted();
+        roleAPI.addRoleToUser(roleA, target);
+        roleAPI.addRoleToUser(roleB, target);
+
+        final Response resourceResponse = resource.update(mockRequest(), response,
+                updateFormFor(target).roles(List.of(roleB.getRoleKey(), roleC.getRoleKey())).build());
+        assertEquals(Status.OK.getStatusCode(), resourceResponse.getStatus());
+
+        assertFalse("role not in the payload must be removed", roleAPI.doesUserHaveRole(target, roleA));
+        assertTrue("role kept in the payload must remain", roleAPI.doesUserHaveRole(target, roleB));
+        assertTrue("new role in the payload must be added", roleAPI.doesUserHaveRole(target, roleC));
+    }
+
+    /**
+     * Given Scenario: The payload names a non-user-assignable role (editUsers=false) and a key
+     * that resolves to no role, alongside nothing else; the user holds one assignable role.
+     * Expected Result: 200 — both entries are ignored (never granted, no error; legacy DWR
+     * gates adds on editUsers and the old add path silently skipped unknown keys), and the
+     * held assignable role is removed because it is not in the desired set.
+     */
+    @Test
+    public void test_update_nonAssignableAndUnknownKeys_ignored() throws Exception {
+        final RoleAPI roleAPI = APILocator.getRoleAPI();
+        final User target = UserTestUtil.getUser("frozenkeys" + uniq(), false, true);
+        final Role held = new RoleDataGen().key("frozenkeysheld" + uniq()).nextPersisted();
+        roleAPI.addRoleToUser(held, target);
+        final Role frozen = new RoleDataGen().key("frozenkeysrole" + uniq()).editUsers(false)
+                .nextPersisted();
+
+        final Response resourceResponse = resource.update(mockRequest(), response,
+                updateFormFor(target)
+                        .roles(List.of(frozen.getRoleKey(), "no-such-role-key-" + uniq()))
+                        .build());
+        assertEquals(Status.OK.getStatusCode(), resourceResponse.getStatus());
+
+        assertFalse("a non-assignable role must never be granted",
+                roleAPI.doesUserHaveRole(target, frozen));
+        assertFalse("the held assignable role is not in the desired set, so it must be removed",
+                roleAPI.doesUserHaveRole(target, held));
+    }
+
+    /**
+     * Given Scenario: The roles list contains a null entry (Jackson accepts null elements in a
+     * JSON array bound to List&lt;String&gt;) alongside a valid key; the user holds one role.
+     * Expected Result: 400 BadRequestException — mirroring RoleUsersForm on the role-side
+     * membership endpoints — and, since processRoles runs inside the update transaction, the
+     * user's roles are untouched.
+     */
+    @Test
+    public void test_update_nullRoleEntry_badRequestAndRolesUntouched() throws Exception {
+        final RoleAPI roleAPI = APILocator.getRoleAPI();
+        final User target = UserTestUtil.getUser("nullentry" + uniq(), false, true);
+        final Role held = new RoleDataGen().key("nullentryheld" + uniq()).nextPersisted();
+        roleAPI.addRoleToUser(held, target);
+
+        try {
+            resource.update(mockRequest(), response,
+                    updateFormFor(target)
+                            .roles(java.util.Arrays.asList(held.getRoleKey(), null))
+                            .build());
+            fail("Should have thrown BadRequestException for a null roles entry");
+        } catch (final com.dotcms.rest.exception.BadRequestException e) {
+            // expected
+        }
+
+        assertTrue("roles must be untouched after a rejected payload",
+                roleAPI.doesUserHaveRole(target, held));
     }
 }

--- a/dotcms-postman/src/main/resources/postman/UserResource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/UserResource.postman_collection.json
@@ -1667,6 +1667,288 @@
 			]
 		},
 		{
+			"name": "UpdateUserEmptyRolesRemovesAll",
+			"item": [
+				{
+					"name": "CreateTestUserWithRoles",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200 OK or 201 Created\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									"",
+									"const responseData = pm.response.json();",
+									"pm.test(\"Entity carries the created userID\", function () {",
+									"    pm.expect(responseData.entity).to.have.property('userID').that.is.a('string');",
+									"});",
+									"pm.environment.set(\"emptyRolesUserId\", responseData.entity.userID);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/users",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"active\": true,\n    \"firstName\": \"EmptyRoles\",\n    \"lastName\": \"TestUser37109\",\n    \"email\": \"emptyroles37109@dotcms.com\",\n    \"password\": [\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\"],\n    \"roles\": [\"DOTCMS_BACK_END_USER\", \"Scripting Developer\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "VerifyUserHoldsAssignableRoles",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200 OK or 201 Created\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									"",
+									"// Precondition pin: the user really holds the two assignable roles before the empty-array update",
+									"const roles = pm.response.json().entity;",
+									"const keys = roles.map(r => r.roleKey);",
+									"pm.test(\"User holds DOTCMS_BACK_END_USER and Scripting Developer\", function () {",
+									"    pm.expect(keys).to.include('DOTCMS_BACK_END_USER');",
+									"    pm.expect(keys).to.include('Scripting Developer');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/roles/users/{{emptyRolesUserId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"roles",
+								"users",
+								"{{emptyRolesUserId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateUserWithEmptyRolesArray",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200 OK or 201 Created\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									"",
+									"// #37109: an explicit empty roles array must be honored (was a silent no-op)",
+									"pm.test(\"Errors array is empty\", function () {",
+									"    pm.expect(pm.response.json()).to.have.property('errors').that.is.an('array').and.is.empty;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/users",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"userId\": \"{{emptyRolesUserId}}\",\n    \"active\": true,\n    \"firstName\": \"EmptyRoles\",\n    \"lastName\": \"TestUser37109\",\n    \"email\": \"emptyroles37109@dotcms.com\",\n    \"roles\": []\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "VerifyAllUserAssignableRolesRemoved",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200 OK or 201 Created\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+									"});",
+									"",
+									"// #37109: after roles: [] every user-assignable (editUsers=true) role must be gone,",
+									"// while system-managed memberships (the user's individual role) are preserved.",
+									"const roles = pm.response.json().entity;",
+									"const keys = roles.map(r => r.roleKey);",
+									"pm.test(\"Assignable roles are removed\", function () {",
+									"    pm.expect(keys).to.not.include('DOTCMS_BACK_END_USER');",
+									"    pm.expect(keys).to.not.include('Scripting Developer');",
+									"});",
+									"pm.test(\"No user-assignable role remains\", function () {",
+									"    pm.expect(roles.filter(r => r.editUsers === true)).to.be.empty;",
+									"});",
+									"pm.test(\"System-managed memberships are preserved\", function () {",
+									"    pm.expect(roles.length).to.be.above(0);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/roles/users/{{emptyRolesUserId}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"roles",
+								"users",
+								"{{emptyRolesUserId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateUserWithNullRoleEntryRejected",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// #37109: null/blank entries in the roles list are rejected up front,",
+									"// mirroring RoleUsersForm on the role-side membership endpoints.",
+									"pm.test(\"Status code is 400 Bad Request\", function () {",
+									"    pm.expect(pm.response.code).to.eql(400);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/users",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"userId\": \"{{emptyRolesUserId}}\",\n    \"active\": true,\n    \"firstName\": \"EmptyRoles\",\n    \"lastName\": \"TestUser37109\",\n    \"email\": \"emptyroles37109@dotcms.com\",\n    \"roles\": [\"DOTCMS_BACK_END_USER\", null]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "FindUsers",
 			"item": [
 				{


### PR DESCRIPTION
Fixes #37109

**Problem**
  
`PUT /api/v1/users` treats an explicit `"roles": []` as "field not sent" and returns 200 without changing anything, so all roles cannot be removed from a user via REST. The legacy Users portlet (DWR `UserAjax#updateUserRoles`) supports this. Root cause: `UtilMethods.isSet()` conflates null and empty, and `UserForm` normalized a missing `roles` field
to an empty list at construction, erasing the distinction before the resource could act on it.

**Fix**

* `UserForm` no longer collapses null (field absent) into an empty list (explicitly sent).
* `UserResource#processRoles` now reconciles memberships against the payload, matching legacy `UserAjax#updateUserRoles`: only user-assignable roles (`editUsers=true`) are added or removed.
  * `roles` absent → roles untouched (unchanged)
  * `roles` non-empty → becomes the user's complete user-assignable role set (same net result as before)
  * `roles: []` → removes all user-assignable roles (was a silent no-op)
  * null/blank entries → 400, whole update rolls back (mirrors `RoleUsersForm` on the role-side endpoints)
* Side effects fixed by the reconcile: the old wipe-and-re-add transiently unlinked the user's individual role on every roles-bearing update, and a payload naming an `editUsers=false` role key aborted the whole request (`DotStateException`); it is now skipped, as legacy does.
* Consistency: `DELETE /v1/roles/{roleId}/users` (merged 2 days ago in #37077, not in any LTS) now rejects `editUsers=false` roles with 403, mirroring the grant endpoint. The legacy Roles portlet never allowed this removal — it hides the controls for such roles.
* OpenAPI descriptions document the roles contract; `openapi.yaml` regenerated.

### Checklist

- [x] Tests: `UserResourceIntegrationTest` (5 new: empty array removes assignable roles and preserves the individual role; absent field untouched; non-empty replaces;
unknown/non-assignable keys ignored; null entry → 400 + rollback), `RoleResourceIntegrationTest` (1 new: `editUsers=false` → 403, membership intact) — 49/49 and 7/7 green
- [x] Postman: new `UpdateUserEmptyRolesRemovesAll` folder asserting the resulting role set per case
- [x] `openapi.yaml` regenerated and committed

This PR fixes: #37109