### PR TITLE
fix(security): reference dotSAML bundle 26.08.21 (BouncyCastle 1.85)

### DIFF
--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.dotcms.samlbundle</groupId>
             <artifactId>com.dotcms.samlbundle</artifactId>
-            <version>26.03.17</version>
+            <version>26.08.21</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## What

Bumps the dotSAML system-bundle reference in `osgi-base/system-bundles/pom.xml` from `26.03.17` to `26.08.21`.

One line, one file. `26.08.21` is the bundle published from `dotCMS/com.dotcms.dotsaml#24` (merged), which upgrades the bundle's embedded BouncyCastle from 1.54 to 1.85.

## Why

Third of the three bundled BouncyCastle locations tracked in #37085 (support ticket 38700). The core BOM does not govern what the SAML bundle embeds — that BC lives inside the bundle jar, declared in the plugin's own build — so this reference bump is what actually makes a dotCMS image ship BC 1.85 on the SAML path.

Driver CVE is CVE-2026-59638 (BC JSSE hostname-verifier CN fallback). It was ruled **not reachable** here — the findings are bundling/version flags, so this is scanner hygiene rather than a live vulnerability.

## Verification

- `26.08.21` resolves from `repo.dotcms.com/artifactory/libs-release`.
- The published jar embeds `libs/bcprov-jdk18on-1.85.jar` and lists it on its `Bundle-ClassPath` (checked in the jar, not inferred from the pom).
- `./mvnw install -pl :dotcms-system-bundles -DskipTests` is green and the assembly copies `com.dotcms.samlbundle-26.08.21.jar`.
- `com.dotcms.samlbundle` is declared in exactly one place repo-wide; every other mention is the OSGi symbolic name in tests/Postman, unaffected by a version change.
- Binary-compatibility review of BC 1.54 -> 1.85 across the OpenSAML stack embedded by the bundle: only 3 classes reference BouncyCastle at all, all member references resolve identically against both versions, and `xmlsec` (signature validation) has zero BC references. Residual risk is behavioral and confined to certificate SAN parsing in `X509Support`.

## Test / QA

Gate before this reaches a release: a real SAML login + logout against an IdP. Nothing else in the platform changes — this bundle is only loaded on the SAML auth path.

## Scope notes

- Does **not** touch the BOM or the tika-plugin — that is #37111.
- The equivalent bump on `release-25.07.10_lts` is held until #37089 (the `SamlNameID` backport that lets the `main` bundle run on LTS core) is merged.

Refs #37085

This PR fixes: #37085

This PR fixes: #37085