### PR TITLE
#37085 include in 25.07.10 LTS — upgrade Bouncy Castle 1.84 → 1.85 (CVE-2026-59638)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -19,7 +19,7 @@
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.14.15</bytebuddy.version>
         <batik.version>1.17</batik.version>
-        <bouncy-castle.version>1.84</bouncy-castle.version>
+        <bouncy-castle.version>1.85</bouncy-castle.version>
         <awaitility.version>4.0.0</awaitility.version>
         <shedlock.version>4.33.0</shedlock.version>
         <jackson.version>2.17.2</jackson.version>

--- a/independent-projects/core-plugins/tika-plugin/pom.xml
+++ b/independent-projects/core-plugins/tika-plugin/pom.xml
@@ -14,8 +14,42 @@
         <osgi.core.version>8.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
         <tika.version>3.3.1</tika.version>
+        <bouncy-castle.version>1.85</bouncy-castle.version>
         <skip.rewrite>true</skip.rewrite>
     </properties>
+
+    <!--
+        Tika drags BouncyCastle in transitively (bcjmail -> bcpkix -> bcutil, plus bcprov) and
+        this module does NOT import bom/application/pom.xml, so <bouncy-castle.version> there does
+        not govern what the bundle embeds. Pin the versions here instead of moving to Tika 3.3.2:
+        that release also makes the SAX-based OOXML parsers the default, which would change text
+        extraction for every docx/pptx/xlsx.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcjmail-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncy-castle.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
## What

LTS counterpart of #37111. Two changes, both build-only:

- `bom/application/pom.xml`: `bouncy-castle.version` 1.84 → 1.85
- `independent-projects/core-plugins/tika-plugin/pom.xml`: local `dependencyManagement` pinning bcjmail / bcpkix / bcprov / bcutil to the same property

Diff is identical to #37111 on `main`.

## Why the tika-plugin needs its own pin

`independent-projects/pom.xml` imports no BOM, so `bouncy-castle.version` in `bom/application/pom.xml` does **not** govern what the Tika OSGi bundle embeds — it resolves BC through Tika's own parent pom and shipped 1.84. Bumping the BOM alone would leave the scanner finding against Tika standing.

The alternative was Tika 3.3.1 → 3.3.2 (which does pin BC 1.85 upstream), rejected: that release also makes the SAX-based OOXML parsers the default, changing text extraction for every docx/pptx/xlsx in a patch. `TikaProxy` uses stock `AutoDetectParser` defaults and there is no tika-config in the repo, so nothing would hold the old behavior. Reasoning is repeated as a comment in the pom.

## Verification

This base runs **no CI** — `cicd_1-pr.yml` on this branch is filtered to `main`/`master`, so no build, no tests, no Sonar. Checks going green here means nothing. Verified by hand instead:

- `./mvnw install -pl :dotcms-core --am -DskipTests` on JDK 21 (`.sdkmanrc` → 21.0.8-ms): green.
- Reactor-wide `dependency:tree -Dincludes=org.bouncycastle`: every module resolves 1.85, including the tika-plugin's four embedded artifacts.
- The assembled webapp carries the 1.85 jars.

## Scope notes

- Driver CVE is CVE-2026-59638 (BC JSSE hostname-verifier CN fallback). Ruled **not reachable** here — the findings are bundling/version flags, so this is scanner hygiene, not a live vulnerability.
- Does not touch the samlbundle reference — that is a separate LTS PR bumping it to 26.08.21.
- `hotfix_tracking.md` already carries entry 47 for #37085 (added by #37089), so no new entry.

Refs #37085

This PR fixes: #37085