### PR TITLE
#37085 include in 25.07.10 LTS — reference dotSAML bundle 26.08.21 (BouncyCastle 1.85)

### DIFF
--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.dotcms.samlbundle</groupId>
             <artifactId>com.dotcms.samlbundle</artifactId>
-            <version>25.06.3</version>
+            <version>26.08.21</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## What

LTS counterpart of #37159. One line: the samlbundle system-bundle reference in `osgi-base/system-bundles/pom.xml` goes `25.06.3` → `26.08.21`.

`26.08.21` is the bundle published from `dotCMS/com.dotcms.dotsaml#24` (merged), which upgrades the bundle's embedded BouncyCastle from 1.54 to 1.85.

## Why

Third of the three bundled BouncyCastle locations in #37085. The core BOM does not govern what the SAML bundle embeds — that BC lives inside the bundle jar — so this reference bump is what makes an LTS image actually ship BC 1.85 on the SAML path.

Note the LTS line was **below** the CVE range: CVE-2026-59638 affects bcprov 1.61 to <1.85 and this branch shipped 1.54. So this is scanner hygiene here rather than exposure, same conclusion as on `main`.

## Depends on #37089 (merged)

The 26.08.21 bundle is built from dotSAML `main`, which references `com.dotcms.saml.SamlNameID` and calls `Attributes.getNameID()Ljava/io/Serializable;`. Neither existed on this branch until #37089 landed. Without that backport this bump would `NoClassDefFoundError` / `NoSuchMethodError` on the SAML auth and logout paths. Both are present on the branch as of `2914d0ec6b`.

## Verification

This base runs **no CI** — `cicd_1-pr.yml` here is filtered to `main`/`master`, so a green PR means nothing. Verified by hand:

- `26.08.21` resolves from `repo.dotcms.com/artifactory/libs-release`.
- The published jar embeds `libs/bcprov-jdk18on-1.85.jar` and lists it on its `Bundle-ClassPath` (checked inside the jar, not inferred from a pom).
- `./mvnw install -pl :dotcms-system-bundles -DskipTests` on JDK 21 (`.sdkmanrc` → 21.0.8-ms) is green and the assembly copies `com.dotcms.samlbundle-26.08.21.jar`.
- `com.dotcms.samlbundle` is declared in exactly one place repo-wide; other mentions are the OSGi symbolic name in tests/Postman, unaffected by a version change.
- Earlier work on this bundle: its 170 `Import-Package` entries were diffed against this branch's `osgi/system/osgi-extra.conf` — zero packages that `main` exports and LTS does not. And a binary-compat scan of BC 1.54 → 1.85 across the embedded OpenSAML stack found only 3 classes referencing BC at all, all members resolving identically on both versions; `xmlsec` (signature validation) references BC zero times.

## Test / QA

Gate before this ships in an LTS patch: a real SAML login + logout against an IdP. Residual risk is behavioral and confined to certificate SAN parsing in `X509Support`. Can be exercised without cutting a release by dropping the bundle jar into the Felix deploy dir, which shadows the system bundle.

## Scope notes

- Does not touch the BOM or the tika-plugin — that is the sibling LTS PR #37160.
- `hotfix_tracking.md` already carries entry 47 for #37085 (added by #37089), so no new entry.

Refs #37085

This PR fixes: #37085