### PR TITLE
ci: add dotbot act + label-gated dotbot review workflows

### DIFF
--- a/.github/workflows/dotbot-act.yml
+++ b/.github/workflows/dotbot-act.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   act:
     name: Act on /dotbot comments
+    # Authorization gate: only repo owners, org members, and collaborators may
+    # trigger the autonomous agent. Without this, any GitHub user could comment
+    # `/dotbot` on a PR and launch a write-privileged agent (privilege escalation).
     if: >-
       (
         (
@@ -24,19 +27,23 @@ jobs:
           startsWith(github.event.comment.body, '/dotbot')
         )
       ) &&
-      github.actor != 'dependabot[bot]'
+      github.actor != 'dependabot[bot]' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      workflows: write
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to a full commit SHA: a mutable tag could be repointed to run
+      # attacker-controlled code with this job's write-scoped GITHUB_TOKEN.
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.2.0
         with:
           fetch-depth: 0
           # The action code must be loaded from the pinned release SHA, not this
           # checkout (untrusted PR head), so `uses:` points at a fixed commit.
+          # Note: the checkout is still the PR head by design (the agent edits it),
+          # which is why the authorization gate above is critical.
           ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
       - name: dotbot autonomous edits
         uses: wezell/openrouter-code-review-action@34ee169dd9f35bf20a6b358b902c6c76e5df3a14

--- a/.github/workflows/dotbot-act.yml
+++ b/.github/workflows/dotbot-act.yml
@@ -1,0 +1,49 @@
+name: dotbot code act
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: dotbot-act-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  act:
+    name: Act on /dotbot comments
+    if: >-
+      (
+        (
+          github.event_name == 'issue_comment' &&
+          startsWith(github.event.comment.body, '/dotbot') &&
+          github.event.issue.pull_request
+        ) || (
+          github.event_name == 'pull_request_review_comment' &&
+          startsWith(github.event.comment.body, '/dotbot')
+        )
+      ) &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      workflows: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # The action code must be loaded from the pinned release SHA, not this
+          # checkout (untrusted PR head), so `uses:` points at a fixed commit.
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
+      - name: dotbot autonomous edits
+        uses: wezell/openrouter-code-review-action@34ee169dd9f35bf20a6b358b902c6c76e5df3a14
+        with:
+          mode: act
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          model: deepseek/deepseek-v4-pro-0813
+          reasoning_effort: high
+          web_search_mode: cached
+          debug_level: 1

--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -13,14 +13,23 @@ jobs:
     # Only run when the PR carries the "PR : dotbot review" label. The
     # `labeled`/`unlabeled` event types make the review fire (or cancel via
     # concurrency) the moment the label is added or removed.
-    if: "contains(github.event.pull_request.labels.*.name, 'PR : dotbot review')"
+    #
+    # Fork PRs are skipped: GitHub forces GITHUB_TOKEN to read-only for
+    # `pull_request` events from forks, so the action's write calls to post
+    # the review would fail. Supporting forks would require pull_request_target,
+    # which reintroduces untrusted-checkout risk.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'PR : dotbot review') &&
+      github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to a full commit SHA: a mutable tag could be repointed to run
+      # attacker-controlled code with this job's write-scoped GITHUB_TOKEN.
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.2.0
         with:
           fetch-depth: 0
       - name: dotbot autonomous review

--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -1,0 +1,34 @@
+name: dotbot code review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+concurrency:
+  group: dotbot-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Only run when the PR carries the "PR : dotbot review" label. The
+    # `labeled`/`unlabeled` event types make the review fire (or cancel via
+    # concurrency) the moment the label is added or removed.
+    if: "contains(github.event.pull_request.labels.*.name, 'PR : dotbot review')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: dotbot autonomous review
+        uses: wezell/openrouter-code-review-action@34ee169dd9f35bf20a6b358b902c6c76e5df3a14
+        with:
+          mode: review
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          review_models: ${{ vars.DOTBOT_REVIEW_MODELS }}
+          reasoning_effort: medium
+          web_search_mode: cached
+          debug_level: 1

--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -4,23 +4,36 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
-concurrency:
-  group: dotbot-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   review:
-    # Only run when the PR carries the "PR : dotbot review" label. The
-    # `labeled`/`unlabeled` event types make the review fire (or cancel via
-    # concurrency) the moment the label is added or removed.
+    # Only run when the PR carries the "PR : dotbot review" label.
     #
     # Fork PRs are skipped: GitHub forces GITHUB_TOKEN to read-only for
     # `pull_request` events from forks, so the action's write calls to post
     # the review would fail. Supporting forks would require pull_request_target,
     # which reintroduces untrusted-checkout risk.
+    #
+    # Label events (`labeled`/`unlabeled`) only proceed when the changed label
+    # IS "PR : dotbot review" — unrelated label churn must not re-run or
+    # restart the review. Note `github.event.pull_request.labels` reflects the
+    # post-event state, so removing the dotbot label fails the contains check
+    # and simply skips (an in-flight review is allowed to finish rather than
+    # being canceled — see concurrency note below).
     if: >-
       contains(github.event.pull_request.labels.*.name, 'PR : dotbot review') &&
-      github.event.pull_request.head.repo.fork == false
+      github.event.pull_request.head.repo.fork == false &&
+      (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+        github.event.label.name == 'PR : dotbot review'
+      )
+    # Concurrency lives at the JOB level (not workflow level) deliberately:
+    # skipped jobs never join the concurrency group, so a run triggered by
+    # unrelated label activity cannot cancel an in-flight review. Only runs
+    # whose `if` passes (real review work) claim the group and supersede
+    # the previous review via cancel-in-progress.
+    concurrency:
+      group: dotbot-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What
Copies the `dotbot code act` and `dotbot code review` GitHub Actions workflows from the `ovh-k8s-cluster` repo.

## Changes
- **`dotbot-act.yml`** — verbatim copy. Runs the pinned `wezell/openrouter-code-review-action` in `act` mode when a `/dotbot ...` comment is posted on a PR.
- **`dotbot-review.yml`** — copy with label gating: the review job only runs when the PR carries the **`PR : dotbot review`** label.
  - `labeled` / `unlabeled` added to the trigger types so the review fires as soon as the label is applied (and the `cancel-in-progress` concurrency group cancels an in-flight review if the label is removed).
  - Label expression is quoted because the label name contains ` : `, which is invalid in a YAML plain scalar.

## Prerequisites (repo settings, not in this PR)
- [x] `OPENROUTER_API_KEY` secret must be set in repo secrets
- [x] `DOTBOT_REVIEW_MODELS` repo variable (optional — action default models are used if unset)
- [x] `PR : dotbot review` label created on the repo

> Note: this PR does not have the review label yet. Add `PR : dotbot review` to test the gating (requires the workflow to exist on the base branch — i.e., after merge).

Closes #37163
