### PR TITLE
fix(content-drive): size a boolean Show-In-List column from its own header (#36795)

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.html
@@ -39,13 +39,17 @@
                 }
             </th>
             @for (column of $columns(); track column.field) {
-                <!-- `min-width: max-content` is what guarantees a header is never cut, and the browser
-                     measures it exactly, so the column is never wider than the label needs either.
-                     It is also what stops `table-layout: fixed` from squeezing the cell: `width` there
-                     is only a share to distribute, and the fixed columns' percentages resolve against
-                     the table's enlarged `min-width`, so they inflate and take room back — which cut
-                     even a short label. Values still truncate in their own cells.
-                     `title` stays as a belt-and-braces affordance. -->
+                <!-- `min-width: max-content` reads like the guarantee that a header is never cut, but
+                     under `table-layout: fixed` it does nothing: the column is sized from the first
+                     row's `width` and a cell's min-width is ignored. Measured in the rendered portlet,
+                     a 7rem header cell whose label and sort icon needed 113px was laid out at 98px,
+                     min-width and all. It is kept only for the layouts that are not fixed; what
+                     actually has to hold is the width each column is given, which is why
+                     `#resolveExtraColumnWidth` sizes an extra column from its own header and reserves
+                     room for the sort indicator.
+                     Nothing clips here either (`whitespace-nowrap`, no `overflow`), so a header that
+                     outgrows its cell draws over its neighbour instead of truncating, which is what
+                     `title` is the affordance for when a narrow table does cut a label. -->
                 @if (column.sortable && !$readOnly()) {
                     <th
                         class="whitespace-nowrap"

--- a/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.spec.ts
@@ -2706,7 +2706,7 @@ describe('DotFolderListViewComponent', () => {
             spectator.detectChanges();
 
             expect(headerByLabel('T')?.style.width).toMatch(/ch$/);
-            expect(headerByLabel('D')?.style.width).toBe('12rem');
+            expect(headerByLabel('D')?.style.width).toBe('19ch');
         });
 
         it('should let the browser size a header so it is never cut nor over-reserved', () => {
@@ -2727,10 +2727,11 @@ describe('DotFolderListViewComponent', () => {
         });
 
         it('should keep a fixed-width column from clipping a long header', () => {
-            // The per-type width used to be an override, so a boolean column stayed pinned at 7rem
-            // however long its header was. Under `table-layout: fixed` with a `whitespace-nowrap`
-            // sortable header and no overflow clipping, the label then spilled into the next header.
-            // The type width is a floor now: wide enough for the label, never narrower than 7rem.
+            // The per-type width used to be an override, so a boolean column stayed pinned at its
+            // compact width however long its header was. Under `table-layout: fixed` with a
+            // `whitespace-nowrap` sortable header and no overflow clipping, the label then spilled
+            // into the next header. It is a floor now: wide enough for the label, never narrower than
+            // the type's own width.
             spectator.setInput('extraColumns', [
                 {
                     field: 'myBool',
@@ -2743,8 +2744,7 @@ describe('DotFolderListViewComponent', () => {
 
             const width = headerByLabel('Bool Radio With A Very Long Header Name')?.style.width;
 
-            expect(width).toMatch(/ch$/);
-            expect(width).not.toBe('7rem');
+            expect(width).toBe('32ch');
         });
 
         it('should not over-reserve width for a long header', () => {
@@ -2771,8 +2771,54 @@ describe('DotFolderListViewComponent', () => {
             ]);
             spectator.detectChanges();
 
-            // The label fits well inside 7rem, so the compact per-type width still wins.
-            expect(headerByLabel('On')?.style.width).toBe('7rem');
+            // The label fits well inside the boolean floor, so the compact per-type width wins.
+            expect(headerByLabel('On')?.style.width).toBe('11ch');
+        });
+
+        it('should widen a boolean column to the header a real True/False field carries', () => {
+            // The reported case, in the shape it was reported in: a Radio or Select field with Data
+            // Type True/False and "Show in List" on. The floor and the header estimate used to be
+            // compared by converting `rem` to `ch` at a hardcoded 2 `ch` per `rem`, which assumes a
+            // 16px root font while dotCMS sets 14px. A 7rem column was therefore scored as 14ch when
+            // it is really 11.3ch, so the floor beat this header, and the label plus its sort icon
+            // (measured at 113px in the rendered portlet) was laid out in a 98px cell and drew over
+            // the next heading. Both are counted in `ch` now, so nothing is converted.
+            spectator.setInput('extraColumns', [
+                { field: 'myBool', header: 'Bool Radio', order: 0, type: 'boolean', sortable: true }
+            ]);
+            spectator.detectChanges();
+
+            expect(headerByLabel('Bool Radio')?.style.width).toBe('16ch');
+        });
+
+        it('should reserve room for the sort indicator in a sortable header', () => {
+            // A sortable header renders its label AND a sort icon, and the icon is ~2.6ch of the
+            // cell. Without an allowance for it, the estimate for "Bool Radio" landed at 13ch, or
+            // 112.7px, against a measured need of 113px: short by a hair, which is all it takes to
+            // spill into the neighbouring header.
+            spectator.setInput('extraColumns', [
+                {
+                    field: 'sortable',
+                    header: 'Bool Radio',
+                    order: 0,
+                    type: 'boolean',
+                    sortable: true
+                },
+                { field: 'plain', header: 'Bool Radio', order: 1, type: 'boolean' }
+            ]);
+            spectator.detectChanges();
+
+            const [sortable] = spectator
+                .queryAll(byTestId('header-column-sortable'))
+                .filter((th) => th.textContent?.trim().startsWith('Bool Radio'))
+                .map((th) => (th as HTMLElement).style.width);
+            const [plain] = spectator
+                .queryAll(byTestId('header-column-not-sortable'))
+                .filter((th) => th.textContent?.trim() === 'Bool Radio')
+                .map((th) => (th as HTMLElement).style.width);
+
+            expect(sortable).toBe('16ch');
+            expect(plain).toBe('13ch');
         });
 
         it('should clamp a text column width to the max for very long values', () => {

--- a/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.ts
@@ -345,17 +345,19 @@ export class DotFolderListViewComponent implements OnInit, AfterViewInit, OnDest
         });
     });
 
-    /**
-     * Rough `ch` per `rem` (16px font, ~8px advance), used ONLY to compare a fixed per-type width
-     * against a header-derived one and pick the wider. Never used to compute a rendered size, so the
-     * approximation cannot drift a column's actual width.
-     */
-    private readonly REM_TO_CH = 2;
     /** Character-count clamps for content-based (text/number) column widths, in `ch`. */
     private readonly EXTRA_COL_MIN_CH = 8;
     private readonly EXTRA_COL_MAX_CH = 32;
 
     private readonly EXTRA_COL_PAD_CH = 3;
+    /**
+     * Room a sortable header needs for its sort indicator, on top of its label. Measured in the
+     * rendered portlet: the icon plus the space before it is ~23px against a `1ch` of 8.67px in the
+     * header font, so 3 covers it. Without it, the estimate for a header like "Bool Radio" landed at
+     * 112.7px against a 113px need, short by a hair, which is all it takes to spill into the next
+     * header since nothing clips it.
+     */
+    private readonly EXTRA_COL_SORT_ICON_CH = 3;
     /** Column types exposed to the template's `@switch`, so cases aren't magic strings. */
     protected readonly COLUMN_TYPE = DOT_FOLDER_LIST_VIEW_COLUMN_TYPE;
 
@@ -376,17 +378,28 @@ export class DotFolderListViewComponent implements OnInit, AfterViewInit, OnDest
         return 'host' in item && item.host === SYSTEM_HOST_ID;
     }
 
-    /** Fixed widths per non-text column type (predictable, so no measuring needed). */
-    private readonly EXTRA_COL_TYPE_WIDTH: Partial<
-        Record<DotFolderListViewColumn['type'], string>
-    > = {
-        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATE]: '12rem',
-        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME]: '16rem',
-        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TIME]: '9rem',
-        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.BOOLEAN]: '7rem',
-        // Fixed thumbnail column — wider than the 4.5rem thumbnail box so a sortable header
-        // (label + sort icon) fits on one line; never measured from content.
-        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.IMAGE]: '9rem'
+    /**
+     * Fixed floor per non-text column type (predictable, so no measuring needed), counted in `ch`:
+     * the same unit the header estimate below uses, so the two can be compared exactly.
+     *
+     * They were authored in `rem` and are converted here, which is the fix for the reported bug. A
+     * `rem` floor and a `ch` estimate cannot be compared without knowing both the root font size and
+     * the header font's advance width, and the conversion that did it (2 `ch` per `rem`) assumed a
+     * 16px root while dotCMS sets 14px. That scored a 7rem boolean column as 14ch when it is really
+     * 11.3ch, so the floor kept beating headers that did not fit inside it. One unit removes the
+     * conversion, and with it that whole class of error.
+     *
+     * The counts hold the widths the `rem` values rendered at (14px root, `1ch` of 8.67px in the
+     * header font) to within a few px: 19ch for 12rem, 26ch for 16rem, 15ch for 9rem, 11ch for 7rem.
+     */
+    private readonly EXTRA_COL_TYPE_CH: Partial<Record<DotFolderListViewColumn['type'], number>> = {
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATE]: 19,
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.DATETIME]: 26,
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.TIME]: 15,
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.BOOLEAN]: 11,
+        // Fixed thumbnail column, wider than the 4.5rem thumbnail box and never measured from
+        // content. A sortable header gets its own room from the estimate below.
+        [DOT_FOLDER_LIST_VIEW_COLUMN_TYPE.IMAGE]: 15
     };
 
     /**
@@ -579,9 +592,10 @@ export class DotFolderListViewComponent implements OnInit, AfterViewInit, OnDest
     /**
      * Resolves an extra column's width. Explicit width wins; otherwise text/number columns size to
      * their content — the average value length across the current rows (never narrower than the
-     * header), padded and clamped, in `ch` so it scales with the cell font. Other types use a fixed
-     * per-type width. Average (not max) keeps one long outlier from blowing the column out; overflow
-     * truncates and the table scrolls horizontally.
+     * header), padded and clamped, in `ch` so it scales with the cell font. Other types keep their
+     * per-type width as a floor, widening to the header when the header needs more. Average (not max)
+     * keeps one long outlier from blowing the column out; overflow truncates in the cells and the
+     * table scrolls horizontally.
      */
     #resolveExtraColumnWidth(
         column: DotFolderListViewColumn,
@@ -600,35 +614,33 @@ export class DotFolderListViewComponent implements OnInit, AfterViewInit, OnDest
             ? Math.round(lengths.reduce((sum, length) => sum + length, 0) / lengths.length)
             : 0;
 
-        const fixed = column.type && this.EXTRA_COL_TYPE_WIDTH[column.type];
+        const typeFloor = column.type ? this.EXTRA_COL_TYPE_CH[column.type] : undefined;
+        const hasTypeFloor = typeFloor !== undefined;
 
-        // A fixed-type column renders formatted text (a date, an icon, a thumbnail) whose width does
-        // not depend on the raw value, so it must not be measured from content — only from its
-        // header, which is the one part that can outgrow the fixed width.
-        const contentLength = fixed ? 0 : averageLength;
+        // A floored column renders formatted text (a date, an icon, a thumbnail) whose width does not
+        // depend on the raw value, so it must not be measured from content, only from its header,
+        // which is the one part that can outgrow the floor.
+        const contentLength = hasTypeFloor ? 0 : averageLength;
 
-        // Both are clamped here, and neither has to be exact: a header is guaranteed to fit by
-        // `min-width: max-content` on the header cell, which the browser measures precisely. Sizing it
-        // from a character count instead over-reserved badly — `1ch` is the width of "0", wider than
-        // the average character in a proportional font, so a 41-character label asked for ~40% more
-        // room than it needed.
-        const chars = Math.min(
+        // `1ch` is the width of "0", wider than the average character in a proportional font, so a
+        // per-character count reserves a little more than the label strictly needs. That slack is
+        // load-bearing: together with the pad it is the only room the cell padding and the sort
+        // indicator get. `min-width: max-content` on the header cell reads like the real guarantee,
+        // but it is inert under `table-layout: fixed`: measured in the rendered portlet, a 7rem header
+        // cell whose label and sort icon needed 113px was laid out at 98px, min-width and all, and the
+        // surplus drew straight over the next heading.
+        //
+        // The floor takes part in the same clamp, so the wider of the two always wins and nothing has
+        // to be converted between units.
+        return `${Math.min(
             Math.max(
-                Math.max(column.header?.length ?? 0, contentLength) + this.EXTRA_COL_PAD_CH,
-                this.EXTRA_COL_MIN_CH
+                Math.max(column.header?.length ?? 0, contentLength) +
+                    this.EXTRA_COL_PAD_CH +
+                    (column.sortable ? this.EXTRA_COL_SORT_ICON_CH : 0),
+                hasTypeFloor ? typeFloor : this.EXTRA_COL_MIN_CH
             ),
             this.EXTRA_COL_MAX_CH
-        );
-
-        if (!fixed) {
-            return `${chars}ch`;
-        }
-
-        // The per-type width is a floor, not an override: a boolean column pinned at 7rem could not
-        // show a header longer than that. Resolved to whichever is wider rather than a CSS `max()`,
-        // because these widths are also summed into the table's `min-width: calc(100% + …)` and a
-        // single length keeps that expression parseable.
-        return chars > parseFloat(fixed) * this.REM_TO_CH ? `${chars}ch` : fixed;
+        )}ch`;
     }
 
     ngOnInit(): void {


### PR DESCRIPTION
## What

QA failed Bug 1 of #36795 on `main` @ `4b46909`: a Radio or Select field with Data Type `True/False` and **Show in List** on still renders its Content Drive column with the reported spacing defect. This is the fix for that one bug; the other five in the issue passed.

## The fix was already there. The arithmetic was not.

Worth saying up front, because the first suspicion was that the fix got lost in the asset-picker merge: it did not. `e399c1e000` is in `main` inside squash `87745ff315` and survived that merge intact. What shipped was the right change with a wrong constant.

That commit correctly turned the per-type column width into a **floor** rather than an override, and then had to pick between the floor and the header-derived estimate:

```ts
private readonly REM_TO_CH = 2;
...
return chars > parseFloat(fixed) * this.REM_TO_CH ? `${chars}ch` : fixed;
```

`REM_TO_CH = 2` assumes a 16px root font. dotCMS sets **14px**. So a `7rem` boolean column was scored as `14ch` when it is really `11.3ch`, and the floor kept beating headers that did not fit inside it.

## Measured, not inferred

Against a running instance, on a Radio and a Select authored the way dotCMS's own Radio help text recommends (`True|1` / `False|0`) with Show in List enabled:

| header | content needs | cell laid out at | overflow |
| --- | --- | --- | --- |
| `Bool Radio` | 113px | 98px | **+15px** |
| `Bool Select` | 118px | 98px | **+20px** |

Nothing clips a header (`whitespace-nowrap`, no `overflow`), so the surplus draws straight over the next heading. That is the spacing QA is seeing.

Two further findings from the same measurement:

1. **`min-width: max-content` on the header cell is inert** under `table-layout: fixed`. The column is sized from the first row's `width` and a cell's min-width is ignored. That 98px cell had it set and ignored. The comment calling it *"what guarantees a header is never cut"* is why the width arithmetic read as a belt-and-braces detail rather than the thing that has to hold.
2. **The sort indicator was never budgeted.** It is ~23px against a `1ch` of 8.67px in the header font. Even with a corrected conversion, `Bool Radio` estimates to `13ch` = 112.7px against that 113px need: short by a hair, which is all it takes to spill.

## What changed

- **The floor is counted in `ch` too**, so it takes part in the same clamp as the header estimate and **nothing is converted between units**. That removes the whole class of error rather than re-tuning a magic number: there is no root-font-size or font-advance assumption left to get wrong. The counts hold the widths the `rem` values rendered at to within a few px (19ch for 12rem, 26ch for 16rem, 15ch for 9rem, 11ch for 7rem).
- **A sortable extra column reserves room for its sort indicator** (`EXTRA_COL_SORT_ICON_CH`), on top of the existing padding allowance.
- **The header comment is corrected** to say that `min-width: max-content` does not hold under `table-layout: fixed`, and to point at the width resolution as the guarantee. The attribute is left in place for the non-fixed layouts; only the claim about it is wrong.

## Reviewer attention

- **A CSS `max()` was the first attempt and was rejected on testability, not correctness.** `calc(100% + max(7rem, 16ch) + ...)` does parse and lay out correctly in Chrome (verified in the rendered portlet), but jsdom's CSS parser rejects `max()`, so `style.width` came back as `""` and every column-width assertion in the suite went blind. Given this bug shipped twice behind tests that could not see the layout, a single unit that stays assertable was the better trade.
- **The clamp now also applies to floored types.** `EXTRA_COL_MAX_CH` (32) caps a floored column too. Every floor is well under it (max 26), so this bounds a runaway header rather than the floor itself.
- **Widths change slightly for the other fixed types**, by a few px each, since the `rem` values are now expressed as `ch` counts. Verified visually against Date and Date-and-Time columns.
- **Sortable extra columns get a little wider than before.** That is the reservation the sort icon always needed and never had; it is not a regression.

## Verification

Reproduced and confirmed in Content Drive on a content type carrying six Show-In-List columns of mixed types (boolean Radio, boolean Select, Text, **non-boolean** Radio, Date, Date-and-Time), which also covers the issue's "does not regress the other types" acceptance criterion.

Before, per rendered header cell: `Bool Radio` +15px over its cell, `Bool Select` +20px, headers visibly colliding with the neighbouring label and its sort icon.

After: **all 14 headers report `scrollWidth === clientWidth`, i.e. zero overflow**, and a short label (`On`) still resolves to the compact floor.

- 199/199 `ui` tests pass. The four new/updated width tests were confirmed **failing first** (`'Bool Radio'` resolved to `7rem`), then green.
- `nx lint ui` clean, `tsc --noEmit` clean for the changed files.
- The only `nx affected -t test` failures are `block-editor` / `dotcms-block-editor` (`AiContentPromptStore`), which fail identically on untouched `main`.

## Acceptance criteria covered

- [x] A Radio or Select field with Data Type `True/False` (`True|1` / `False|0`) and Show in List enabled renders with the same spacing/alignment as other Show-In-List column types.
- [x] No regression for non-boolean Radio/Select Show-In-List columns or the other existing types.

Fixes the failed QA on #36795 (Bug 1).

This PR fixes: #36795

This PR fixes: #36795