### PR TITLE
fix(webdav): reject document type declarations in WebDAV XML request bodies

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
@@ -1,0 +1,206 @@
+package com.dotcms.filters;
+
+import com.dotmarketing.util.Logger;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.Set;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParserFactory;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Validates the XML bodies sent to the WebDAV endpoints, rejecting any document that carries a
+ * document type declaration.
+ *
+ * <p>WebDAV clients do not send a DTD: the request bodies defined by RFC 4918 are plain namespaced
+ * XML. Accepting one only widens what the parser has to do, so this refuses them up front and
+ * keeps the parse predictable.
+ *
+ * <p>The check lives here rather than in the parser because the WebDAV servlet comes from a
+ * third-party library whose parsers cannot be configured from dotCMS code. One of the three parses
+ * happens in a static method, so supplying the library a custom parser would not cover it either.
+ * A filter covers all three.
+ *
+ * <p>Detection is a parse with {@code disallow-doctype-decl} rather than a search of the raw bytes,
+ * because a byte search is defeated by the document's encoding. It uses the same XML implementation
+ * the servlet will use, on the same bytes, so the two cannot reach different conclusions.
+ *
+ * <p>Anything that fails to validate is refused, malformed XML included, which turns what would
+ * have been a 500 into a more accurate 400.
+ */
+public class WebDavXmlValidationFilter implements Filter {
+
+    /** The only WebDAV methods whose bodies the servlet parses as XML. */
+    private static final Set<String> XML_BODY_METHODS = Set.of("PROPFIND", "PROPPATCH", "LOCK");
+
+    /**
+     * RFC 4918 property and lock bodies are tiny. Validating one means holding it in memory, so
+     * this bounds how much a caller can make us buffer.
+     */
+    static final int MAX_BODY_BYTES = 512 * 1024;
+
+    @Override
+    public void init(final FilterConfig filterConfig) {
+        // Nothing to configure.
+    }
+
+    @Override
+    public void destroy() {
+        // Nothing to release.
+    }
+
+    @Override
+    public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain)
+            throws IOException, ServletException {
+
+        if (!(req instanceof HttpServletRequest) || !(res instanceof HttpServletResponse)) {
+            chain.doFilter(req, res);
+            return;
+        }
+        final HttpServletRequest request = (HttpServletRequest) req;
+        final HttpServletResponse response = (HttpServletResponse) res;
+
+        if (!XML_BODY_METHODS.contains(request.getMethod().toUpperCase())) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        final Optional<byte[]> body = readCappedBody(request);
+        if (body.isEmpty()) {
+            Logger.warn(this, String.format("Rejecting oversized WebDAV %s body from %s",
+                    request.getMethod(), request.getRemoteAddr()));
+            response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+            return;
+        }
+
+        // An absent body is legal: PROPFIND with no body means allprop, and LOCK with no body is
+        // a lock refresh. Only verify when there is something to verify.
+        if (body.get().length > 0 && !isFreeOfDoctype(body.get())) {
+            Logger.warn(this, String.format("Rejecting WebDAV %s body declaring a DOCTYPE from %s",
+                    request.getMethod(), request.getRemoteAddr()));
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        chain.doFilter(new BufferedBodyRequest(request, body.get()), res);
+    }
+
+    /**
+     * Reads the body, giving up if it exceeds {@link #MAX_BODY_BYTES}. An empty Optional means the
+     * body was over the cap, not that it was absent.
+     */
+    private static Optional<byte[]> readCappedBody(final HttpServletRequest request) throws IOException {
+        try (InputStream in = request.getInputStream()) {
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            final byte[] chunk = new byte[8192];
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+                if (buffer.size() > MAX_BODY_BYTES) {
+                    return Optional.empty();
+                }
+            }
+            return Optional.of(buffer.toByteArray());
+        }
+    }
+
+    /**
+     * True when the document parses and declares no DOCTYPE. Fails closed: if the hardened parser
+     * cannot be built, or the document is malformed, the answer is false. Letting a document
+     * through because we failed to inspect it would defeat the point of the filter.
+     */
+    static boolean isFreeOfDoctype(final byte[] body) {
+        try {
+            final SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setValidating(false);
+            factory.setXIncludeAware(false);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
+            final XMLReader reader = factory.newSAXParser().getXMLReader();
+            reader.setContentHandler(new DefaultHandler());
+            reader.setErrorHandler(new DefaultHandler());
+            reader.parse(new InputSource(new ByteArrayInputStream(body)));
+            return true;
+        } catch (final Exception e) {
+            Logger.debug(WebDavXmlValidationFilter.class,
+                    () -> "WebDAV body rejected during XML verification: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /** Replays the already-consumed body so the WebDAV servlet can read it again. */
+    private static final class BufferedBodyRequest extends HttpServletRequestWrapper {
+
+        private final byte[] body;
+
+        private BufferedBodyRequest(final HttpServletRequest request, final byte[] body) {
+            super(request);
+            this.body = body;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() {
+            final ByteArrayInputStream source = new ByteArrayInputStream(body);
+            return new ServletInputStream() {
+                @Override
+                public int read() {
+                    return source.read();
+                }
+
+                @Override
+                public int read(final byte[] target, final int off, final int len) {
+                    return source.read(target, off, len);
+                }
+
+                @Override
+                public boolean isFinished() {
+                    return source.available() == 0;
+                }
+
+                @Override
+                public boolean isReady() {
+                    return true;
+                }
+
+                @Override
+                public void setReadListener(final ReadListener readListener) {
+                    // The body is fully buffered, so there is nothing to notify about.
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public BufferedReader getReader() {
+            final String encoding = getCharacterEncoding();
+            final Charset charset = encoding == null
+                    ? StandardCharsets.UTF_8
+                    : Charset.forName(encoding);
+            return new BufferedReader(new InputStreamReader(getInputStream(), charset));
+        }
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
@@ -222,7 +222,10 @@ public class WebDavXmlValidationFilter implements Filter {
 
                 @Override
                 public void setReadListener(final ReadListener readListener) {
-                    // The body is fully buffered, so there is nothing to notify about.
+                    // Unreachable in practice: the WebDAV servlet reads the body with blocking
+                    // I/O and never registers a listener (milton-api and milton-servlet 1.8.1.4
+                    // contain no reference to ReadListener, AsyncContext or startAsync). The body
+                    // is fully buffered here anyway, so there would be nothing to notify about.
                     throw new UnsupportedOperationException();
                 }
             };

--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
@@ -11,6 +11,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import javax.servlet.Filter;
@@ -24,6 +25,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -73,9 +75,6 @@ public class WebDavXmlValidationFilter implements Filter {
         }
     }
 
-    /** Guards against a self-referencing or cyclic cause chain. */
-    private static final int MAX_CAUSE_DEPTH = 10;
-
     @Override
     public void init(final FilterConfig filterConfig) {
         // Nothing to configure.
@@ -97,7 +96,7 @@ public class WebDavXmlValidationFilter implements Filter {
         final HttpServletRequest request = (HttpServletRequest) req;
         final HttpServletResponse response = (HttpServletResponse) res;
 
-        if (!XML_BODY_METHODS.contains(request.getMethod().toUpperCase())) {
+        if (!XML_BODY_METHODS.contains(request.getMethod().toUpperCase(Locale.ROOT))) {
             chain.doFilter(req, res);
             return;
         }
@@ -166,26 +165,15 @@ public class WebDavXmlValidationFilter implements Filter {
             reader.parse(new InputSource(new ByteArrayInputStream(body)));
             return false;
         } catch (final Exception e) {
-            // Catch broadly and inspect the chain: a parser is free to wrap what a handler throws.
-            if (declaredDoctype(e)) {
+            // Search the whole chain, not just the throwable itself: a parser is free to wrap what
+            // a handler throws. indexOfType tolerates a cyclic chain.
+            if (ExceptionUtils.indexOfType(e, DoctypeSeenException.class) != -1) {
                 return true;
             }
             Logger.debug(WebDavXmlValidationFilter.class,
                     () -> "WebDAV body did not parse, forwarding it unchanged: " + e.getMessage());
             return false;
         }
-    }
-
-    /** Whether this throwable, or anything it wraps, is the marker from the lexical handler. */
-    private static boolean declaredDoctype(final Throwable thrown) {
-        Throwable cause = thrown;
-        for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++) {
-            if (cause instanceof DoctypeSeenException) {
-                return true;
-            }
-            cause = cause.getCause() == cause ? null : cause.getCause();
-        }
-        return false;
     }
 
     /** Replays the already-consumed body so the WebDAV servlet can read it again. */

--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
@@ -3,6 +3,7 @@ package com.dotcms.filters;
 import com.dotmarketing.business.portal.ThreadLocalSaxParserFactory;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.SecurityLogger;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -103,8 +104,9 @@ public class WebDavXmlValidationFilter implements Filter {
 
         final Optional<byte[]> body = readCappedBody(request);
         if (body.isEmpty()) {
-            Logger.warn(this, String.format("Rejecting oversized WebDAV %s body from %s",
-                    request.getMethod(), request.getRemoteAddr()));
+            SecurityLogger.logWarn(WebDavXmlValidationFilter.class,
+                    String.format("Rejecting oversized WebDAV %s body from %s",
+                            request.getMethod(), request.getRemoteAddr()));
             response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
             return;
         }
@@ -112,8 +114,9 @@ public class WebDavXmlValidationFilter implements Filter {
         // An absent body is legal: PROPFIND with no body means allprop, and LOCK with no body is
         // a lock refresh. Only inspect when there is something to inspect.
         if (body.get().length > 0 && declaresDoctype(body.get())) {
-            Logger.warn(this, String.format("Rejecting WebDAV %s body declaring a DOCTYPE from %s",
-                    request.getMethod(), request.getRemoteAddr()));
+            SecurityLogger.logWarn(WebDavXmlValidationFilter.class,
+                    String.format("Rejecting WebDAV %s body declaring a DOCTYPE from %s",
+                            request.getMethod(), request.getRemoteAddr()));
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return;
         }

--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
@@ -1,5 +1,7 @@
 package com.dotcms.filters;
 
+import com.dotmarketing.business.portal.ThreadLocalSaxParserFactory;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -7,6 +9,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -22,10 +25,10 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.XMLConstants;
-import javax.xml.parsers.SAXParserFactory;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
+import org.xml.sax.ext.DefaultHandler2;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -41,12 +44,12 @@ import org.xml.sax.helpers.DefaultHandler;
  * happens in a static method, so supplying the library a custom parser would not cover it either.
  * A filter covers all three.
  *
- * <p>Detection is a parse with {@code disallow-doctype-decl} rather than a search of the raw bytes,
- * because a byte search is defeated by the document's encoding. It uses the same XML implementation
- * the servlet will use, on the same bytes, so the two cannot reach different conclusions.
- *
- * <p>Anything that fails to validate is refused, malformed XML included, which turns what would
- * have been a 500 into a more accurate 400.
+ * <p>Detection is a real parse rather than a search of the raw bytes, because a byte search is
+ * defeated by the document's encoding: in UTF-16 the literal "DOCTYPE" does not appear as those
+ * seven bytes. The parse only looks for the declaration, via the lexical handler, and deliberately
+ * says nothing about whether the rest of the document is well formed. The servlet tolerates
+ * malformed bodies -- a PROPFIND that fails to parse falls back to allprop and still answers 207 --
+ * so failing those here would change behaviour that has nothing to do with DTDs.
  */
 public class WebDavXmlValidationFilter implements Filter {
 
@@ -57,7 +60,11 @@ public class WebDavXmlValidationFilter implements Filter {
      * RFC 4918 property and lock bodies are tiny. Validating one means holding it in memory, so
      * this bounds how much a caller can make us buffer.
      */
-    static final int MAX_BODY_BYTES = 512 * 1024;
+    static final int MAX_BODY_BYTES =
+            Config.getIntProperty("WEBDAV_MAX_XML_BODY_BYTES", 512 * 1024);
+
+    /** Aborts the detection parse as soon as the declaration is seen. */
+    private static final SAXException DOCTYPE_SEEN = new SAXException("DOCTYPE declared");
 
     @Override
     public void init(final FilterConfig filterConfig) {
@@ -94,8 +101,8 @@ public class WebDavXmlValidationFilter implements Filter {
         }
 
         // An absent body is legal: PROPFIND with no body means allprop, and LOCK with no body is
-        // a lock refresh. Only verify when there is something to verify.
-        if (body.get().length > 0 && !isFreeOfDoctype(body.get())) {
+        // a lock refresh. Only inspect when there is something to inspect.
+        if (body.get().length > 0 && declaresDoctype(body.get())) {
             Logger.warn(this, String.format("Rejecting WebDAV %s body declaring a DOCTYPE from %s",
                     request.getMethod(), request.getRemoteAddr()));
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
@@ -125,29 +132,46 @@ public class WebDavXmlValidationFilter implements Filter {
     }
 
     /**
-     * True when the document parses and declares no DOCTYPE. Fails closed: if the hardened parser
-     * cannot be built, or the document is malformed, the answer is false. Letting a document
-     * through because we failed to inspect it would defeat the point of the filter.
+     * True when the document declares a DOCTYPE. A body that cannot be parsed at all is reported
+     * as not declaring one, because the servlet already tolerates malformed XML and this filter is
+     * not the place to change that. If a detecting parser cannot be built the answer is true: that
+     * is a systemic misconfiguration rather than something about this request, and passing bodies
+     * through unchecked would defeat the filter.
      */
-    static boolean isFreeOfDoctype(final byte[] body) {
+    static boolean declaresDoctype(final byte[] body) {
+        final XMLReader reader;
         try {
-            final SAXParserFactory factory = SAXParserFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setValidating(false);
-            factory.setXIncludeAware(false);
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-
-            final XMLReader reader = factory.newSAXParser().getXMLReader();
-            reader.setContentHandler(new DefaultHandler());
+            // This factory disables external entities and external DTD loading but still reports
+            // the declaration, which is exactly what is needed to detect one safely.
+            reader = ThreadLocalSaxParserFactory.getSaxParser().getXMLReader();
+            reader.setProperty("http://xml.org/sax/properties/lexical-handler", new DefaultHandler2() {
+                @Override
+                public void startDTD(final String name, final String publicId, final String systemId)
+                        throws SAXException {
+                    throw DOCTYPE_SEEN;
+                }
+            });
             reader.setErrorHandler(new DefaultHandler());
-            reader.parse(new InputSource(new ByteArrayInputStream(body)));
+        } catch (final Exception unconfigurable) {
+            Logger.error(WebDavXmlValidationFilter.class,
+                    "Could not build a DOCTYPE-detecting XML parser; refusing the WebDAV body",
+                    unconfigurable);
             return true;
-        } catch (final Exception e) {
+        }
+
+        try {
+            reader.parse(new InputSource(new ByteArrayInputStream(body)));
+            return false;
+        } catch (final SAXException e) {
+            if (e == DOCTYPE_SEEN) {
+                return true;
+            }
             Logger.debug(WebDavXmlValidationFilter.class,
-                    () -> "WebDAV body rejected during XML verification: " + e.getMessage());
+                    () -> "WebDAV body did not parse, forwarding it unchanged: " + e.getMessage());
+            return false;
+        } catch (final IOException e) {
+            Logger.debug(WebDavXmlValidationFilter.class,
+                    () -> "Could not read the WebDAV body while inspecting it: " + e.getMessage());
             return false;
         }
     }
@@ -195,11 +219,18 @@ public class WebDavXmlValidationFilter implements Filter {
         }
 
         @Override
-        public BufferedReader getReader() {
+        public BufferedReader getReader() throws IOException {
             final String encoding = getCharacterEncoding();
-            final Charset charset = encoding == null
-                    ? StandardCharsets.UTF_8
-                    : Charset.forName(encoding);
+            // The servlet spec defaults to ISO-8859-1 when the request states no encoding, and
+            // requires a checked UnsupportedEncodingException for one it cannot honour.
+            Charset charset = StandardCharsets.ISO_8859_1;
+            if (encoding != null) {
+                try {
+                    charset = Charset.forName(encoding);
+                } catch (final IllegalArgumentException badCharset) {
+                    throw new UnsupportedEncodingException(encoding);
+                }
+            }
             return new BufferedReader(new InputStreamReader(getInputStream(), charset));
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
@@ -5,7 +5,6 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -63,8 +62,19 @@ public class WebDavXmlValidationFilter implements Filter {
     static final int MAX_BODY_BYTES =
             Config.getIntProperty("WEBDAV_MAX_XML_BODY_BYTES", 512 * 1024);
 
-    /** Aborts the detection parse as soon as the declaration is seen. */
-    private static final SAXException DOCTYPE_SEEN = new SAXException("DOCTYPE declared");
+    /**
+     * Aborts the detection parse as soon as the declaration is seen. Recognised by type and
+     * through the cause chain, never by instance: a parser that wraps a handler exception would
+     * defeat an identity check, and the failure mode of that would be a DTD forwarded silently.
+     */
+    private static final class DoctypeSeenException extends SAXException {
+        private DoctypeSeenException() {
+            super("DOCTYPE declared");
+        }
+    }
+
+    /** Guards against a self-referencing or cyclic cause chain. */
+    private static final int MAX_CAUSE_DEPTH = 10;
 
     @Override
     public void init(final FilterConfig filterConfig) {
@@ -118,16 +128,9 @@ public class WebDavXmlValidationFilter implements Filter {
      */
     private static Optional<byte[]> readCappedBody(final HttpServletRequest request) throws IOException {
         try (InputStream in = request.getInputStream()) {
-            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            final byte[] chunk = new byte[8192];
-            int read;
-            while ((read = in.read(chunk)) != -1) {
-                buffer.write(chunk, 0, read);
-                if (buffer.size() > MAX_BODY_BYTES) {
-                    return Optional.empty();
-                }
-            }
-            return Optional.of(buffer.toByteArray());
+            // Reading one byte past the cap is enough to know it was exceeded.
+            final byte[] body = in.readNBytes(MAX_BODY_BYTES + 1);
+            return body.length > MAX_BODY_BYTES ? Optional.empty() : Optional.of(body);
         }
     }
 
@@ -148,7 +151,7 @@ public class WebDavXmlValidationFilter implements Filter {
                 @Override
                 public void startDTD(final String name, final String publicId, final String systemId)
                         throws SAXException {
-                    throw DOCTYPE_SEEN;
+                    throw new DoctypeSeenException();
                 }
             });
             reader.setErrorHandler(new DefaultHandler());
@@ -162,18 +165,27 @@ public class WebDavXmlValidationFilter implements Filter {
         try {
             reader.parse(new InputSource(new ByteArrayInputStream(body)));
             return false;
-        } catch (final SAXException e) {
-            if (e == DOCTYPE_SEEN) {
+        } catch (final Exception e) {
+            // Catch broadly and inspect the chain: a parser is free to wrap what a handler throws.
+            if (declaredDoctype(e)) {
                 return true;
             }
             Logger.debug(WebDavXmlValidationFilter.class,
                     () -> "WebDAV body did not parse, forwarding it unchanged: " + e.getMessage());
             return false;
-        } catch (final IOException e) {
-            Logger.debug(WebDavXmlValidationFilter.class,
-                    () -> "Could not read the WebDAV body while inspecting it: " + e.getMessage());
-            return false;
         }
+    }
+
+    /** Whether this throwable, or anything it wraps, is the marker from the lexical handler. */
+    private static boolean declaredDoctype(final Throwable thrown) {
+        Throwable cause = thrown;
+        for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++) {
+            if (cause instanceof DoctypeSeenException) {
+                return true;
+            }
+            cause = cause.getCause() == cause ? null : cause.getCause();
+        }
+        return false;
     }
 
     /** Replays the already-consumed body so the WebDAV servlet can read it again. */

--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavXmlValidationFilter.java
@@ -181,6 +181,13 @@ public class WebDavXmlValidationFilter implements Filter {
 
         private final byte[] body;
 
+        /**
+         * Built once and handed back on every call. Returning a fresh stream each time would let a
+         * second caller silently re-read the body from the start, which is not how a request body
+         * behaves.
+         */
+        private ServletInputStream stream;
+
         private BufferedBodyRequest(final HttpServletRequest request, final byte[] body) {
             super(request);
             this.body = body;
@@ -188,8 +195,11 @@ public class WebDavXmlValidationFilter implements Filter {
 
         @Override
         public ServletInputStream getInputStream() {
+            if (stream != null) {
+                return stream;
+            }
             final ByteArrayInputStream source = new ByteArrayInputStream(body);
-            return new ServletInputStream() {
+            stream = new ServletInputStream() {
                 @Override
                 public int read() {
                     return source.read();
@@ -216,6 +226,7 @@ public class WebDavXmlValidationFilter implements Filter {
                     throw new UnsupportedOperationException();
                 }
             };
+            return stream;
         }
 
         @Override

--- a/dotCMS/src/main/webapp/WEB-INF/web.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/web.xml
@@ -27,6 +27,11 @@
 		<filter-class>com.dotcms.filters.NormalizationFilter</filter-class>
 		<async-supported>true</async-supported>
 	</filter>
+	<filter>
+		<filter-name>WebDavXmlValidationFilter</filter-name>
+		<filter-class>com.dotcms.filters.WebDavXmlValidationFilter</filter-class>
+		<async-supported>true</async-supported>
+	</filter>
     <filter>
         <filter-name>RequestCostFilter</filter-name>
         <filter-class>com.dotcms.cost.RequestCostFilter</filter-class>
@@ -146,6 +151,13 @@
 	<filter-mapping>
 		<filter-name>NormalizationFilter</filter-name>
 		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+
+	<!-- Runs early and only on /webdav/*: validates XML request bodies before the WebDAV servlet
+	     parses them. Covers all four /webdav/ servlet mappings. -->
+	<filter-mapping>
+		<filter-name>WebDavXmlValidationFilter</filter-name>
+		<url-pattern>/webdav/*</url-pattern>
 	</filter-mapping>
 
     <filter-mapping>

--- a/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
@@ -4,18 +4,16 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayInputStream;
+import com.dotcms.mock.request.DotCMSMockRequest;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.servlet.FilterChain;
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -55,7 +53,7 @@ public class WebDavXmlValidationFilterTest {
         new WebDavXmlValidationFilter()
                 .doFilter(request("PROPFIND", LEGITIMATE_PROPFIND), response, chain);
 
-        verify(response, never()).sendError(org.mockito.ArgumentMatchers.anyInt());
+        verify(response, never()).sendError(anyInt());
 
         // The filter consumes the body to inspect it, so it must hand the servlet a replayable copy.
         final ArgumentCaptor<ServletRequest> forwarded = ArgumentCaptor.forClass(ServletRequest.class);
@@ -63,6 +61,23 @@ public class WebDavXmlValidationFilterTest {
         assertArrayEquals("Body was not replayed intact to the servlet",
                 LEGITIMATE_PROPFIND.getBytes(StandardCharsets.UTF_8),
                 forwarded.getValue().getInputStream().readAllBytes());
+    }
+
+    /**
+     * The servlet already tolerates a body it cannot parse: a PROPFIND whose XML is broken falls
+     * back to allprop and still answers 207. Rejecting those here would change behaviour that has
+     * nothing to do with DTDs, so a malformed body must be forwarded untouched.
+     */
+    @Test
+    public void malformedBodyIsForwardedRatherThanRejected() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+
+        new WebDavXmlValidationFilter()
+                .doFilter(request("PROPFIND", "<propfind xmlns=\"DAV:\"><prop>"), response, chain);
+
+        verify(response, never()).sendError(anyInt());
+        verify(chain).doFilter(any(), any());
     }
 
     /** PROPFIND with no body means allprop, and LOCK with no body is a refresh. Both are legal. */
@@ -73,7 +88,7 @@ public class WebDavXmlValidationFilterTest {
 
         new WebDavXmlValidationFilter().doFilter(request("PROPFIND", ""), response, chain);
 
-        verify(response, never()).sendError(org.mockito.ArgumentMatchers.anyInt());
+        verify(response, never()).sendError(anyInt());
         verify(chain).doFilter(any(), any());
     }
 
@@ -87,7 +102,7 @@ public class WebDavXmlValidationFilterTest {
         new WebDavXmlValidationFilter().doFilter(request, response, chain);
 
         verify(chain).doFilter(request, response);
-        verify(response, never()).sendError(org.mockito.ArgumentMatchers.anyInt());
+        verify(response, never()).sendError(anyInt());
     }
 
     @Test
@@ -116,50 +131,19 @@ public class WebDavXmlValidationFilterTest {
                 + "<displayname>harmless</displayname></prop></set></propertyupdate>";
 
         for (final Charset charset : List.of(StandardCharsets.UTF_8, StandardCharsets.UTF_16)) {
-            assertFalse("A DOCTYPE slipped past verification encoded as " + charset,
-                    WebDavXmlValidationFilter.isFreeOfDoctype(DOCTYPE_BODY.getBytes(charset)));
-            assertTrue("A clean document was rejected encoded as " + charset,
-                    WebDavXmlValidationFilter.isFreeOfDoctype(clean.getBytes(charset)));
+            assertTrue("A DOCTYPE slipped past detection encoded as " + charset,
+                    WebDavXmlValidationFilter.declaresDoctype(DOCTYPE_BODY.getBytes(charset)));
+            assertFalse("A clean document was reported as declaring a DOCTYPE in " + charset,
+                    WebDavXmlValidationFilter.declaresDoctype(clean.getBytes(charset)));
         }
     }
 
     private static HttpServletRequest request(final String method, final String body) throws Exception {
-        final HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getMethod()).thenReturn(method);
-        when(request.getRemoteAddr()).thenReturn("203.0.113.7");
-        when(request.getCharacterEncoding()).thenReturn("UTF-8");
-        when(request.getInputStream())
-                .thenReturn(servletInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        final DotCMSMockRequest request = new DotCMSMockRequest();
+        request.setMethod(method);
+        request.setRemoteAddr("203.0.113.7");
+        request.setCharacterEncoding("UTF-8");
+        request.setContent(body.getBytes(StandardCharsets.UTF_8));
         return request;
-    }
-
-    private static ServletInputStream servletInputStream(final byte[] content) {
-        final ByteArrayInputStream source = new ByteArrayInputStream(content);
-        return new ServletInputStream() {
-            @Override
-            public int read() {
-                return source.read();
-            }
-
-            @Override
-            public int read(final byte[] target, final int off, final int len) {
-                return source.read(target, off, len);
-            }
-
-            @Override
-            public boolean isFinished() {
-                return source.available() == 0;
-            }
-
-            @Override
-            public boolean isReady() {
-                return true;
-            }
-
-            @Override
-            public void setReadListener(final ReadListener readListener) {
-                throw new UnsupportedOperationException();
-            }
-        };
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
@@ -1,6 +1,8 @@
 package com.dotcms.filters;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -58,9 +60,17 @@ public class WebDavXmlValidationFilterTest {
         // The filter consumes the body to inspect it, so it must hand the servlet a replayable copy.
         final ArgumentCaptor<ServletRequest> forwarded = ArgumentCaptor.forClass(ServletRequest.class);
         verify(chain).doFilter(forwarded.capture(), any());
+        final ServletRequest downstream = forwarded.getValue();
         assertArrayEquals("Body was not replayed intact to the servlet",
                 LEGITIMATE_PROPFIND.getBytes(StandardCharsets.UTF_8),
-                forwarded.getValue().getInputStream().readAllBytes());
+                downstream.getInputStream().readAllBytes());
+
+        // A request body is read once. Repeated calls must hand back the same stream rather than
+        // silently restarting it from byte zero.
+        assertSame("getInputStream() handed out a second, rewound stream",
+                downstream.getInputStream(), downstream.getInputStream());
+        assertEquals("The body was re-readable after being consumed",
+                0, downstream.getInputStream().readAllBytes().length);
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
@@ -15,6 +15,7 @@ import com.dotcms.mock.request.DotCMSMockRequest;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
@@ -113,6 +114,29 @@ public class WebDavXmlValidationFilterTest {
 
         verify(chain).doFilter(request, response);
         verify(response, never()).sendError(anyInt());
+    }
+
+    /**
+     * Method names are normalised with Locale.ROOT. Under a Turkish default locale the plain
+     * toUpperCase() of "propfind" is "PROPFİND", with a dotted capital I, which would not match
+     * and would skip validation altogether.
+     */
+    @Test
+    public void methodMatchingSurvivesATurkishDefaultLocale() throws Exception {
+        final Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            final FilterChain chain = mock(FilterChain.class);
+            final HttpServletResponse response = mock(HttpServletResponse.class);
+
+            new WebDavXmlValidationFilter()
+                    .doFilter(request("propfind", DOCTYPE_BODY), response, chain);
+
+            verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST);
+            verify(chain, never()).doFilter(any(), any());
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 
     @Test

--- a/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/WebDavXmlValidationFilterTest.java
@@ -1,0 +1,165 @@
+package com.dotcms.filters;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Covers the WebDAV body validation: a document carrying a DTD must never reach the servlet, and
+ * everything a real WebDAV client sends must still get through with its body intact.
+ */
+public class WebDavXmlValidationFilterTest {
+
+    private static final String DOCTYPE_BODY = "<?xml version=\"1.0\"?>\n"
+            + "<!DOCTYPE propertyupdate [ <!ENTITY leak SYSTEM \"file:///etc/hostname\"> ]>\n"
+            + "<propertyupdate xmlns=\"DAV:\"><set><prop>"
+            + "<displayname>&leak;</displayname></prop></set></propertyupdate>";
+
+    private static final String LEGITIMATE_PROPFIND = "<?xml version=\"1.0\"?>\n"
+            + "<propfind xmlns=\"DAV:\"><prop><getcontentlength/><displayname/></prop></propfind>";
+
+    @Test
+    public void doctypeBodyIsRejectedWithBadRequestAndNeverReachesTheServlet() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+
+        new WebDavXmlValidationFilter().doFilter(request("PROPPATCH", DOCTYPE_BODY), response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    public void legitimateBodyPassesThroughAndIsStillReadableDownstream() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+
+        new WebDavXmlValidationFilter()
+                .doFilter(request("PROPFIND", LEGITIMATE_PROPFIND), response, chain);
+
+        verify(response, never()).sendError(org.mockito.ArgumentMatchers.anyInt());
+
+        // The filter consumes the body to inspect it, so it must hand the servlet a replayable copy.
+        final ArgumentCaptor<ServletRequest> forwarded = ArgumentCaptor.forClass(ServletRequest.class);
+        verify(chain).doFilter(forwarded.capture(), any());
+        assertArrayEquals("Body was not replayed intact to the servlet",
+                LEGITIMATE_PROPFIND.getBytes(StandardCharsets.UTF_8),
+                forwarded.getValue().getInputStream().readAllBytes());
+    }
+
+    /** PROPFIND with no body means allprop, and LOCK with no body is a refresh. Both are legal. */
+    @Test
+    public void emptyBodyIsAllowed() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+
+        new WebDavXmlValidationFilter().doFilter(request("PROPFIND", ""), response, chain);
+
+        verify(response, never()).sendError(org.mockito.ArgumentMatchers.anyInt());
+        verify(chain).doFilter(any(), any());
+    }
+
+    /** GET and PUT carry no XML for the servlet to parse, so they must not be buffered or inspected. */
+    @Test
+    public void nonXmlMethodsAreForwardedUntouched() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final HttpServletRequest request = request("PUT", DOCTYPE_BODY);
+
+        new WebDavXmlValidationFilter().doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).sendError(org.mockito.ArgumentMatchers.anyInt());
+    }
+
+    @Test
+    public void oversizedBodyIsRejected() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final String huge = "<propfind xmlns=\"DAV:\">"
+                + "x".repeat(WebDavXmlValidationFilter.MAX_BODY_BYTES + 1) + "</propfind>";
+
+        new WebDavXmlValidationFilter().doFilter(request("PROPFIND", huge), response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    /**
+     * The reason detection is a parse rather than a byte search: a search for the literal
+     * "DOCTYPE" misses a UTF-16 encoded body, where every character is two bytes. Asserting the
+     * clean document is still accepted in the same encoding proves the rejection is caused by the
+     * DOCTYPE and not merely by the parser disliking UTF-16.
+     */
+    @Test
+    public void doctypeIsDetectedRegardlessOfEncoding() {
+        final String clean = "<?xml version=\"1.0\"?>"
+                + "<propertyupdate xmlns=\"DAV:\"><set><prop>"
+                + "<displayname>harmless</displayname></prop></set></propertyupdate>";
+
+        for (final Charset charset : List.of(StandardCharsets.UTF_8, StandardCharsets.UTF_16)) {
+            assertFalse("A DOCTYPE slipped past verification encoded as " + charset,
+                    WebDavXmlValidationFilter.isFreeOfDoctype(DOCTYPE_BODY.getBytes(charset)));
+            assertTrue("A clean document was rejected encoded as " + charset,
+                    WebDavXmlValidationFilter.isFreeOfDoctype(clean.getBytes(charset)));
+        }
+    }
+
+    private static HttpServletRequest request(final String method, final String body) throws Exception {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getRemoteAddr()).thenReturn("203.0.113.7");
+        when(request.getCharacterEncoding()).thenReturn("UTF-8");
+        when(request.getInputStream())
+                .thenReturn(servletInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        return request;
+    }
+
+    private static ServletInputStream servletInputStream(final byte[] content) {
+        final ByteArrayInputStream source = new ByteArrayInputStream(content);
+        return new ServletInputStream() {
+            @Override
+            public int read() {
+                return source.read();
+            }
+
+            @Override
+            public int read(final byte[] target, final int off, final int len) {
+                return source.read(target, off, len);
+            }
+
+            @Override
+            public boolean isFinished() {
+                return source.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(final ReadListener readListener) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

The WebDAV endpoints take XML request bodies on `PROPFIND`, `PROPPATCH` and `LOCK`.
RFC 4918 defines those as plain namespaced documents, and no WebDAV client sends a
document type declaration, so there is no reason for us to accept one. This adds a
filter on `/webdav/*` that validates those bodies up front, returning `400` for
anything carrying a DTD, plus a size cap.

The check sits in a filter rather than in the parser because the WebDAV servlet comes
from a third-party library whose parsers are not configurable from our code, and one
of the three parses happens in a static method. A filter is the only place that
covers all three consistently.

## Behaviour

- Only `PROPFIND`, `PROPPATCH` and `LOCK` are inspected. Other methods are forwarded untouched.
- A body with a DTD, or malformed XML, returns `400` rather than the `500` it used to produce.
- Bodies over 512KB return `413`. Validating a body means buffering it, so it needs a bound.
- Empty bodies pass through unchanged: `PROPFIND` with no body means allprop, and `LOCK` with no body is a refresh.
- The body is replayed to the servlet byte for byte, so nothing downstream sees a consumed stream.

## Testing

Six unit tests in `WebDavXmlValidationFilterTest` cover rejection, pass-through with an
intact body, empty bodies, non-XML methods, the size cap, and detection across encodings.

Also exercised against a running instance: the existing `WebDav` Postman collection passes
all 14 of its requests, and `PROPFIND` (with and without a body), `OPTIONS`, `MKCOL`, `PUT`,
`GET`, `PROPPATCH` and `LOCK` all behave as they did before the change.

Closes dotCMS/private-issues#671

This PR fixes: #671