### PR TITLE
fix(uve): lock layout canvas during save to prevent container data loss (#36197)

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.html
@@ -1,4 +1,5 @@
 <dotcms-template-builder-lib
+    [disabled]="$isSaving()"
     (templateChange)="nextTemplateUpdate($event)"
     [layout]="$layoutProperties().layout"
     [template]="$layoutProperties().template"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -262,6 +262,9 @@ describe('EditEmaLayoutComponent', () => {
     describe('LOADING guard and disabled binding', () => {
         it('should drop templateChange events and not forbid navigation while uveStatus is LOADING', () => {
             store.setUveStatus(UVE_STATUS.LOADING);
+            // The mock is shared across all tests — clear accumulated calls from earlier tests
+            // before asserting this specific action had no effect.
+            (dotRouter.forbidRouteDeactivation as jest.Mock).mockClear();
 
             templateBuilder.templateChange.emit();
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -224,6 +224,17 @@ describe('EditEmaLayoutComponent', () => {
             expect(store.isClientReady()).toBe(false);
         }));
 
+        it('should NOT set uveStatus to LOADING before the debounce fires', fakeAsync(() => {
+            const setUveStatusSpy = jest.spyOn(store, 'setUveStatus');
+
+            templateBuilder.templateChange.emit();
+            tick(1000); // Less than DEBOUNCE_TIME (5000 ms)
+
+            expect(setUveStatusSpy).not.toHaveBeenCalledWith(UVE_STATUS.LOADING);
+
+            tick(4000); // flush remaining timer to avoid pending-timer warning
+        }));
+
         it('should save right away if we request page leave before the 5 secs', () => {
             const saveTemplate = jest.spyOn(component, 'saveTemplate');
 
@@ -245,6 +256,35 @@ describe('EditEmaLayoutComponent', () => {
                 summary: 'Success',
                 detail: 'dot.common.message.saved'
             });
+        });
+    });
+
+    describe('LOADING guard and disabled binding', () => {
+        it('should drop templateChange events and not forbid navigation while uveStatus is LOADING', () => {
+            store.setUveStatus(UVE_STATUS.LOADING);
+
+            templateBuilder.templateChange.emit();
+
+            expect(dotRouter.forbidRouteDeactivation).not.toHaveBeenCalled();
+        });
+
+        it('should process templateChange events and forbid navigation when uveStatus is not LOADING', () => {
+            templateBuilder.templateChange.emit();
+
+            expect(dotRouter.forbidRouteDeactivation).toHaveBeenCalled();
+        });
+
+        it('should pass disabled=true to the template builder when uveStatus is LOADING', () => {
+            store.setUveStatus(UVE_STATUS.LOADING);
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(true);
+        });
+
+        it('should pass disabled=false to the template builder when uveStatus is not LOADING', () => {
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(false);
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -6,6 +6,7 @@ import {
     Component,
     OnDestroy,
     OnInit,
+    computed,
     effect,
     inject
 } from '@angular/core';
@@ -19,8 +20,7 @@ import {
     finalize,
     switchMap,
     take,
-    takeUntil,
-    tap
+    takeUntil
 } from 'rxjs/operators';
 
 import { DotMessageService, DotPageLayoutService, DotRouterService } from '@dotcms/data-access';
@@ -53,6 +53,10 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
     protected readonly uveStore = inject(UVEStore);
 
     protected readonly $layoutProperties = this.uveStore.$layoutProps;
+
+    protected readonly $isSaving = computed(
+        () => this.uveStore.uveStatus() === UVE_STATUS.LOADING
+    );
 
     readonly $handleCanEditLayout = effect(() => {
         // The only way to enter here directly is by the URL, so we need to redirect the user to the correct page
@@ -87,6 +91,13 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
      * @memberof EditEmaLayoutComponent
      */
     nextTemplateUpdate(template: DotTemplateDesigner) {
+        // Drop edits that complete mid-flight: in-progress drags or open dropdowns
+        // can still emit templateChange after the canvas is frozen. Discarding them
+        // prevents corrupting the payload of the in-flight save.
+        if (this.uveStore.uveStatus() === UVE_STATUS.LOADING) {
+            return;
+        }
+
         this.dotRouterService.forbidRouteDeactivation();
         this.updateTemplate$.next(template);
         this.lastTemplate = template;
@@ -134,10 +145,11 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
             .pipe(
                 // debounceTime should be before takeUntil to avoid calling the observable after unsubscribe.
                 // More information: https://stackoverflow.com/questions/58974320/how-is-it-possible-to-stop-a-debounced-rxjs-observable
-                tap(() => this.uveStore.setUveStatus(UVE_STATUS.LOADING)), // Prevent the user to access page properties
                 debounceTime(DEBOUNCE_TIME),
                 takeUntil(this.destroy$),
                 switchMap((layout: DotTemplateDesigner) => {
+                    // Lock the canvas only when the POST is actually sent, not on every edit.
+                    this.uveStore.setUveStatus(UVE_STATUS.LOADING);
                     this.messageService.add({
                         severity: 'info',
                         summary: 'Info',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -54,9 +54,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
 
     protected readonly $layoutProperties = this.uveStore.$layoutProps;
 
-    protected readonly $isSaving = computed(
-        () => this.uveStore.uveStatus() === UVE_STATUS.LOADING
-    );
+    protected readonly $isSaving = computed(() => this.uveStore.uveStatus() === UVE_STATUS.LOADING);
 
     readonly $handleCanEditLayout = effect(() => {
         // The only way to enter here directly is by the URL, so we need to redirect the user to the correct page

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -116,3 +116,13 @@
         }
     </div>
 }
+@if (disabled) {
+    <div
+        class="absolute inset-0 z-50 flex items-center justify-center bg-white/50 backdrop-blur-[2px] cursor-not-allowed"
+        data-testId="template-builder-disabled-overlay">
+        <p-progress-spinner
+            [style]="{ width: '3rem', height: '3rem' }"
+            strokeWidth="4"
+            aria-label="Saving layout" />
+    </div>
+}

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -33,7 +33,7 @@
     <div
         (mousemove)="fixGridStackNodeOptions()"
         [ngStyle]="customStyles"
-        class="overflow-y-auto overflow-x-hidden transition-opacity duration-300 ease-in-out h-full p-6"
+        class="h-full overflow-x-hidden overflow-y-auto p-6 transition-opacity duration-300 ease-in-out"
         #templateContainerRef
         data-testId="template-builder-main">
         @if (vm.layoutProperties.header) {
@@ -118,7 +118,7 @@
 }
 @if (disabled) {
     <div
-        class="absolute inset-0 z-50 flex items-center justify-center bg-white/50 backdrop-blur-[2px] cursor-not-allowed"
+        class="absolute inset-0 z-50 flex cursor-not-allowed items-center justify-center bg-white/50 backdrop-blur-[2px]"
         data-testId="template-builder-disabled-overlay">
         <p-progress-spinner
             [style]="{ width: '3rem', height: '3rem' }"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -431,6 +431,93 @@ describe('TemplateBuilderComponent', () => {
             });
     });
 
+    describe('disabled input', () => {
+        it('should not render the disabled overlay by default', () => {
+            expect(spectator.query(byTestId('template-builder-disabled-overlay'))).toBeFalsy();
+        });
+
+        it('should render the disabled overlay when disabled is set to true', () => {
+            spectator.setInput('disabled', true);
+            spectator.detectChanges();
+            expect(spectator.query(byTestId('template-builder-disabled-overlay'))).toBeTruthy();
+        });
+
+        it('should hide the disabled overlay when disabled is set back to false', () => {
+            spectator.setInput('disabled', true);
+            spectator.detectChanges();
+            spectator.setInput('disabled', false);
+            spectator.detectChanges();
+            expect(spectator.query(byTestId('template-builder-disabled-overlay'))).toBeFalsy();
+        });
+
+        describe('grid interactions', () => {
+            let mockGrid: {
+                disable: jest.Mock;
+                enable: jest.Mock;
+                el: { querySelectorAll: jest.Mock };
+            };
+
+            beforeEach(() => {
+                mockGrid = {
+                    disable: jest.fn(),
+                    enable: jest.fn(),
+                    el: { querySelectorAll: jest.fn().mockReturnValue([]) }
+                };
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                spectator.component.grid = mockGrid as any;
+            });
+
+            it('should call grid.disable() when disabled becomes true', () => {
+                spectator.setInput('disabled', true);
+                expect(mockGrid.disable).toHaveBeenCalled();
+            });
+
+            it('should dispatch a document Escape keydown event when disabled becomes true', () => {
+                const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+                spectator.setInput('disabled', true);
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({ type: 'keydown', key: 'Escape' })
+                );
+                dispatchSpy.mockRestore();
+            });
+
+            it('should call grid.enable() when disabled becomes false', () => {
+                spectator.setInput('disabled', true);
+                spectator.setInput('disabled', false);
+                expect(mockGrid.enable).toHaveBeenCalled();
+            });
+
+            it('should disable all subgrids when disabled becomes true', () => {
+                const subGridDisable = jest.fn();
+                const subGridEnable = jest.fn();
+                mockGrid.el.querySelectorAll.mockReturnValue([
+                    { gridstack: { disable: subGridDisable, enable: subGridEnable } }
+                ]);
+
+                spectator.setInput('disabled', true);
+                expect(subGridDisable).toHaveBeenCalled();
+            });
+
+            it('should enable all subgrids when disabled becomes false', () => {
+                const subGridDisable = jest.fn();
+                const subGridEnable = jest.fn();
+                mockGrid.el.querySelectorAll.mockReturnValue([
+                    { gridstack: { disable: subGridDisable, enable: subGridEnable } }
+                ]);
+
+                spectator.setInput('disabled', true);
+                spectator.setInput('disabled', false);
+                expect(subGridEnable).toHaveBeenCalled();
+            });
+
+            it('should not call grid methods if grid is not yet initialized', () => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                spectator.component.grid = undefined as any;
+                expect(() => spectator.setInput('disabled', true)).not.toThrow();
+            });
+        });
+    });
+
     describe('Scroll on Drag', () => {
         beforeEach(() => {
             spectator.component.templateContainerRef = {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -31,6 +31,7 @@ import {
 
 import { DividerModule } from 'primeng/divider';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { ToolbarModule } from 'primeng/toolbar';
 
 import { filter, take, map, takeUntil, skip } from 'rxjs/operators';
@@ -89,6 +90,7 @@ import {
         DynamicDialogModule,
         ToolbarModule,
         DividerModule,
+        ProgressSpinnerModule,
         AddWidgetComponent,
         TemplateBuilderActionsComponent,
         TemplateBuilderSectionComponent,
@@ -112,6 +114,9 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
 
     @Input()
     containerMap!: DotContainerMap;
+
+    @Input()
+    disabled = false;
 
     @Output()
     templateChange: EventEmitter<DotTemplateDesigner> = new EventEmitter<DotTemplateDesigner>();
@@ -271,6 +276,42 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
                 isAnonymousTemplate: currentTemplate?.anonymous || this.template.anonymous // We createa a custom template for the page
             });
         }
+
+        if (changes.disabled !== undefined && this.grid) {
+            this.applyGridDisabled(!!changes.disabled.currentValue);
+        }
+    }
+
+    /**
+     * @description Enables or disables drag, resize, and external drop on the main grid
+     * and all of its subgrids. Called synchronously from ngOnChanges so GridStack
+     * blocks (or restores) interactions in the same tick the input changes — before
+     * any Angular render cycle.
+     *
+     * @param {boolean} disabled
+     * @memberof TemplateBuilderComponent
+     */
+    private applyGridDisabled(disabled: boolean): void {
+        if (disabled) {
+            this.grid.disable();
+            // Cancel any in-progress drag (internal row move or external toolbar widget drag-in).
+            // GridStack's DDDraggable registers a document keydown listener and calls cancel()
+            // on Escape, removing the drag clone from the DOM so the overlay becomes visible.
+            // PrimeNG dropdowns also close on Escape, covering the open-dropdown edge case.
+            document.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+            );
+        } else {
+            this.grid.enable();
+        }
+
+        const subGridEls = this.grid.el.querySelectorAll(
+            '.grid-stack'
+        ) as NodeListOf<GridHTMLElement>;
+
+        subGridEls.forEach((el) => {
+            el.gridstack?.[disabled ? 'disable' : 'enable']();
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes dotCMS/core#36197 — UVE Layout tab data loss caused by the GridStack canvas never being locked while a layout save is in flight.

### Root cause

Every layout change emits `templateChange` → `updateTemplate$` → 5-second debounce → `POST /api/v1/page/{id}/layout`. The canvas remained fully interactive during the entire debounce window, the in-flight POST, and the `pageReload()` + `updateOldRows()` re-hydration cycle. Any edit made in that window was silently discarded when the server response overwrote local state. Because the backend performs a destructive diff (deletes any container absent from the incoming payload), mid-flight edits could permanently remove content.

---

## Changes

### `TemplateBuilderComponent` (`template-builder.component.ts` / `.html`)

- **`@Input() disabled = false`** — new input that locks the canvas.
- **`applyGridDisabled(disabled)`** — called synchronously from `ngOnChanges` (before any render cycle):
  - `grid.disable()` / `grid.enable()` on the main grid and every subgrid — blocks drag, resize, and external drop at the GridStack event level.
  - Dispatches `keydown Escape` on `document` — GridStack's `DDDraggable` registers a document-level `keydown` handler and calls `cancel()` on Escape, removing the drag clone from the body so the overlay is visible. PrimeNG dropdowns also close on Escape, covering the open-dropdown edge case.
- **Visual overlay** — `@if (disabled)` block rendered **after** the grid content (correct DOM stacking order), with `bg-white/50 backdrop-blur-[2px]` and a centered `p-progress-spinner`, so the user clearly sees the canvas is saving.

### `EditEmaLayoutComponent` (`edit-ema-layout.component.ts` / `.html`)

- **`$isSaving` computed signal** — `computed(() => uveStore.uveStatus() === UVE_STATUS.LOADING)`, bound as `[disabled]="$isSaving()"` on the template builder.
- **Lock timing fixed** — `setUveStatus(LOADING)` moved from the `tap()` before `debounceTime` (locked on every keystroke) into `switchMap` (locks only when the POST is actually sent, i.e. when the "Saving…" toast appears). Users can edit freely during the 5-second debounce window.
- **`nextTemplateUpdate` guard** — returns early when `uveStatus === LOADING`. Covers edge cases where an in-progress action (held drag, open dropdown selection) completes after the freeze activates, preventing the late `templateChange` from resetting the debounce or corrupting the in-flight payload.

---

## Lock lifecycle

```
User edits → 5 s debounce settles
  → setUveStatus(LOADING)           [canvas locks + overlay appears]
  → POST /api/v1/page/{id}/layout
  → handleSuccessSaveTemplate()
  → pageReload()                    [LOADING held through re-fetch]
  → updateOldRows() re-hydration
  → setUveStatus(LOADED)            [canvas unlocks]
```

---

## Test plan

- [ ] Edit layout (move a row) → wait 5 s → "Saving…" toast appears → canvas shows overlay + spinner → cannot drag/add/resize during save + reload cycle → canvas unlocks after reload
- [ ] Edit layout → **do not wait** → immediately start dragging "Add Row" button → hold for 5 s → Escape cancels the drag, overlay appears → row is not added
- [ ] Edit layout → open "+" container dropdown in a box → wait 5 s → dropdown closes, overlay appears → canvas is frozen
- [ ] Edit layout → save fails (disconnect network) → canvas unlocks, `uveStatus` set to `ERROR`, user can retry
- [ ] `pnpm nx test portlets-edit-ema-portlet --testPathPattern=edit-ema-layout`
- [ ] `pnpm nx test template-builder --testPathPattern=template-builder.component`

---

https://github.com/user-attachments/assets/b77977ad-8b99-43ff-83f4-faa5705b2a4d


🤖 Generated with [Claude Code](https://claude.com/claude-code)