### PR TITLE
fix(cicd): freeze Date constructor in qa-stuck-check smoke tests

### DIFF
--- a/.github/scripts/qa-stuck-check/test-find-stuck-issues.js
+++ b/.github/scripts/qa-stuck-check/test-find-stuck-issues.js
@@ -14,7 +14,21 @@ const SCRIPT_PATH = path.resolve(
 // Pin "now" to a fixed UTC Monday so weekday counting is deterministic
 // regardless of when the test is run. Monday 2026-05-25 13:00 UTC.
 const FIXED_NOW = Date.UTC(2026, 4, 25, 13, 0, 0);
-Date.now = () => FIXED_NOW;
+// Freeze the whole Date constructor, not just Date.now(). find-stuck-issues.js
+// reads the clock via `new Date()` (line 73), which ignores a Date.now() stub —
+// so pinning only Date.now left the fixtures frozen while the script kept using
+// the real clock, and every fixture aged past STUCK_DAYS once the real date
+// drifted past FIXED_NOW.
+const RealDate = Date;
+class MockDate extends RealDate {
+  constructor(...args) {
+    super(...(args.length ? args : [FIXED_NOW]));
+  }
+  static now() {
+    return FIXED_NOW;
+  }
+}
+global.Date = MockDate;
 const now = Date.now();
 const daysAgo = (n) => new Date(now - n * 24 * 60 * 60 * 1000).toISOString();
 
@@ -226,7 +240,8 @@ async function testTeamWithoutSlackChannelIgnored() {
   // silently ignore issues that only carry that team's label.
   const fs = require('fs');
   const os = require('os');
-  const tmp = path.join(os.tmpdir(), `triage-${Date.now()}.json`);
+  // RealDate/pid, not the frozen Date.now(), so the temp name stays unique.
+  const tmp = path.join(os.tmpdir(), `triage-${RealDate.now()}-${process.pid}.json`);
   fs.writeFileSync(
     tmp,
     JSON.stringify({


### PR DESCRIPTION
## Problem

The **QA Stuck Check — PR validate** job fails on `main` with:

```
assert.ok(!byTeam['Team : Maintenance'])
    at testMainScenario (.github/scripts/qa-stuck-check/test-find-stuck-issues.js:125)
```

This is a **pre-existing time bomb**, not a regression from any particular PR. It reproduces on a clean checkout of `main`:

```bash
git checkout main
node .github/scripts/qa-stuck-check/test-find-stuck-issues.js   # fails today
```

It went unnoticed because the validate workflow only runs on PRs touching `.github/scripts/qa-stuck-check/**`, its two workflow files, or `.claude/triage-config.json` — which is rare. It surfaced on #37150, which edits `.claude/triage-config.json`.

## Root cause

The test pins the clock:

```js
const FIXED_NOW = Date.UTC(2026, 4, 25, 13, 0, 0);  // Monday 2026-05-25
Date.now = () => FIXED_NOW;
```

But `find-stuck-issues.js:73` reads the clock as:

```js
const now = new Date();
```

`new Date()` does **not** consult `Date.now()` — it reads the system clock directly. So the stub never reached the code under test: fixtures were frozen at 2026-05-25 while the script compared them against the real clock.

Once the real date drifted past `FIXED_NOW`, every fixture aged past `STUCK_DAYS=3`. The fixture deliberately labelled **"Too fresh"** — 1 day old, `Team : Maintenance`, which must *not* be reported — was measured at **66 business days** stuck:

```
  "title": "Too fresh",
  "itemUpdatedAt": "2026-05-24T13:00:00.000Z",
  "daysStuck": 66
```

so it was grouped as stuck and the negative assertion blew up. The suite passed only while real time stayed within ~3 business days of `FIXED_NOW`, i.e. it has been failing since roughly **late May 2026**.

## Fix

Freeze the whole `Date` constructor, not just `Date.now()`, so the pin the test already intended actually applies to the script under test:

```js
const RealDate = Date;
class MockDate extends RealDate {
  constructor(...args) {
    super(...(args.length ? args : [FIXED_NOW]));
  }
  static now() { return FIXED_NOW; }
}
global.Date = MockDate;
```

`new Date(someString)` and `new Date(someNumber)` still pass through to the real constructor, so `new Date(item.updatedAt)` (line 99) and `new Date(d)` (line 175) keep working; only the zero-arg form is pinned.

Also derives the temp-config filename from the real clock plus `process.pid`, since a frozen `Date.now()` would otherwise make that name a constant:

```js
const tmp = path.join(os.tmpdir(), `triage-${RealDate.now()}-${process.pid}.json`);
```

**No production code changes** — `find-stuck-issues.js` is untouched. Test file only, +17/−2.

## Verification

All 12 scenarios pass, and the result no longer depends on the date the suite is run:

```
=== testMainScenario ===            OK
=== testEmptyProject ===            OK
=== testCrossTeamIssue ===          OK
=== testMissingStatusFailsLoudly === OK
=== testSomeMissingStatusWarnsButContinues === OK
=== testNullProjectFailsLoudly ===  OK
=== testTeamWithoutSlackChannelIgnored === OK
=== testInvalidStuckDaysFailsLoudly === OK
=== testNonIssueContentDoesNotTripRatio === OK
=== testWeekdayCounting ===         OK
=== testClosedQaIssueIsSkipped ===  OK
=== testLabelsOverflowSkipsIssue === OK

All tests passed.
```

## Note on the scheduled run

Only the smoke tests were affected. The Mon/Thu scheduled job (`cicd_scheduled_qa-stuck-check.yml`) runs against real project data with a real clock, so its behaviour was always correct — this bug was confined to the test harness.

Unblocks #37150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)