### PR TITLE
perf(cicd): shallow checkouts for release build and prepare phases

### DIFF
--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -90,7 +90,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Bounded shallow checkout: Find Build Commit walks `git log` on main
+          # back to midnight UTC (max observed on main is ~19 commits/day, so
+          # 100 commits is ~5 days of headroom; use-latest-commit only needs
+          # HEAD). fetch-depth: 0 pulled every branch ref (~2k+ branches,
+          # ~1.1 GB pack) when only main's recent history is consulted.
+          fetch-depth: 100
           ref: main
 
       - name: Find Build Commit

--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -91,11 +91,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # Bounded shallow checkout: Find Build Commit walks `git log` on main
-          # back to midnight UTC (max observed on main is ~19 commits/day, so
-          # 100 commits is ~5 days of headroom; use-latest-commit only needs
-          # HEAD). fetch-depth: 0 pulled every branch ref (~2k+ branches,
-          # ~1.1 GB pack) when only main's recent history is consulted.
-          fetch-depth: 100
+          # back to midnight UTC. The window that matters is commits landing
+          # between midnight and run time (~3h); max observed is ~19 commits/day,
+          # so 1000 commits is ~52 days of volume and can't realistically overrun
+          # the midnight boundary. use-latest-commit only needs HEAD. Avoids the
+          # fetch-depth: 0 full fetch (~2k+ branches, ~1.1 GB pack) when only
+          # main's recent history is consulted.
+          fetch-depth: 1000
           ref: main
 
       - name: Find Build Commit

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -342,7 +342,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
+          # Shallow checkout: this job only needs HEAD of main (it does its own
+          # `git fetch origin main` before checkout -B). fetch-depth: 0 pulled
+          # every branch ref (~2k+ branches, ~1.1 GB pack) at ~19-20 min.
+          fetch-depth: 1
           token: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
 
       - name: Bump MinSdkVersion.VALUE and open PR

--- a/.github/workflows/cicd_comp_build-phase.yml
+++ b/.github/workflows/cicd_comp_build-phase.yml
@@ -91,18 +91,22 @@ jobs:
         if: inputs.ref == ''
         with:
           fetch-depth: 0
-      # Shallow checkout (fetch-depth: 1): the build only needs the ref snapshot.
-      # fetch-depth: 0 pulled every branch ref (~2k+ branches, ~1.1 GB pack) and
-      # cost ~19-20 min per job. buildnumber-maven-plugin (scmRevision) only reads
-      # HEAD, which works fine on a shallow clone. The `run-pr-checks` steps that
-      # need real history (git diff origin/main...HEAD, git status) are only used
-      # by the inputs.ref == '' path below, which keeps fetch-depth: 0.
+      # The ref path builds a tag/branch snapshot; buildnumber-maven-plugin
+      # (scmRevision) only reads HEAD, which works on a shallow clone, so we
+      # avoid the full fetch (~2k+ branches, ~1.1 GB pack, ~19-20 min).
+      # Depth is driven by run-pr-checks (NOT ref): the PR-only steps below
+      # (`.mvn/maven.config` guard, clean-tree check) need real history
+      # (git diff origin/main...HEAD), so when they run we fetch full history.
+      # No current caller sets both ref and run-pr-checks, but this keeps that
+      # future combination correct. String literals are used deliberately:
+      # `inputs.run-pr-checks && 0 || 1` is wrong because 0 is falsy in GH
+      # expressions, collapsing the true branch to 1.
       - name: Checkout code with ref ${{ inputs.ref }}
         if: inputs.ref != ''
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          fetch-depth: 1
+          fetch-depth: ${{ inputs.run-pr-checks && '0' || '1' }}
 
       # Check if .mvn/maven.config is modified in PR (only for PR checks)
       - name: Check if .mvn/maven.config is in the PR commit

--- a/.github/workflows/cicd_comp_build-phase.yml
+++ b/.github/workflows/cicd_comp_build-phase.yml
@@ -91,12 +91,18 @@ jobs:
         if: inputs.ref == ''
         with:
           fetch-depth: 0
+      # Shallow checkout (fetch-depth: 1): the build only needs the ref snapshot.
+      # fetch-depth: 0 pulled every branch ref (~2k+ branches, ~1.1 GB pack) and
+      # cost ~19-20 min per job. buildnumber-maven-plugin (scmRevision) only reads
+      # HEAD, which works fine on a shallow clone. The `run-pr-checks` steps that
+      # need real history (git diff origin/main...HEAD, git status) are only used
+      # by the inputs.ref == '' path below, which keeps fetch-depth: 0.
       - name: Checkout code with ref ${{ inputs.ref }}
         if: inputs.ref != ''
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       # Check if .mvn/maven.config is modified in PR (only for PR checks)
       - name: Check if .mvn/maven.config is in the PR commit

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -145,7 +145,11 @@ jobs:
       # Checkout the repository
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Shallow checkout: nothing in this job reads git history (no git
+          # commands after checkout; Docker/NPM publishing works from the
+          # working tree). fetch-depth: 0 pulled every branch ref (~2k+
+          # branches, ~1.1 GB pack) at ~19-20 min per job.
+          fetch-depth: 1
 
       - name: Get SDKMan Version
         id: get-sdkman-version

--- a/.github/workflows/cicd_comp_release-prepare-phase.yml
+++ b/.github/workflows/cicd_comp_release-prepare-phase.yml
@@ -93,10 +93,14 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
+      # Shallow checkout (fetch-depth: 1): this job only needs HEAD of the default
+      # branch (or the explicitly supplied release commit, fetched below) to cut
+      # the release branch from. fetch-depth: 0 pulled every branch ref
+      # (~2k+ branches, ~1.1 GB pack) and cost ~20 min per release run.
       - name: Checkout core
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
 
       - uses: ./.github/actions/core-cicd/cleanup-runner
@@ -146,7 +150,15 @@ jobs:
             git push origin :refs/tags/${release_tag}
           fi
 
-          git reset --hard ${{ steps.set-version.outputs.release_commit }}
+          release_commit=${{ steps.set-version.outputs.release_commit }}
+          # Shallow checkout (fetch-depth: 1) only guarantees HEAD of the default
+          # branch. When an explicit release commit was supplied, fetch just that
+          # commit (GitHub enables uploadpack.allowAnySHA1InWant) before resetting.
+          if ! git cat-file -e "${release_commit}^{commit}" 2>/dev/null; then
+            echo "Release commit ${release_commit} not present locally, fetching it"
+            git fetch --depth=1 origin "${release_commit}"
+          fi
+          git reset --hard "${release_commit}"
           release_version=${{ steps.set-version.outputs.release_version }}
           release_branch=${{ steps.set-version.outputs.release_branch }}
 

--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -96,7 +96,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Shallow checkout: this job only reads .github/test-matrix.yml from HEAD.
+          # fetch-depth: 0 pulled every branch ref (~2k+ branches, ~1.1 GB pack).
+          fetch-depth: 1
         
       - name: Parse test configuration
         id: parse-config
@@ -249,7 +251,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Shallow checkout: test jobs run Maven suites against the checked-out
+          # snapshot only — no git history is read anywhere in this job or in the
+          # maven-job action (buildnumber-maven-plugin reads HEAD, which works on
+          # a shallow clone). fetch-depth: 0 pulled every branch ref (~2k+
+          # branches, ~1.1 GB pack) at ~19-20 min per matrix job.
+          fetch-depth: 1
 
       # The libvips image engine (IMAGE_API_USE_LIBVIPS) is exercised by VipsParityTest.
       # Install native libvips on the JVM unit-test runner so those tests run instead of


### PR DESCRIPTION
Closes #37178

## Problem

Release runs spend most of their wall-clock time in `git fetch`, not building. From run [32759840677](https://github.com/dotCMS/core/actions/runs/32759840677) (Release 26.08.24-01):

| Job | Total | Git fetch |
|---|---|---|
| Prepare Release | 22m04s | ~20m33s |
| Build / Initial Artifact Build | 34m22s | ~19m13s |

Root cause: every checkout uses `fetch-depth: 0`, which fetches **all refs** — all ~2,100+ branches plus full history (~1.1 GB pack). The build fetch log even shows it downloading unrelated branches (e.g. `revert-pubsub-checkout`) that have nothing to do with the release tag.

## Changes

1. **`cicd_comp_build-phase.yml`** — the ref-based checkout (release tag, LTS tag, manual-deploy ref, nightly ref) now uses `fetch-depth: 1`. The build only needs the ref snapshot; `buildnumber-maven-plugin` (`scmRevision`) reads HEAD only, which works fine on a shallow clone. The no-ref path used by PR checks (`git diff origin/main...HEAD`, `git status` clean-tree check) keeps `fetch-depth: 0`, so PR workflows are unaffected.
2. **`cicd_comp_release-prepare-phase.yml`** — shallow checkout of the default branch HEAD. When an explicit `release_commit` is supplied and isn't already present locally, it is fetched with `git fetch --depth=1 origin <sha>` (GitHub enables `uploadpack.allowAnySHA1InWant`) before `git reset --hard`.
3. **`cicd_comp_test-phase.yml`** — the same fix, multiplied: the test phase fans out to **up to 26 jobs** (setup-matrix + 25 suites from `.github/test-matrix.yml`), each doing a full `fetch-depth: 0` checkout (~19-20 min per job). Nothing in these jobs reads git history (no git commands after checkout, the maven-job action has no git usage, Sonar runs in a separate workflow), so both checkouts are now `fetch-depth: 1`. This speeds up PR, merge-queue, trunk, and nightly test cycles.
4. **`cicd_comp_deployment-phase.yml`**, **`cicd_6-release.yml`** (bump-min-sdk-version), and **`cicd_4-nightly.yml`** (setup) — completes the audit of every `fetch-depth: 0` in `.github/`. The semantics were misread: `fetch-depth: 0` means *unlimited* history for *all* refs (every one of ~2,100+ branches, ~1.1 GB pack), not "no history". Deployment and the SDK bump only need the snapshot/HEAD of main (`fetch-depth: 1`); nightly's setup walks `git log` on main back to midnight UTC, so it gets a bounded `fetch-depth: 100` (max observed on main is ~19 commits/day). Two spots intentionally keep `fetch-depth: 0` because they genuinely read history: the build-phase PR path (`git diff origin/main...HEAD` merge base) and `ai_claude-backend-reviewer.yml` (agent runs git diff/log/show between base and head SHAs). The deprecated `legacy-release_maven-release-process.yml` is left untouched.

## Measurements (cold clone, tag `v26.08.24-01`)

| Method | Time |
|---|---|
| Full-ref fetch (current, `fetch-depth: 0`) | ~19 min in CI |
| Single-tag full-depth fetch | 9m41s |
| **Single-tag shallow fetch (this PR)** | **77s** |
| Tarball snapshot (codeload) | 24s |

The tarball was rejected: no `.git` means `scmRevision` silently falls back to `UNKNOWN` in the shipped artifacts.

Expected savings: **~38 of the ~66 min** profiled in the release run.

## Validation

- YAML syntax validated for both workflows
- Audited every git consumer in the release path: `buildnumber-maven-plugin` (works shallow), PR-check steps (gated off, `run-pr-checks: false`), docker/npm scripts (no git usage)
- Callers passing `ref`: release, LTS, java-variant, manual-deploy, CLI, nightly — all have `run-pr-checks: false`

## Follow-ups (not in this PR)
- The stale-branch cleanup (backup + delete of ~1,800 branches >6m old) is still worth doing for general repo hygiene
- `bump-min-sdk-version` is fixed by this PR. **Correction on `Check Changed Files`:** it does *not* pay the fetch tax — for PRs `dorny/paths-filter` uses the GitHub REST API for changed files (~1s) and its checkout is already shallow by default (~13s); the 2m26s seen in the release run was runner-queue time (release also passes `change-detection: 'disabled'`, skipping those steps entirely)
- `maven-job` action declares a `needs-history` input that is never consumed (vestigial)



