### PR TITLE
fix(webdav): require credentials and apply the property permission result

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/filters/WebDavAuthenticationFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/filters/WebDavAuthenticationFilter.java
@@ -1,0 +1,87 @@
+package com.dotcms.filters;
+
+import com.dotmarketing.util.SecurityLogger;
+import com.dotmarketing.util.UtilMethods;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Requires credentials on the WebDAV endpoints.
+ *
+ * <p>WebDAV in dotCMS is an authenticated interface throughout: every resource is resolved against
+ * a user, and the resource implementations answer {@code authorise(...)} with false when there is
+ * no user to check. The library that serves these endpoints does not apply that answer uniformly,
+ * because a few of its method handlers run their own sequence instead of the shared one that
+ * consults it. A request carrying no credentials at all is therefore handled by those handlers,
+ * with the resource's own answer never consulted or, for a PROPPATCH naming no property, consulted
+ * and then discarded.
+ *
+ * <p>Answering here removes that variation: a request with no credentials gets the RFC 7235
+ * challenge it should have got, for every method and whatever the body, and the servlet only ever
+ * sees requests that at least claim to be from somebody. Whether that claim is any good, and what
+ * the caller may then do, stays where it belongs -- with the library's authentication handlers and
+ * the resources' own permission checks.
+ *
+ * <p>This deliberately does not exempt OPTIONS. A client sends it to discover what the server
+ * supports, and being challenged is the normal answer to that: every WebDAV client already handles
+ * a challenge on its first request, since that is how it learns to send credentials at all.
+ */
+public class WebDavAuthenticationFilter implements Filter {
+
+    /**
+     * Basic is what the library's own challenge offers, and what dotCMS authenticates WebDAV with:
+     * the resources verify a username and password, so there is nothing else to offer here. The
+     * realm is a label a client shows and keys saved credentials by, not a decision input.
+     */
+    private static final String CHALLENGE = "Basic realm=\"dotCMS WebDAV\"";
+
+    @Override
+    public void init(final FilterConfig filterConfig) {
+        // Nothing to configure.
+    }
+
+    @Override
+    public void destroy() {
+        // Nothing to release.
+    }
+
+    @Override
+    public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain)
+            throws IOException, ServletException {
+
+        if (!(req instanceof HttpServletRequest) || !(res instanceof HttpServletResponse)) {
+            chain.doFilter(req, res);
+            return;
+        }
+        final HttpServletRequest request = (HttpServletRequest) req;
+        final HttpServletResponse response = (HttpServletResponse) res;
+
+        // Credentials reach WebDAV only in this header: the resources authenticate a username and
+        // password, and the library's handlers read nothing else. A present but blank header is no
+        // more a caller than an absent one.
+        if (!UtilMethods.isSet(request.getHeader("Authorization"))) {
+            // A refused request on an interface that serves nobody anonymously belongs in the
+            // security log, the same as a back-end URL requested without a session. The volume is
+            // bounded: a client is challenged once and then sends credentials up front, so what
+            // lands here past the first request of a handshake is something that never had any.
+            SecurityLogger.logInfo(WebDavAuthenticationFilter.class,
+                    () -> String.format("Refused WebDAV %s %s from %s: no credentials sent",
+                            request.getMethod(), request.getRequestURI(), request.getRemoteAddr()));
+            // setStatus, not sendError: web.xml maps 401 to /html/error/custom-error-page.jsp,
+            // which redirects, and a WebDAV client handed a 302 to a login page has nothing it can
+            // do with it. Setting the status keeps the challenge as the answer to the request.
+            response.setHeader("WWW-Authenticate", CHALLENGE);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        chain.doFilter(req, res);
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavServlet.java
@@ -1,0 +1,24 @@
+package com.dotmarketing.webdav;
+
+import com.bradmcevoy.http.MiltonServlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+
+/**
+ * The WebDAV servlet, with dotCMS's own property permission check installed.
+ *
+ * <p>The library builds its handlers during {@code init}, and the only way to reach them afterwards
+ * is through the manager it leaves behind. Nothing else here differs from the servlet this extends;
+ * the resource factory and everything else still comes from the init parameters in {@code web.xml}.
+ *
+ * @see WebdavPropertyAuthoriser
+ */
+public class DotWebdavServlet extends MiltonServlet {
+
+    @Override
+    public void init(final ServletConfig config) throws ServletException {
+        super.init(config);
+        // Reaches every handler that checks property permissions, which is PROPPATCH and PROPFIND.
+        httpManager.setPropertyPermissionService(new WebdavPropertyAuthoriser());
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/WebdavPropertyAuthoriser.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/WebdavPropertyAuthoriser.java
@@ -1,0 +1,53 @@
+package com.dotmarketing.webdav;
+
+import com.bradmcevoy.http.Request;
+import com.bradmcevoy.http.Request.Method;
+import com.bradmcevoy.http.Resource;
+import com.bradmcevoy.http.Response.Status;
+import com.bradmcevoy.property.PropertyAuthoriser;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.xml.namespace.QName;
+
+/**
+ * Decides whether a WebDAV request may read or write a resource's properties.
+ *
+ * <p>The decision is the resource's, exactly as in the library default: ask
+ * {@link Resource#authorise(Request, Method, com.bradmcevoy.http.Auth)} and report a refusal for
+ * each property the request named. What differs is an empty request.
+ *
+ * <p>The library builds its answer by iterating the property names, so a request that names none
+ * produces an empty set of refusals. The caller reads that set as the list of problems found and
+ * treats empty as "no problems", which means the resource's answer decides nothing at all for such
+ * a request: it is refused and handled anyway. A PROPPATCH whose body sets no property is the case
+ * that reaches this, and the property implementations dotCMS registers make that body a no-op, but
+ * a permission check whose result depends on how much the request asked for is not one worth
+ * relying on. This reports the refusal either way, naming the resource itself when the request
+ * named nothing.
+ */
+public class WebdavPropertyAuthoriser implements PropertyAuthoriser {
+
+    /**
+     * Stands in for the property list when a request named none, so that a refusal is never
+     * reported as an empty set. The name is the DAV element that would have held them.
+     */
+    private static final QName NO_PROPERTY_NAMED = new QName("DAV:", "prop");
+
+    @Override
+    public Set<CheckResult> checkPermissions(final Request request, final Method method,
+            final PropertyPermission permission, final Set<QName> fields, final Resource resource) {
+
+        if (resource.authorise(request, method, request.getAuthorization())) {
+            // Null rather than an empty set, matching what the caller expects of a clean check.
+            return null;
+        }
+
+        final Set<QName> refused = (fields == null || fields.isEmpty())
+                ? Set.of(NO_PROPERTY_NAMED)
+                : fields;
+
+        return refused.stream()
+                .map(field -> new CheckResult(field, Status.SC_UNAUTHORIZED, "Not authorised", resource))
+                .collect(Collectors.toSet());
+    }
+}

--- a/dotCMS/src/main/webapp/WEB-INF/web.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,11 @@
 		<async-supported>true</async-supported>
 	</filter>
 	<filter>
+		<filter-name>WebDavAuthenticationFilter</filter-name>
+		<filter-class>com.dotcms.filters.WebDavAuthenticationFilter</filter-class>
+		<async-supported>true</async-supported>
+	</filter>
+	<filter>
 		<filter-name>WebDavXmlValidationFilter</filter-name>
 		<filter-class>com.dotcms.filters.WebDavXmlValidationFilter</filter-class>
 		<async-supported>true</async-supported>
@@ -153,8 +158,15 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
-	<!-- Runs early and only on /webdav/*: validates XML request bodies before the WebDAV servlet
-	     parses them. Covers all four /webdav/ servlet mappings. -->
+	<!-- Runs early and only on /webdav/*: requires credentials before the WebDAV servlet handles
+	     anything. Covers all four /webdav/ servlet mappings. -->
+	<filter-mapping>
+		<filter-name>WebDavAuthenticationFilter</filter-name>
+		<url-pattern>/webdav/*</url-pattern>
+	</filter-mapping>
+
+	<!-- Runs after authentication and only on /webdav/*: validates XML request bodies before the
+	     WebDAV servlet parses them. Covers all four /webdav/ servlet mappings. -->
 	<filter-mapping>
 		<filter-name>WebDavXmlValidationFilter</filter-name>
 		<url-pattern>/webdav/*</url-pattern>
@@ -404,7 +416,7 @@
     </servlet>
 	<servlet>
 		<servlet-name>WebDav</servlet-name>
-		<servlet-class>com.bradmcevoy.http.MiltonServlet</servlet-class>
+		<servlet-class>com.dotmarketing.webdav.DotWebdavServlet</servlet-class>
 		<init-param>
 				<param-name>resource.factory.class</param-name>
 				<param-value>com.dotmarketing.webdav.ResourceFactoryImpl</param-value>

--- a/dotCMS/src/test/java/com/dotcms/filters/WebDavAuthenticationFilterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/WebDavAuthenticationFilterTest.java
@@ -20,8 +20,8 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * Covers the credentials requirement on the WebDAV endpoints: a request that carries none is
- * answered with a challenge and never reaches the servlet, whatever method or body it uses, and a
- * request that carries credentials is forwarded untouched.
+ * answered with a challenge and never reaches the servlet, whatever method it uses, and a request
+ * that carries credentials is forwarded untouched.
  */
 public class WebDavAuthenticationFilterTest {
 
@@ -46,27 +46,6 @@ public class WebDavAuthenticationFilterTest {
 
         verifyChallenged(response);
         verify(chain, never()).doFilter(any(), any());
-    }
-
-    /**
-     * The body is what the reported cases varied, and it is exactly what must not matter: a
-     * PROPPATCH naming no property was handled to completion because the check that refuses one
-     * works by iterating the properties named.
-     */
-    @Test
-    public void aBodyThatNamesNoPropertyIsStillRefused() throws Exception {
-        for (final String body : List.of("", "<?xml version=\"1.0\"?><r/>",
-                "<?xml version=\"1.0\"?><propertyupdate xmlns=\"DAV:\"/>")) {
-            final FilterChain chain = mock(FilterChain.class);
-            final HttpServletResponse response = mock(HttpServletResponse.class);
-
-            final DotCMSMockRequest request = request("PROPPATCH", null);
-            request.setContent(body);
-            new WebDavAuthenticationFilter().doFilter(request, response, chain);
-
-            verifyChallenged(response);
-            verify(chain, never()).doFilter(any(), any());
-        }
     }
 
     @Test

--- a/dotCMS/src/test/java/com/dotcms/filters/WebDavAuthenticationFilterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/filters/WebDavAuthenticationFilterTest.java
@@ -1,0 +1,167 @@
+package com.dotcms.filters;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.dotcms.mock.request.DotCMSMockRequest;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Covers the credentials requirement on the WebDAV endpoints: a request that carries none is
+ * answered with a challenge and never reaches the servlet, whatever method or body it uses, and a
+ * request that carries credentials is forwarded untouched.
+ */
+public class WebDavAuthenticationFilterTest {
+
+    private static final String CREDENTIALS = "Basic YWRtaW5AZG90Y21zLmNvbTphZG1pbg==";
+
+    /**
+     * Every WebDAV method the servlet answers. The methods the library routes through its shared
+     * path were already refused without credentials; PROPPATCH and OPTIONS were not. The filter
+     * makes no distinction between them, and this asserts that rather than only the two that were
+     * reported.
+     */
+    private static final List<String> WEBDAV_METHODS = List.of(
+            "PROPPATCH", "PROPFIND", "OPTIONS", "LOCK", "UNLOCK", "MKCOL", "MOVE", "COPY",
+            "GET", "HEAD", "PUT", "DELETE");
+
+    @Test
+    public void requestWithoutCredentialsIsChallengedAndNeverReachesTheServlet() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+
+        new WebDavAuthenticationFilter().doFilter(request("PROPPATCH", null), response, chain);
+
+        verifyChallenged(response);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    /**
+     * The body is what the reported cases varied, and it is exactly what must not matter: a
+     * PROPPATCH naming no property was handled to completion because the check that refuses one
+     * works by iterating the properties named.
+     */
+    @Test
+    public void aBodyThatNamesNoPropertyIsStillRefused() throws Exception {
+        for (final String body : List.of("", "<?xml version=\"1.0\"?><r/>",
+                "<?xml version=\"1.0\"?><propertyupdate xmlns=\"DAV:\"/>")) {
+            final FilterChain chain = mock(FilterChain.class);
+            final HttpServletResponse response = mock(HttpServletResponse.class);
+
+            final DotCMSMockRequest request = request("PROPPATCH", null);
+            request.setContent(body);
+            new WebDavAuthenticationFilter().doFilter(request, response, chain);
+
+            verifyChallenged(response);
+            verify(chain, never()).doFilter(any(), any());
+        }
+    }
+
+    @Test
+    public void everyMethodIsRefusedWithoutCredentials() throws Exception {
+        for (final String method : WEBDAV_METHODS) {
+            final FilterChain chain = mock(FilterChain.class);
+            final HttpServletResponse response = mock(HttpServletResponse.class);
+
+            new WebDavAuthenticationFilter().doFilter(request(method, null), response, chain);
+
+            verifyChallenged(response);
+            verify(chain, never()).doFilter(any(), any());
+        }
+    }
+
+    /**
+     * A refusal with no challenge leaves a client nothing to do but give up, so the header is part
+     * of the behaviour and not decoration.
+     */
+    @Test
+    public void theRefusalCarriesABasicChallenge() throws Exception {
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+
+        new WebDavAuthenticationFilter()
+                .doFilter(request("OPTIONS", null), response, mock(FilterChain.class));
+
+        final ArgumentCaptor<String> challenge = ArgumentCaptor.forClass(String.class);
+        verify(response).setHeader(eq("WWW-Authenticate"), challenge.capture());
+        assertTrue("The challenge must name a scheme the client can use: " + challenge.getValue(),
+                challenge.getValue().startsWith("Basic realm="));
+    }
+
+    @Test
+    public void requestWithCredentialsIsForwardedUntouched() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final HttpServletRequest request = request("PROPPATCH", CREDENTIALS);
+
+        new WebDavAuthenticationFilter().doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).sendError(anyInt());
+    }
+
+    /**
+     * A header that is present but empty is not credentials. Treating it as some evidence of a
+     * caller would reopen the path this closes.
+     */
+    @Test
+    public void anEmptyAuthorizationHeaderIsNotCredentials() throws Exception {
+        for (final String header : List.of("", "   ")) {
+            final FilterChain chain = mock(FilterChain.class);
+            final HttpServletResponse response = mock(HttpServletResponse.class);
+
+            new WebDavAuthenticationFilter().doFilter(request("PROPPATCH", header), response, chain);
+
+            verifyChallenged(response);
+            verify(chain, never()).doFilter(any(), any());
+        }
+    }
+
+    /** Nothing but HTTP reaches this mapping, but a non-HTTP request must not be swallowed. */
+    @Test
+    public void nonHttpRequestIsForwarded() throws Exception {
+        final FilterChain chain = mock(FilterChain.class);
+        final ServletRequest request = mock(ServletRequest.class);
+        final ServletResponse response = mock(ServletResponse.class);
+
+        new WebDavAuthenticationFilter().doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+
+    /**
+     * A refusal has to be the answer to the request, so the status is set rather than raised as a
+     * container error: web.xml maps 401 to an error page that redirects, and a client handed a 302
+     * to a login page cannot act on it. Caught live, where every refusal came back 302.
+     */
+    private static void verifyChallenged(final HttpServletResponse response) throws Exception {
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(response, never()).sendError(anyInt());
+    }
+
+    private static DotCMSMockRequest request(final String method, final String authorization) {
+        // DotCMSMockRequest holds headers but exposes no setter for them, so the one header this
+        // filter reads is supplied here.
+        final DotCMSMockRequest request = new DotCMSMockRequest() {
+            @Override
+            public String getHeader(final String name) {
+                return "authorization".equalsIgnoreCase(name) ? authorization : super.getHeader(name);
+            }
+        };
+        request.setMethod(method);
+        request.setRequestURI("/webdav/live/1/default");
+        request.setRemoteAddr("127.0.0.1");
+        return request;
+    }
+}

--- a/dotCMS/src/test/java/com/dotmarketing/webdav/WebdavPropertyAuthoriserTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/webdav/WebdavPropertyAuthoriserTest.java
@@ -1,0 +1,116 @@
+package com.dotmarketing.webdav;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bradmcevoy.http.Auth;
+import com.bradmcevoy.http.Request;
+import com.bradmcevoy.http.Request.Method;
+import com.bradmcevoy.http.Resource;
+import com.bradmcevoy.http.Response.Status;
+import com.bradmcevoy.property.PropertyAuthoriser.CheckResult;
+import com.bradmcevoy.property.PropertyAuthoriser.PropertyPermission;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import org.junit.Test;
+
+/**
+ * Covers the property permission check for the WebDAV endpoints.
+ *
+ * <p>The decision itself is the resource's, and these tests only pin what is done with the answer.
+ * The case that matters is a request that names no property: the library default builds its result
+ * by iterating the names, so with none to iterate a refusal comes back as an empty result, and the
+ * caller reads empty as "nothing wrong" and carries on.
+ */
+public class WebdavPropertyAuthoriserTest {
+
+    private static final QName DISPLAY_NAME = new QName("DAV:", "displayname");
+    private static final QName CREATION_DATE = new QName("DAV:", "creationdate");
+
+    @Test
+    public void aRefusalIsReportedEvenWhenNoPropertyWasNamed() {
+        final Resource resource = refusing();
+
+        final Set<CheckResult> result = new WebdavPropertyAuthoriser()
+                .checkPermissions(request(), Method.PROPPATCH, PropertyPermission.WRITE,
+                        Set.of(), resource);
+
+        assertFalse("A refusal reported as an empty result reads to the caller as no refusal",
+                result == null || result.isEmpty());
+        assertEquals(Status.SC_UNAUTHORIZED, result.iterator().next().getStatus());
+    }
+
+    /** Same case, reached the other way: the caller hands in a null set for some bodies. */
+    @Test
+    public void aRefusalIsReportedWhenTheNameSetIsNull() {
+        final Set<CheckResult> result = new WebdavPropertyAuthoriser()
+                .checkPermissions(request(), Method.PROPPATCH, PropertyPermission.WRITE,
+                        null, refusing());
+
+        assertFalse("A null name set must not turn a refusal into a pass",
+                result == null || result.isEmpty());
+    }
+
+    @Test
+    public void aRefusalNamesEveryPropertyTheRequestAskedFor() {
+        final Resource resource = refusing();
+
+        final Set<CheckResult> result = new WebdavPropertyAuthoriser()
+                .checkPermissions(request(), Method.PROPPATCH, PropertyPermission.WRITE,
+                        Set.of(DISPLAY_NAME, CREATION_DATE), resource);
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(r -> r.getStatus() == Status.SC_UNAUTHORIZED));
+        assertTrue(result.stream().allMatch(r -> r.getResource() == resource));
+        assertEquals(Set.of(DISPLAY_NAME, CREATION_DATE),
+                result.stream().map(CheckResult::getField).collect(toSet()));
+    }
+
+    @Test
+    public void nothingIsReportedWhenTheResourceAllowsIt() {
+        final Resource resource = mock(Resource.class);
+        when(resource.authorise(any(), any(), any())).thenReturn(true);
+
+        final Set<CheckResult> result = new WebdavPropertyAuthoriser()
+                .checkPermissions(request(), Method.PROPPATCH, PropertyPermission.WRITE,
+                        Set.of(DISPLAY_NAME), resource);
+
+        assertTrue("An allowed request must report nothing", result == null || result.isEmpty());
+    }
+
+    /**
+     * The resource is what holds the permission logic, so it has to be asked with the request's own
+     * method and credentials rather than anything reconstructed here.
+     */
+    @Test
+    public void theResourceIsAskedWithTheRequestsOwnMethodAndCredentials() {
+        final Request request = request();
+        final Auth auth = request.getAuthorization();
+        final Resource resource = refusing();
+
+        new WebdavPropertyAuthoriser().checkPermissions(request, Method.PROPPATCH,
+                PropertyPermission.WRITE, Set.of(DISPLAY_NAME), resource);
+
+        verify(resource).authorise(request, Method.PROPPATCH, auth);
+    }
+
+    private static Request request() {
+        final Request request = mock(Request.class);
+        final Auth auth = mock(Auth.class);
+        when(request.getAuthorization()).thenReturn(auth);
+        when(request.getMethod()).thenReturn(Method.PROPPATCH);
+        return request;
+    }
+
+    private static Resource refusing() {
+        final Resource resource = mock(Resource.class);
+        when(resource.authorise(any(), any(), any())).thenReturn(false);
+        return resource;
+    }
+}


### PR DESCRIPTION
## Summary

The WebDAV endpoints are served by a third-party library whose method handlers do not all
consult `Resource.authorise(...)`. Two things follow from that, both measured against a running
instance.

A request carrying no `Authorization` header is handled by the handlers that run their own
sequence instead of the shared one. Anonymous `PROPPATCH` answered `207`, anonymous `OPTIONS`
answered `200` on every `/webdav/` mount point, and anonymous `LOCK` on a legacy language path
answered `500`. WebDAV in dotCMS resolves every resource against a user, so there is nothing on
these endpoints to serve a caller who has not identified themselves. This adds a filter on
`/webdav/*` that answers those with the RFC 7235 challenge instead.

Separately, the permission check for `PROPPATCH` reports one problem per property named in the
request, so a body naming none reports an empty list of problems, which the caller reads as no
problem: the resource's answer is obtained and then discarded. `WebdavPropertyAuthoriser` reports
the refusal either way, and `DotWebdavServlet` installs it through the library's own extension
point, which reaches both handlers that check property permissions.

## Behaviour

- A request to `/webdav/*` with no `Authorization` header, or a blank one, gets `401` with
  `WWW-Authenticate: Basic`. Every method, whatever the body.
- The status is set rather than raised as a container error, because `web.xml` maps `401` to
  `/html/error/custom-error-page.jsp`, which redirects, and a WebDAV client has nothing it can do
  with a `302` to a login page.
- `OPTIONS` is not exempt. Being challenged on the first request is how a WebDAV client learns to
  send credentials at all.
- Refusals go to the security log, alongside comparable events such as a back-end URL requested
  without a session.
- Authenticated traffic is unchanged: `PROPFIND` with and without a body, `OPTIONS`, `MKCOL`,
  `PUT`, `GET`, `PROPPATCH`, `LOCK` and `DELETE` all behave as they did before.
- A `PROPPATCH` whose body names no property is now refused for a caller holding no permission on
  the resource, instead of answering `207`.

## Merge order with #37167

Both branches add a `<filter>` and a `<filter-mapping>` immediately after `NormalizationFilter`,
so `web.xml` will conflict. #37167 should land first. When this branch is rebased, keep both
filters and map `WebDavAuthenticationFilter` **before** `WebDavXmlValidationFilter`: there is no
reason to buffer and parse a body for a caller who is about to be refused. The `<servlet-class>`
change here is in a part of the file #37167 does not touch and merges cleanly.

Two filters on the same path is deliberate. One asks whether there is a caller at all, by reading
a single header; the other asks whether the body is shaped the way RFC 4918 says, and has to
buffer and parse to answer. Merging them would put an XML parse behind a credentials check in one
class for no gain.

## Testing

11 unit tests. `WebDavAuthenticationFilterTest` (6) covers the challenge and its header, every
WebDAV method, a blank `Authorization` header, non-HTTP pass-through, and pass-through for a
request that does carry credentials. `WebdavPropertyAuthoriserTest` (5) covers refusal when no
property was named, when the name set is null, one refusal per named property, and the allowed
case reporting nothing.

Against a running instance, before and after the change: anonymous `PROPPATCH` on three mount
points with three different no-property bodies went `207` → `401`, anonymous `OPTIONS` `200` →
`401`, anonymous `LOCK` on the legacy language path `500` → `401`, and nine functional checks
covering the traffic a real client sends are unchanged. Each guard was also verified by reverting
it and confirming the tests fail.

Not covered: no real desktop client was tested. Finder, Explorer and Office now meet a challenge
on `OPTIONS` where they previously got a `200`. That is the standard handshake and every client
implements it, but it is reasoning rather than a measurement. There is also no CI coverage for
these methods — the `WebDav` Postman collection sends Basic auth on every request, so it
exercises the authenticated path only.

Closes dotCMS/private-issues#672

This PR fixes: #672