### PR TITLE
fix(block-editor): register link, emoji and youtube regardless of Allowed Blocks (#37175)

### DIFF
--- a/core-web/libs/new-block-editor/CLAUDE.md
+++ b/core-web/libs/new-block-editor/CLAUDE.md
@@ -162,7 +162,8 @@ What actions are available on each node type. **Slash** = appears in `/` menu (`
 | `dotImage` | `image.extension.ts` | Image (modal picker) | Insert image, wrap-left/right (node-scoped), align, image properties popover (node-scoped) | `image` |
 | `dotVideo` | `video.extension.ts` | Video (modal picker) | Insert video | `video` |
 | `dotAudio` | `audio.extension.ts` | Audio (modal picker) | Insert audio | `audio` |
-| `youtube` | `@tiptap/extension-youtube` | — (legacy slash entry) | — | `youtube` |
+| `youtube` | `@tiptap/extension-youtube` | — (legacy slash entry) | — | none — always registered. `youtube` is not an Allowed Blocks option, so gating it only dropped stored embeds on restricted fields (#37175). Insertion is gated in the UI via `showAssetByUrl()`. |
+| `emoji` | `@tiptap/extension-emoji` | — (toolbar popover, gated by `emoji`) | — | none — always registered, same reason as `youtube` (#37175). Authoring is gated: toolbar button behind `@if (isAllowed('emoji'))`, `:)` input rule behind `enableEmoticons: has('emoji')`. |
 | `dotContent` | `contentlet/contentlet.extension.ts` | Content type → submenu | Edit contentlet (node-scoped) | `dotContent` |
 | `gridBlock` | `grid.extension.ts` | Grid (2 columns) | — | `gridBlock` |
 | `gridColumn` | `grid.extension.ts` | — (created by `insertGrid`) | — | inherits gridBlock |
@@ -181,7 +182,7 @@ What actions are available on each node type. **Slash** = appears in `/` menu (`
 | `superscript` | `@tiptap/extension-superscript` | Sup | any text |
 | `subscript` | `@tiptap/extension-subscript` | Sub | any text |
 | `highlight` | `@tiptap/extension-highlight` | — (schema only; the legacy editor has no button either) | any text |
-| `link` | `@tiptap/extension-link` | Link popover | any text (gated by `link` allowed-block) |
+| `link` | `@tiptap/extension-link` | Link popover — hidden when `link` is not in allowed blocks | any text. Always in the schema; `allowedBlocks` gates only the authoring paths (button, autolink, link-on-paste). Gating the *registration* blanked every restricted field (#37175) — a missing mark aborts `Node.fromJSON` for the whole document, and `link` is not even offered as an Allowed Blocks option. |
 | `textAlign` | `@tiptap/extension-text-align` | Align L/C/R/Justify | configured for `paragraph` + `heading` only |
 
 ### Special / node-scoped commands

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.spec.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.spec.ts
@@ -23,8 +23,8 @@ import type { SlashMenuService } from '../components/slash-menu/slash-menu.servi
  * JSON is intact.
  */
 describe('createEditorExtensions', () => {
-    // `allowedBlocks: ['link']` keeps DotLink but excludes table/codeBlock/image/etc., so the
-    // injector is never touched during assembly — a bare stub is enough.
+    // A restricted list keeps table/codeBlock/image out, so the injector is never touched
+    // during assembly — a bare stub is enough.
     const injector = { get: jest.fn() } as unknown as Injector;
     const menuService = {} as SlashMenuService;
     const messageService = { get: (key: string) => key } as unknown as DotMessageService;
@@ -105,5 +105,87 @@ describe('createEditorExtensions', () => {
         const doc = PMNode.fromJSON(schema, legacyDoc);
 
         expect(doc.textContent).toBe('Good Credit History:');
+    });
+
+    /**
+     * #37175 — `link`, `emoji` and `youtube` are gated by `has()` but are not offered as
+     * Allowed Blocks options, so every restricted field dropped them. `link` is a mark, and a
+     * missing mark aborts `Node.fromJSON` for the whole document; `emoji`/`youtube` are nodes,
+     * so they resurfaced as `Unsupported block (…)`. All three now register unconditionally and
+     * gate their authoring paths instead.
+     */
+    describe('extensions gated by keys Allowed Blocks never offers (#37175)', () => {
+        /** Mirrors what the settings UI produces — it cannot contain link/emoji/youtube. */
+        const RESTRICTED = ['bulletList', 'orderedList', 'codeBlock'];
+
+        const restricted = () =>
+            createEditorExtensions(menuService, RESTRICTED, injector, messageService);
+        const unrestricted = () =>
+            createEditorExtensions(menuService, undefined, injector, messageService);
+        const byName = (extensions: ReturnType<typeof restricted>, name: string) =>
+            flattenExtensions(extensions).find((ext) => ext.name === name);
+
+        it.each(['link', 'emoji', 'youtube'])('registers "%s" on a restricted field', (name) => {
+            const names = flattenExtensions(restricted()).map((ext) => ext.name);
+
+            expect(names.filter((registered) => registered === name)).toHaveLength(1);
+        });
+
+        it('deserializes a document containing link marks on a restricted field', () => {
+            const schema = getSchema(restricted());
+            const storedDoc = {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'text',
+                                marks: [{ type: 'link', attrs: { href: 'https://dotcms.com' } }],
+                                text: 'Getting started'
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            // Threw `RangeError: There is no mark type link in this schema` before the fix.
+            const doc = PMNode.fromJSON(schema, storedDoc);
+
+            expect(doc.textContent).toBe('Getting started');
+            expect(doc.firstChild?.firstChild?.marks[0].type.name).toBe('link');
+        });
+
+        it('renders a stored emoji instead of an unsupported-block placeholder', () => {
+            const schema = getSchema(restricted());
+            const storedDoc = {
+                type: 'doc',
+                content: [
+                    { type: 'paragraph', content: [{ type: 'emoji', attrs: { name: 'smile' } }] }
+                ]
+            };
+
+            const doc = PMNode.fromJSON(schema, storedDoc);
+
+            expect(doc.firstChild?.firstChild?.type.name).toBe('emoji');
+        });
+
+        // The schema keeps the extensions so stored content loads; these flags are what
+        // actually enforce the restriction, alongside the toolbar's `@if (isAllowed(...))`.
+        it('disables the implicit authoring paths when the block is not allowed', () => {
+            const extensions = restricted();
+
+            expect(byName(extensions, 'link')?.options.autolink).toBe(false);
+            expect(byName(extensions, 'link')?.options.linkOnPaste).toBe(false);
+            expect(byName(extensions, 'emoji')?.options.enableEmoticons).toBe(false);
+        });
+
+        it('keeps the implicit authoring paths on an unrestricted field', () => {
+            const extensions = unrestricted();
+
+            expect(byName(extensions, 'link')?.options.autolink).toBe(true);
+            expect(byName(extensions, 'link')?.options.linkOnPaste).toBe(true);
+            expect(byName(extensions, 'emoji')?.options.enableEmoticons).toBe(true);
+        });
     });
 });

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/editor-extensions.ts
@@ -54,6 +54,15 @@ export function createEditorExtensions(
                 t(`dot.block.editor.upload.media-type.${mediaType}`)
             )
     };
+    /**
+     * Only gate a REGISTRATION with this if the key is selectable in Allowed Blocks — that
+     * list comes from `getEditorBlockOptions()`, which offers block nodes only. `link`,
+     * `emoji` and `youtube` are not in it, so gating them dropped the extension on every
+     * restricted field instead of restricting anything: `link` (a mark) aborted
+     * `Node.fromJSON` for the whole document, `emoji`/`youtube` resurfaced as
+     * `Unsupported block (…)`. Those three are registered unconditionally and gate their
+     * authoring paths instead (#37175).
+     */
     const has = (name: string): boolean => !allowedBlocks || allowedBlocks.includes(name);
 
     // Headings use customer-facing per-level names ("heading1".."heading6"). When the field
@@ -115,33 +124,28 @@ export function createEditorExtensions(
               ]
             : []),
         ...(has('image') ? [DotImage] : []),
-        ...(has('link')
-            ? [
-                  DotLink.configure({
-                      openOnClick: false,
-                      enableClickSelection: true,
-                      autolink: true,
-                      linkOnPaste: true,
-                      HTMLAttributes: {
-                          rel: 'noopener noreferrer',
-                          target: '_self'
-                      }
-                  })
-              ]
-            : []),
+        // Always registered — see `has()`. Authoring gate: toolbar button + the two flags below.
+        DotLink.configure({
+            openOnClick: false,
+            enableClickSelection: true,
+            autolink: has('link'),
+            linkOnPaste: has('link'),
+            HTMLAttributes: {
+                rel: 'noopener noreferrer',
+                target: '_self'
+            }
+        }),
         ...(has('video') ? [Video] : []),
         ...(has('audio') ? [Audio] : []),
-        ...(has('youtube')
-            ? [
-                  Youtube.configure({
-                      height: 300,
-                      width: 400,
-                      interfaceLanguage: 'us',
-                      nocookie: true,
-                      modestBranding: true
-                  })
-              ]
-            : []),
+        // Always registered — see `has()`. Authoring gate: the "Add asset by URL" popover,
+        // already behind `showAssetByUrl()`.
+        Youtube.configure({
+            height: 300,
+            width: 400,
+            interfaceLanguage: 'us',
+            nocookie: true,
+            modestBranding: true
+        }),
         ...(has('dotContent') ? [createDotContentlet(injector)] : []),
         ...(has('gridBlock') ? [GridBlock, GridColumn] : []),
         TextAlign.configure({ types: ['heading', 'paragraph'] }),
@@ -160,24 +164,22 @@ export function createEditorExtensions(
         // `aiContent` block — still parses and renders. Removing it would silently drop
         // those blocks on load. See `ai-content.extension.ts` for details.
         AIContent,
-        ...(has('emoji')
-            ? [
-                  Emoji.configure({
-                      emojis,
-                      enableEmoticons: true,
-                      suggestion: {
-                          char: ':',
-                          items: () => [],
-                          render: () => ({
-                              onStart: () => undefined,
-                              onUpdate: () => undefined,
-                              onKeyDown: () => false,
-                              onExit: () => undefined
-                          })
-                      }
-                  })
-              ]
-            : []),
+        // Always registered — see `has()`. Authoring gate: toolbar button + `enableEmoticons`.
+        // The `:` suggestion trigger is inert by design; insertion goes through the popover.
+        Emoji.configure({
+            emojis,
+            enableEmoticons: has('emoji'),
+            suggestion: {
+                char: ':',
+                items: () => [],
+                render: () => ({
+                    onStart: () => undefined,
+                    onUpdate: () => undefined,
+                    onKeyDown: () => false,
+                    onExit: () => undefined
+                })
+            }
+        }),
         SelectionPreserveExtension,
         createSlashCommandExtension(menuService)
     ];


### PR DESCRIPTION
## Proposed Changes

Fixes #37175 — a Block Editor field with **Allowed Blocks** configured rendered blank on
edit whenever the stored content contained a link.

`createEditorExtensions()` gated `link`, `emoji` and `youtube` behind the field's Allowed
Blocks list. None of the three is offered as an Allowed Blocks option — that list comes
from `getEditorBlockOptions()`, which only exposes block nodes — so gating on those keys
never restricted anything. It dropped the extension on **every** field with a non-empty
`allowedBlocks`, with no configuration able to avoid it.

`link` is a **mark**, so its absence made `Mark.fromJSON` throw mid-recursion and abort
`Node.fromJSON` for the whole document. The field rendered blank even though the stored
JSON was intact and the live site rendered correctly. Authors saw what looked like deleted
content, and saving on top of it would have made that loss real. `emoji` and `youtube` are
nodes, so they degraded to `Unsupported block (…)` placeholders rather than crashing.

All three now register unconditionally, so stored content always loads. The restriction
moves to the authoring paths, where it actually belongs:

| Extension | Schema | Authoring gate |
|---|---|---|
| `link` | always registered | toolbar button (already gated) + `autolink` + `linkOnPaste` |
| `emoji` | always registered | toolbar button (already gated) + `enableEmoticons` (`:)` → 😀) |
| `youtube` | always registered | "Add asset by URL" popover, already gated by `showAssetByUrl()` |

A field that excludes links still cannot create them — it just stops destroying the
content it already has.

The invariant is documented once on `has()` rather than at each call site, so the next
gated extension gets checked against the Allowed Blocks options first.

This is the second occurrence of this failure mode; #37145 was the same crash from an
unregistered `highlight` mark.

### Deliberately out of scope

- **Unknown marks still abort the document.** Unknown *nodes* degrade via the
  `dotUnsupportedBlock` placeholder, which round-trips the original JSON; marks have no
  equivalent, so any future missing mark reproduces this class of bug. Hardening that means
  threading a `knownMarkNames` set through `preserveUnknownNodesInDocument` and deciding
  whether an unknown mark is discarded (loses formatting on the next save) or preserved via
  a `dotUnsupportedMark` placeholder. That is a schema-affecting change and deserves its own
  review — tracked in the ACs of #37175.
- **Pasting HTML that contains `<a>` into a link-restricted field.** `linkOnPaste` only
  covers pasting a raw URL over a selection; HTML paste goes through the mark's `parseHTML`.
  Previously the mark was absent from the schema so those links were silently stripped; now
  they are kept. Closing it needs a `transformPasted` handler — notably **not**
  `appendTransaction`, which would also run on `setContent` and strip the very links this PR
  restores.

## Issue

Fixes #37175

Support tickets: [Freshdesk #38997](https://dotcms.freshdesk.com/a/tickets/38997) ·
[Freshdesk #38993](https://dotcms.freshdesk.com/a/tickets/38993)

## Verification

Frontend-only; no schema, API contract or DB change, so this is rollback-safe and a clean
backport candidate.

- `pnpm nx test new-block-editor` → **101 passed** (12 suites)
- `pnpm nx lint new-block-editor` → clean
- `pnpm nx format:write` → no changes

The 6 new specs were verified to **fail without the production change** (fix stashed, suite
re-run), including the customer-facing error verbatim:
`RangeError: There is no mark type link in this schema`. Two of them assert the restriction
is still enforced on an unrestricted vs. restricted field, guarding against over-correcting
by leaving `autolink` off everywhere.

Manually verified against a local dev server with `FEATURE_FLAG_NEW_BLOCK_EDITOR` enabled:
a field restricted to lists + code block, holding content with a hyperlink and an emoji,
loads both instead of rendering blank / `Unsupported block (emoji)`.

### Suggested reviewer checks

1. Restricted field + stored link → content loads, link editable.
2. Same field → no link button in the toolbar, and typing a bare URL does not auto-link.
3. Same field → no emoji button, and `:)` does not auto-convert.
4. Unrestricted field → autolink, link-on-paste and emoticons all still work.

This PR fixes: #37175