### PR TITLE
refactor(sdk-release): replace regex-based PR subject parsing with GitHub commit-to-PR association API in release workflow

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -145,16 +145,21 @@ jobs:
           # release-prepare hasn't created this release's tag yet at this point in the
           # pipeline — main is the correct proxy for "what's about to ship" (release_commit
           # defaults to main's tip the same way).
-          # Only the commit SUBJECT (first line) — the full multi-line message's body
-          # routinely has prose or footnotes ending in "(#N)" that reference an unrelated,
-          # often much older PR/issue (confirmed: ~20 real examples in this repo's last 3000
-          # commits). Scanning the full message would treat those stray references as PRs in
-          # this release's range, risking both a false block (an old referenced PR happens to
-          # carry the label) and an unwarranted floor bump if the operator reruns with
-          # bump_min_sdk_version=true to "fix" it.
-          PR_NUMBERS=$(gh api "repos/${REPO}/compare/${PREV_TAG}...main" --paginate \
-            --jq '.commits[].commit.message | split("\n")[0]' \
-            | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+' | sort -un || true)
+          # Resolve each commit to its merged PR via GitHub's commits→PRs association API
+          # rather than parsing the commit subject for a trailing "(#N)". That regex only
+          # matched squash-merge subjects; merge-commit subjects ("Merge pull request #N
+          # from …") don't end in "(#N)", so once squash merges were disabled on this repo
+          # (dotCMS/private-issues#673) the regex silently found zero PRs and this gate
+          # always passed. The API resolves off git's actual PR-merge metadata, not the
+          # subject's text shape, so it stays correct under squash, merge, or rebase.
+          COMMIT_SHAS=$(gh api "repos/${REPO}/compare/${PREV_TAG}...main" --paginate \
+            --jq '.commits[].sha' || true)
+
+          PR_NUMBERS=$(
+            for sha in ${COMMIT_SHAS}; do
+              gh api "repos/${REPO}/commits/${sha}/pulls" --jq '.[].number' 2>/dev/null || true
+            done | sort -un
+          )
 
           BREAKING_PRS=()
           for pr in ${PR_NUMBERS}; do

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -155,11 +155,22 @@ jobs:
           COMMIT_SHAS=$(gh api "repos/${REPO}/compare/${PREV_TAG}...main" --paginate \
             --jq '.commits[].sha' || true)
 
-          PR_NUMBERS=$(
-            for sha in ${COMMIT_SHAS}; do
-              gh api "repos/${REPO}/commits/${sha}/pulls" --jq '.[].number' 2>/dev/null || true
-            done | sort -un
-          )
+          # Fix for PR #37219 review feedback (sfreudenthaler + Claude bot, High): a bare
+          # `2>/dev/null || true` here would make a genuine API failure (rate limit,
+          # transient 5xx, network blip) indistinguishable from "this commit has no PR" —
+          # silently dropping that commit's PR from the count re-introduces the same
+          # silent-pass failure this gate exists to prevent. So each lookup is checked
+          # explicitly: a real failure fails the step loudly and by name, instead of being
+          # swallowed like a normal empty result.
+          PR_NUMBERS_FILE=$(mktemp)
+          for sha in ${COMMIT_SHAS}; do
+            if ! gh api "repos/${REPO}/commits/${sha}/pulls" --jq '.[].number' >> "${PR_NUMBERS_FILE}"; then
+              echo "::error::Failed to look up the PR(s) associated with commit ${sha} (repos/${REPO}/commits/${sha}/pulls) — likely a transient GitHub API error or rate limit, not the absence of a PR. Re-run the release; if this keeps failing, check GitHub API status/rate limits before assuming this commit has no associated PR."
+              exit 1
+            fi
+          done
+          PR_NUMBERS=$(sort -un "${PR_NUMBERS_FILE}")
+          rm -f "${PR_NUMBERS_FILE}"
 
           BREAKING_PRS=()
           for pr in ${PR_NUMBERS}; do


### PR DESCRIPTION
To fix the new mechanism without squash-merge

This PR fixes: #37200