### PR TITLE
fix(cicd): fetch origin/main for Nx affected in Frontend Unit Tests

### DIFF
--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -258,6 +258,13 @@ jobs:
           # branches, ~1.1 GB pack) at ~19-20 min per matrix job.
           fetch-depth: 1
 
+      # Frontend Unit Tests runs `nx affected` (lint-test, -Pvalidate) which diffs
+      # against origin/main (core-web/pom.xml git.origin.branch). The shallow
+      # checkout above has no origin/main ref, so fetch just that ref, shallow.
+      - name: Fetch origin/main for Nx affected
+        if: contains(matrix.maven_args, '-Pvalidate')
+        run: git fetch --depth=1 origin main:refs/remotes/origin/main
+
       # The libvips image engine (IMAGE_API_USE_LIBVIPS) is exercised by VipsParityTest.
       # Install native libvips on the JVM unit-test runner so those tests run instead of
       # self-skipping. Ubuntu 24.04 libvips42 bundles the pdf/heif/svg/webp/jxl delegates.


### PR DESCRIPTION
## Problem

Merge Group Test / Frontend Unit Tests fails on every merge-group run:

```
fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.
```

`nx affected` (lint-test, `-Pvalidate`) diffs against `origin/main`
(`core-web/pom.xml` `git.origin.branch`), but the shallow `fetch-depth: 1`
checkout landed for #37178 leaves no `origin/main` ref, so Maven's
`exec:exec@lint-test` exits 1. That fails the job, which cancels every
other job in the merge group and blocks the queue.

Run: https://github.com/dotCMS/core/actions/runs/32915658690/job/98021660180

## Fix

Fetch just `origin/main`, shallow, before the lint-test step — only for
the suite that actually runs `nx affected` (`-Pvalidate`).

Fixes #37178

## Test plan

- [ ] Merge-group run shows Frontend Unit Tests passing with origin/main present
