### PR TITLE
fix(uve): lock layout canvas during save to prevent container data loss (#36197)

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.html
@@ -1,4 +1,5 @@
 <dotcms-template-builder-lib
+    [disabled]="$isSaving()"
     (templateChange)="nextTemplateUpdate($event)"
     [layout]="$layoutProperties().layout"
     [template]="$layoutProperties().template"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -2,9 +2,9 @@ import { expect, describe } from '@jest/globals';
 import { SpyObject } from '@openng/spectator';
 import { Spectator, createComponentFactory, mockProvider } from '@openng/spectator/jest';
 import { MockComponent, MockProvider } from 'ng-mocks';
-import { of } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
-import { provideHttpClient } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
@@ -38,7 +38,7 @@ import {
     MockDotRouterJestService
 } from '@dotcms/utils-testing';
 
-import { EditEmaLayoutComponent } from './edit-ema-layout.component';
+import { DEBOUNCE_TIME, EditEmaLayoutComponent } from './edit-ema-layout.component';
 
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api/dot-page-api.service';
@@ -158,6 +158,8 @@ describe('EditEmaLayoutComponent', () => {
     });
 
     beforeEach(async () => {
+        jest.clearAllMocks();
+
         spectator = createComponent();
         component = spectator.component;
         dotRouter = spectator.inject(DotRouterService);
@@ -185,8 +187,18 @@ describe('EditEmaLayoutComponent', () => {
             expect(dotRouter.forbidRouteDeactivation).toHaveBeenCalled();
         });
 
-        it('should trigger a save after 5 secs', fakeAsync(() => {
+        it('should set uveStatus to LOADING immediately when templateChange is emitted', fakeAsync(() => {
             const setUveStatusSpy = jest.spyOn(store, 'setUveStatus');
+
+            templateBuilder.templateChange.emit();
+
+            // tap fires synchronously before debounce — no tick needed
+            expect(setUveStatusSpy).toHaveBeenCalledWith(UVE_STATUS.LOADING);
+
+            tick(5000); // flush timer to avoid pending-timer warning
+        }));
+
+        it('should trigger a save after 5 secs', fakeAsync(() => {
             const reloadSpy = jest.spyOn(store, 'pageReload');
 
             templateBuilder.templateChange.emit();
@@ -194,7 +206,6 @@ describe('EditEmaLayoutComponent', () => {
 
             expect(dotPageLayoutService.save).toHaveBeenCalled();
             expect(reloadSpy).toHaveBeenCalled();
-            expect(setUveStatusSpy).toHaveBeenCalledWith(UVE_STATUS.LOADING);
 
             expect(messageService.add).toHaveBeenNthCalledWith(1, {
                 severity: 'info',
@@ -224,17 +235,6 @@ describe('EditEmaLayoutComponent', () => {
             expect(store.isClientReady()).toBe(false);
         }));
 
-        it('should NOT set uveStatus to LOADING before the debounce fires', fakeAsync(() => {
-            const setUveStatusSpy = jest.spyOn(store, 'setUveStatus');
-
-            templateBuilder.templateChange.emit();
-            tick(1000); // Less than DEBOUNCE_TIME (5000 ms)
-
-            expect(setUveStatusSpy).not.toHaveBeenCalledWith(UVE_STATUS.LOADING);
-
-            tick(4000); // flush remaining timer to avoid pending-timer warning
-        }));
-
         it('should save right away if we request page leave before the 5 secs', () => {
             const saveTemplate = jest.spyOn(component, 'saveTemplate');
 
@@ -259,35 +259,72 @@ describe('EditEmaLayoutComponent', () => {
         });
     });
 
-    describe('LOADING guard and disabled binding', () => {
-        it('should drop templateChange events and not forbid navigation while uveStatus is LOADING', () => {
-            store.setUveStatus(UVE_STATUS.LOADING);
-            // The mock is shared across all tests — clear accumulated calls from earlier tests
-            // before asserting this specific action had no effect.
-            (dotRouter.forbidRouteDeactivation as jest.Mock).mockClear();
+    describe('Canvas lock (#layoutSaveInFlight)', () => {
+        it('should drop templateChange events and not forbid navigation while save is in-flight', fakeAsync(() => {
+            const saveSubject = new Subject();
+            (dotPageLayoutService.save as jest.Mock).mockReturnValue(saveSubject.asObservable());
 
+            // First emit starts the debounce; forbidRouteDeactivation called once
+            templateBuilder.templateChange.emit();
+            tick(DEBOUNCE_TIME); // debounce fires → POST sent → #layoutSaveInFlight = true
+
+            // Save still in-flight. Second emit should be dropped by the in-flight guard.
             templateBuilder.templateChange.emit();
 
-            expect(dotRouter.forbidRouteDeactivation).not.toHaveBeenCalled();
-        });
+            expect(dotRouter.forbidRouteDeactivation).toHaveBeenCalledTimes(1);
 
-        it('should process templateChange events and forbid navigation when uveStatus is not LOADING', () => {
+            saveSubject.complete(); // clean up
+        }));
+
+        it('should process templateChange events and forbid navigation when not saving', () => {
             templateBuilder.templateChange.emit();
 
-            expect(dotRouter.forbidRouteDeactivation).toHaveBeenCalled();
+            expect(dotRouter.forbidRouteDeactivation).toHaveBeenCalledTimes(1);
         });
 
-        it('should pass disabled=true to the template builder when uveStatus is LOADING', () => {
-            store.setUveStatus(UVE_STATUS.LOADING);
+        it('should pass disabled=true to the template builder while save is in-flight', fakeAsync(() => {
+            const saveSubject = new Subject();
+            (dotPageLayoutService.save as jest.Mock).mockReturnValue(saveSubject.asObservable());
+
+            templateBuilder.templateChange.emit();
+            tick(DEBOUNCE_TIME);
             spectator.detectChanges();
 
             expect(templateBuilder.disabled).toBe(true);
-        });
 
-        it('should pass disabled=false to the template builder when uveStatus is not LOADING', () => {
+            saveSubject.complete();
+        }));
+
+        it('should pass disabled=false to the template builder when not saving', () => {
             spectator.detectChanges();
 
             expect(templateBuilder.disabled).toBe(false);
         });
+
+        it('should unlock canvas (disabled=false) after save completes', fakeAsync(() => {
+            const saveSubject = new Subject();
+            (dotPageLayoutService.save as jest.Mock).mockReturnValue(saveSubject.asObservable());
+
+            templateBuilder.templateChange.emit();
+            tick(DEBOUNCE_TIME);
+
+            saveSubject.next(PAGE_RESPONSE);
+            saveSubject.complete();
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(false);
+        }));
+
+        it('should unlock canvas (disabled=false) on save error', fakeAsync(() => {
+            (dotPageLayoutService.save as jest.Mock).mockReturnValue(
+                throwError(() => new HttpErrorResponse({ status: 400 }))
+            );
+
+            templateBuilder.templateChange.emit();
+            tick(DEBOUNCE_TIME);
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(false);
+        }));
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -326,5 +326,24 @@ describe('EditEmaLayoutComponent', () => {
 
             expect(templateBuilder.disabled).toBe(false);
         }));
+
+        it('should keep canvas locked through the pageReload window and unlock only when reload completes', fakeAsync(() => {
+            // Prevent the real pageReload from running so we can control when it "finishes"
+            const pageReloadSpy = jest.spyOn(store, 'pageReload').mockImplementation(jest.fn());
+
+            templateBuilder.templateChange.emit();
+            tick(DEBOUNCE_TIME); // POST fires and succeeds synchronously (default mock)
+            spectator.detectChanges();
+
+            // POST returned 200 but reload hasn't signalled LOADED yet — canvas must stay locked
+            expect(templateBuilder.disabled).toBe(true);
+            expect(pageReloadSpy).toHaveBeenCalled();
+
+            // Simulate the reload completing
+            store.setUveStatus(UVE_STATUS.LOADED);
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(false);
+        }));
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -262,6 +262,9 @@ describe('EditEmaLayoutComponent', () => {
     describe('LOADING guard and disabled binding', () => {
         it('should drop templateChange events and not forbid navigation while uveStatus is LOADING', () => {
             store.setUveStatus(UVE_STATUS.LOADING);
+            // The mock is shared across all tests — clear accumulated calls from earlier tests
+            // before asserting this specific action had no effect.
+            (dotRouter.forbidRouteDeactivation as jest.Mock).mockClear();
 
             templateBuilder.templateChange.emit();
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -327,6 +327,23 @@ describe('EditEmaLayoutComponent', () => {
             expect(templateBuilder.disabled).toBe(false);
         }));
 
+        it('should unlock canvas when pageReload fails (uveStatus = ERROR) to avoid a permanent lock', fakeAsync(() => {
+            const pageReloadSpy = jest.spyOn(store, 'pageReload').mockImplementation(jest.fn());
+
+            templateBuilder.templateChange.emit();
+            tick(DEBOUNCE_TIME);
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(true);
+            expect(pageReloadSpy).toHaveBeenCalled();
+
+            // Simulate re-fetch failure
+            store.setUveStatus(UVE_STATUS.ERROR);
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(false);
+        }));
+
         it('should keep canvas locked through the pageReload window and unlock only when reload completes', fakeAsync(() => {
             // Prevent the real pageReload from running so we can control when it "finishes"
             const pageReloadSpy = jest.spyOn(store, 'pageReload').mockImplementation(jest.fn());

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -224,6 +224,17 @@ describe('EditEmaLayoutComponent', () => {
             expect(store.isClientReady()).toBe(false);
         }));
 
+        it('should NOT set uveStatus to LOADING before the debounce fires', fakeAsync(() => {
+            const setUveStatusSpy = jest.spyOn(store, 'setUveStatus');
+
+            templateBuilder.templateChange.emit();
+            tick(1000); // Less than DEBOUNCE_TIME (5000 ms)
+
+            expect(setUveStatusSpy).not.toHaveBeenCalledWith(UVE_STATUS.LOADING);
+
+            tick(4000); // flush remaining timer to avoid pending-timer warning
+        }));
+
         it('should save right away if we request page leave before the 5 secs', () => {
             const saveTemplate = jest.spyOn(component, 'saveTemplate');
 
@@ -245,6 +256,35 @@ describe('EditEmaLayoutComponent', () => {
                 summary: 'Success',
                 detail: 'dot.common.message.saved'
             });
+        });
+    });
+
+    describe('LOADING guard and disabled binding', () => {
+        it('should drop templateChange events and not forbid navigation while uveStatus is LOADING', () => {
+            store.setUveStatus(UVE_STATUS.LOADING);
+
+            templateBuilder.templateChange.emit();
+
+            expect(dotRouter.forbidRouteDeactivation).not.toHaveBeenCalled();
+        });
+
+        it('should process templateChange events and forbid navigation when uveStatus is not LOADING', () => {
+            templateBuilder.templateChange.emit();
+
+            expect(dotRouter.forbidRouteDeactivation).toHaveBeenCalled();
+        });
+
+        it('should pass disabled=true to the template builder when uveStatus is LOADING', () => {
+            store.setUveStatus(UVE_STATUS.LOADING);
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(true);
+        });
+
+        it('should pass disabled=false to the template builder when uveStatus is not LOADING', () => {
+            spectator.detectChanges();
+
+            expect(templateBuilder.disabled).toBe(false);
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -167,6 +167,11 @@ describe('EditEmaLayoutComponent', () => {
         dotPageLayoutService = spectator.inject(DotPageLayoutService);
         messageService = spectator.inject(MessageService);
 
+        // Reset save mock to default — jest.clearAllMocks() does not reset mockReturnValue/
+        // mockImplementation overrides, so tests that call mockReturnValue(throwError(...))
+        // would contaminate subsequent tests that rely on the default of(PAGE_RESPONSE) behavior.
+        (dotPageLayoutService.save as jest.Mock).mockImplementation(() => of(PAGE_RESPONSE));
+
         store.pageLoad({
             clientHost: 'http://localhost:3000',
             language_id: '1',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -59,8 +59,21 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
     // Component-local save-in-flight flag. Deliberately separate from uveStore.uveStatus()
     // so that unrelated global LOADING events (lock toggle, page-api re-fetch) cannot
     // unlock the canvas mid-POST or throw a spurious spinner over the layout builder.
+    //
+    // Lifecycle: set true when the POST fires → stays true through pageReload() re-hydration
+    // → cleared by #handleReloadComplete when uveStatus returns to LOADED.
+    // On HTTP error it is cleared immediately (no reload happens on failure).
     readonly #layoutSaveInFlight = signal(false);
     protected readonly $isSaving = this.#layoutSaveInFlight.asReadonly();
+
+    // Keep the canvas locked through the full save + reload cycle.
+    // pageReload() transitions uveStatus LOADING → LOADED when the re-fetch is done;
+    // that is the earliest safe point to re-enable editing.
+    readonly #handleReloadComplete = effect(() => {
+        if (this.#layoutSaveInFlight() && this.uveStore.uveStatus() === UVE_STATUS.LOADED) {
+            this.#layoutSaveInFlight.set(false);
+        }
+    });
 
     readonly $handleCanEditLayout = effect(() => {
         // The only way to enter here directly is by the URL, so we need to redirect the user to the correct page
@@ -192,7 +205,9 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
      * @memberof EditEmaLayoutComponent
      */
     private handleSuccessSaveTemplate(): void {
-        this.#layoutSaveInFlight.set(false);
+        // Do NOT clear #layoutSaveInFlight here — the canvas must stay locked
+        // through the pageReload() re-hydration window. The #handleReloadComplete
+        // effect clears it once uveStatus signals LOADED.
         this.messageService.add({
             severity: 'success',
             summary: 'Success',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -6,6 +6,7 @@ import {
     Component,
     OnDestroy,
     OnInit,
+    computed,
     effect,
     inject
 } from '@angular/core';
@@ -19,8 +20,7 @@ import {
     finalize,
     switchMap,
     take,
-    takeUntil,
-    tap
+    takeUntil
 } from 'rxjs/operators';
 
 import { DotMessageService, DotPageLayoutService, DotRouterService } from '@dotcms/data-access';
@@ -53,6 +53,10 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
     protected readonly uveStore = inject(UVEStore);
 
     protected readonly $layoutProperties = this.uveStore.$layoutProps;
+
+    protected readonly $isSaving = computed(
+        () => this.uveStore.uveStatus() === UVE_STATUS.LOADING
+    );
 
     readonly $handleCanEditLayout = effect(() => {
         // The only way to enter here directly is by the URL, so we need to redirect the user to the correct page
@@ -87,6 +91,13 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
      * @memberof EditEmaLayoutComponent
      */
     nextTemplateUpdate(template: DotTemplateDesigner) {
+        // Drop edits that complete mid-flight: in-progress drags or open dropdowns
+        // can still emit templateChange after the canvas is frozen. Discarding them
+        // prevents corrupting the payload of the in-flight save.
+        if (this.uveStore.uveStatus() === UVE_STATUS.LOADING) {
+            return;
+        }
+
         this.dotRouterService.forbidRouteDeactivation();
         this.updateTemplate$.next(template);
         this.lastTemplate = template;
@@ -134,10 +145,11 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
             .pipe(
                 // debounceTime should be before takeUntil to avoid calling the observable after unsubscribe.
                 // More information: https://stackoverflow.com/questions/58974320/how-is-it-possible-to-stop-a-debounced-rxjs-observable
-                tap(() => this.uveStore.setUveStatus(UVE_STATUS.LOADING)), // Prevent the user to access page properties
                 debounceTime(DEBOUNCE_TIME),
                 takeUntil(this.destroy$),
                 switchMap((layout: DotTemplateDesigner) => {
+                    // Lock the canvas only when the POST is actually sent, not on every edit.
+                    this.uveStore.setUveStatus(UVE_STATUS.LOADING);
                     this.messageService.add({
                         severity: 'info',
                         summary: 'Info',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -54,9 +54,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
 
     protected readonly $layoutProperties = this.uveStore.$layoutProps;
 
-    protected readonly $isSaving = computed(
-        () => this.uveStore.uveStatus() === UVE_STATUS.LOADING
-    );
+    protected readonly $isSaving = computed(() => this.uveStore.uveStatus() === UVE_STATUS.LOADING);
 
     readonly $handleCanEditLayout = effect(() => {
         // The only way to enter here directly is by the URL, so we need to redirect the user to the correct page

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { EMPTY, Subject } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import {
@@ -6,21 +6,23 @@ import {
     Component,
     OnDestroy,
     OnInit,
-    computed,
     effect,
-    inject
+    inject,
+    signal
 } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { MessageService } from 'primeng/api';
 
 import {
+    catchError,
     debounceTime,
     distinctUntilChanged,
     finalize,
     switchMap,
     take,
-    takeUntil
+    takeUntil,
+    tap
 } from 'rxjs/operators';
 
 import { DotMessageService, DotPageLayoutService, DotRouterService } from '@dotcms/data-access';
@@ -54,7 +56,11 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
 
     protected readonly $layoutProperties = this.uveStore.$layoutProps;
 
-    protected readonly $isSaving = computed(() => this.uveStore.uveStatus() === UVE_STATUS.LOADING);
+    // Component-local save-in-flight flag. Deliberately separate from uveStore.uveStatus()
+    // so that unrelated global LOADING events (lock toggle, page-api re-fetch) cannot
+    // unlock the canvas mid-POST or throw a spurious spinner over the layout builder.
+    readonly #layoutSaveInFlight = signal(false);
+    protected readonly $isSaving = this.#layoutSaveInFlight.asReadonly();
 
     readonly $handleCanEditLayout = effect(() => {
         // The only way to enter here directly is by the URL, so we need to redirect the user to the correct page
@@ -92,7 +98,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
         // Drop edits that complete mid-flight: in-progress drags or open dropdowns
         // can still emit templateChange after the canvas is frozen. Discarding them
         // prevents corrupting the payload of the in-flight save.
-        if (this.uveStore.uveStatus() === UVE_STATUS.LOADING) {
+        if (this.#layoutSaveInFlight()) {
             return;
         }
 
@@ -141,13 +147,18 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
         // - https://blog.bitsrc.io/3-ways-to-debounce-http-requests-in-angular-c407eb165ada
         this.updateTemplate$
             .pipe(
+                tap(() => {
+                    // Gate the Page Properties nav item immediately on any edit so users
+                    // cannot navigate to page settings while layout changes are pending.
+                    this.uveStore.setUveStatus(UVE_STATUS.LOADING);
+                }),
                 // debounceTime should be before takeUntil to avoid calling the observable after unsubscribe.
                 // More information: https://stackoverflow.com/questions/58974320/how-is-it-possible-to-stop-a-debounced-rxjs-observable
                 debounceTime(DEBOUNCE_TIME),
                 takeUntil(this.destroy$),
                 switchMap((layout: DotTemplateDesigner) => {
-                    // Lock the canvas only when the POST is actually sent, not on every edit.
-                    this.uveStore.setUveStatus(UVE_STATUS.LOADING);
+                    // Lock the canvas when the POST is actually sent, not on every edit.
+                    this.#layoutSaveInFlight.set(true);
                     this.messageService.add({
                         severity: 'info',
                         summary: 'Info',
@@ -160,13 +171,17 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
                             ...layout,
                             title: null
                         })
-                        .pipe(finalize(() => this.dotRouterService.allowRouteDeactivation()));
+                        .pipe(
+                            catchError((err: HttpErrorResponse) => {
+                                this.handleErrorSaveTemplate(err);
+
+                                return EMPTY;
+                            }),
+                            finalize(() => this.dotRouterService.allowRouteDeactivation())
+                        );
                 })
             )
-            .subscribe(
-                () => this.handleSuccessSaveTemplate(),
-                (err: HttpErrorResponse) => this.handleErrorSaveTemplate(err)
-            );
+            .subscribe(() => this.handleSuccessSaveTemplate());
     }
 
     /**
@@ -177,6 +192,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
      * @memberof EditEmaLayoutComponent
      */
     private handleSuccessSaveTemplate(): void {
+        this.#layoutSaveInFlight.set(false);
         this.messageService.add({
             severity: 'success',
             summary: 'Success',
@@ -194,6 +210,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
      * @memberof EditEmaLayoutComponent
      */
     private handleErrorSaveTemplate(_: HttpErrorResponse) {
+        this.#layoutSaveInFlight.set(false);
         this.messageService.add({
             severity: 'error',
             summary: 'Error',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -67,10 +67,21 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
     protected readonly $isSaving = this.#layoutSaveInFlight.asReadonly();
 
     // Keep the canvas locked through the full save + reload cycle.
-    // pageReload() transitions uveStatus LOADING → LOADED when the re-fetch is done;
-    // that is the earliest safe point to re-enable editing.
+    // pageReload() transitions uveStatus LOADING → LOADED on success, or → ERROR on a
+    // re-fetch failure (withPageApi.ts:369). Both signal the reload is finished — unlock
+    // on either so a failed reload never leaves the canvas permanently locked.
+    //
+    // Known residual: any cross-feature store writer that lands LOADED (e.g. withWorkflow
+    // completing a lock/unlock) during the in-flight window would also clear the flag
+    // early. This is a narrow race (< 2 s window, requires a concurrent banner-button
+    // click) and a proper fix requires pageReload() to expose a completion observable.
+    // The risk is accepted and documented here to prevent silent "fixes" that would
+    // inadvertently widen the original data-loss window.
     readonly #handleReloadComplete = effect(() => {
-        if (this.#layoutSaveInFlight() && this.uveStore.uveStatus() === UVE_STATUS.LOADED) {
+        const status = this.uveStore.uveStatus();
+        const done = status === UVE_STATUS.LOADED || status === UVE_STATUS.ERROR;
+
+        if (this.#layoutSaveInFlight() && done) {
             this.#layoutSaveInFlight.set(false);
         }
     });
@@ -111,6 +122,11 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
         // Drop edits that complete mid-flight: in-progress drags or open dropdowns
         // can still emit templateChange after the canvas is frozen. Discarding them
         // prevents corrupting the payload of the in-flight save.
+        //
+        // Intentional: lastTemplate is NOT updated here. Dropped edits are changes the
+        // server never saw, so the page-leave force-save (initForceSaveOnLeave) correctly
+        // persists the last *accepted* template — not a partial in-flight state that
+        // updateOldRows would have overwritten anyway.
         if (this.#layoutSaveInFlight()) {
             return;
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.ts
@@ -77,7 +77,7 @@ export class EditEmaLayoutComponent implements OnInit, OnDestroy {
     // click) and a proper fix requires pageReload() to expose a completion observable.
     // The risk is accepted and documented here to prevent silent "fixes" that would
     // inadvertently widen the original data-loss window.
-    readonly #handleReloadComplete = effect(() => {
+    readonly $handleReloadComplete = effect(() => {
         const status = this.uveStore.uveStatus();
         const done = status === UVE_STATUS.LOADED || status === UVE_STATUS.ERROR;
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -121,7 +121,7 @@
     <div
         role="status"
         aria-busy="true"
-        class="absolute inset-0 z-[9999] flex cursor-not-allowed items-center justify-center bg-white/50 backdrop-blur-[2px]"
+        class="absolute inset-0 z-9999 flex cursor-not-allowed items-center justify-center bg-white/50 backdrop-blur-[2px]"
         data-testId="template-builder-disabled-overlay">
         <p-progress-spinner
             [style]="{ width: '3rem', height: '3rem' }"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -126,6 +126,6 @@
         <p-progress-spinner
             [style]="{ width: '3rem', height: '3rem' }"
             strokeWidth="4"
-            aria-label="Saving layout" />
+            [attr.aria-label]="'dot.template.builder.saving.layout' | dm" />
     </div>
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -116,3 +116,13 @@
         }
     </div>
 }
+@if (disabled) {
+    <div
+        class="absolute inset-0 z-50 flex items-center justify-center bg-white/50 backdrop-blur-[2px] cursor-not-allowed"
+        data-testId="template-builder-disabled-overlay">
+        <p-progress-spinner
+            [style]="{ width: '3rem', height: '3rem' }"
+            strokeWidth="4"
+            aria-label="Saving layout" />
+    </div>
+}

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -1,5 +1,5 @@
 @if (vm$ | async; as vm) {
-    <p-toolbar>
+    <p-toolbar [attr.inert]="disabled ? '' : null">
         <ng-template #start>
             <ng-content select="[toolbar-left]" />
         </ng-template>
@@ -33,6 +33,7 @@
     <div
         (mousemove)="fixGridStackNodeOptions()"
         [ngStyle]="customStyles"
+        [attr.inert]="disabled ? '' : null"
         class="h-full overflow-x-hidden overflow-y-auto p-6 transition-opacity duration-300 ease-in-out"
         #templateContainerRef
         data-testId="template-builder-main">
@@ -118,7 +119,9 @@
 }
 @if (disabled) {
     <div
-        class="absolute inset-0 z-50 flex cursor-not-allowed items-center justify-center bg-white/50 backdrop-blur-[2px]"
+        role="status"
+        aria-busy="true"
+        class="absolute inset-0 z-[9999] flex cursor-not-allowed items-center justify-center bg-white/50 backdrop-blur-[2px]"
         data-testId="template-builder-disabled-overlay">
         <p-progress-spinner
             [style]="{ width: '3rem', height: '3rem' }"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.html
@@ -33,7 +33,7 @@
     <div
         (mousemove)="fixGridStackNodeOptions()"
         [ngStyle]="customStyles"
-        class="overflow-y-auto overflow-x-hidden transition-opacity duration-300 ease-in-out h-full p-6"
+        class="h-full overflow-x-hidden overflow-y-auto p-6 transition-opacity duration-300 ease-in-out"
         #templateContainerRef
         data-testId="template-builder-main">
         @if (vm.layoutProperties.header) {
@@ -118,7 +118,7 @@
 }
 @if (disabled) {
     <div
-        class="absolute inset-0 z-50 flex items-center justify-center bg-white/50 backdrop-blur-[2px] cursor-not-allowed"
+        class="absolute inset-0 z-50 flex cursor-not-allowed items-center justify-center bg-white/50 backdrop-blur-[2px]"
         data-testId="template-builder-disabled-overlay">
         <p-progress-spinner
             [style]="{ width: '3rem', height: '3rem' }"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -610,7 +610,7 @@ describe('TemplateBuilderComponent', () => {
         let store: DotTemplateBuilderStore;
 
         beforeEach(() => {
-            store = spectator.inject(DotTemplateBuilderStore);
+            store = spectator.inject(DotTemplateBuilderStore, true); // true = component injector (DotTemplateBuilderStore is component-scoped)
             handlers = {};
             mockSubGrid = {
                 removeWidget: jest.fn(),

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -526,7 +526,9 @@ describe('TemplateBuilderComponent', () => {
 
             it('should reset suppressStoreUpdates to false after cancelling an in-progress drag', () => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (spectator.component as any).preDragState = [{ id: 'row-1', x: 0, y: 0, w: 12, h: 1 }];
+                (spectator.component as any).preDragState = [
+                    { id: 'row-1', x: 0, y: 0, w: 12, h: 1 }
+                ];
                 spectator.component.draggingElement = document.createElement('div');
 
                 spectator.setInput('disabled', true);

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -461,6 +461,8 @@ describe('TemplateBuilderComponent', () => {
                 mockGrid = {
                     disable: jest.fn(),
                     enable: jest.fn(),
+                    load: jest.fn(),
+                    save: jest.fn().mockReturnValue([{ id: 'row-1', x: 0, y: 0, w: 12, h: 1 }]),
                     el: { querySelectorAll: jest.fn().mockReturnValue([]) }
                 };
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -472,12 +474,91 @@ describe('TemplateBuilderComponent', () => {
                 expect(mockGrid.disable).toHaveBeenCalled();
             });
 
-            it('should dispatch a document Escape keydown event when disabled becomes true', () => {
+            it('should dispatch a synthetic mouseup to terminate an in-progress drag before locking the grid', () => {
                 const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+                spectator.component.draggingElement = document.createElement('div');
+
                 spectator.setInput('disabled', true);
+
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({ type: 'mouseup' })
+                );
+                expect(mockGrid.disable).toHaveBeenCalled();
+
+                dispatchSpy.mockRestore();
+            });
+
+            it('should restore the pre-drag layout with grid.load() to undo the committed drag position', () => {
+                const savedState = [{ id: 'row-1', x: 0, y: 0, w: 12, h: 1 }];
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (spectator.component as any).preDragState = savedState;
+                spectator.component.draggingElement = document.createElement('div');
+
+                spectator.setInput('disabled', true);
+
+                expect(mockGrid.load).toHaveBeenCalledWith(savedState);
+            });
+
+            it('should NOT call grid.load() when there is no pre-drag state (external drag-in)', () => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (spectator.component as any).preDragState = null;
+                spectator.component.draggingElement = document.createElement('div');
+
+                spectator.setInput('disabled', true);
+
+                expect(mockGrid.load).not.toHaveBeenCalled();
+            });
+
+            it('should call load() on preDragGrid (not main grid) when cancelling a column drag', () => {
+                const savedState = [{ id: 'col-1', x: 0, y: 0, w: 6, h: 1 }];
+                const subGridLoad = jest.fn();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (spectator.component as any).preDragState = savedState;
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (spectator.component as any).preDragGrid = { load: subGridLoad };
+                spectator.component.draggingElement = document.createElement('div');
+
+                spectator.setInput('disabled', true);
+
+                expect(subGridLoad).toHaveBeenCalledWith(savedState);
+                expect(mockGrid.load).not.toHaveBeenCalled();
+            });
+
+            it('should reset suppressStoreUpdates to false after cancelling an in-progress drag', () => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (spectator.component as any).preDragState = [{ id: 'row-1', x: 0, y: 0, w: 12, h: 1 }];
+                spectator.component.draggingElement = document.createElement('div');
+
+                spectator.setInput('disabled', true);
+
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect((spectator.component as any).suppressStoreUpdates).toBe(false);
+            });
+
+            it('should NOT dispatch mouseup when disabled becomes true with no active drag', () => {
+                const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+                spectator.component.draggingElement = null;
+
+                spectator.setInput('disabled', true);
+
+                const mouseupCalls = dispatchSpy.mock.calls.filter(
+                    ([event]) => (event as Event).type === 'mouseup'
+                );
+                expect(mouseupCalls).toHaveLength(0);
+                expect(mockGrid.disable).toHaveBeenCalled();
+
+                dispatchSpy.mockRestore();
+            });
+
+            it('should dispatch Escape to close open PrimeNG panels when disabled becomes true', () => {
+                const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+
+                spectator.setInput('disabled', true);
+
                 expect(dispatchSpy).toHaveBeenCalledWith(
                     expect.objectContaining({ type: 'keydown', key: 'Escape' })
                 );
+
                 dispatchSpy.mockRestore();
             });
 
@@ -515,6 +596,65 @@ describe('TemplateBuilderComponent', () => {
                 spectator.component.grid = undefined as any;
                 expect(() => spectator.setInput('disabled', true)).not.toThrow();
             });
+        });
+    });
+
+    describe('setSubGridEvent — dropped handler', () => {
+        let handlers: Record<string, (...args: unknown[]) => void>;
+        let mockSubGrid: {
+            on: jest.Mock;
+            removeWidget: jest.Mock;
+        };
+        let store: DotTemplateBuilderStore;
+
+        beforeEach(() => {
+            store = spectator.inject(DotTemplateBuilderStore);
+            handlers = {};
+            mockSubGrid = {
+                removeWidget: jest.fn(),
+                on: jest.fn().mockImplementation(function (this: unknown, event, cb) {
+                    handlers[event as string] = cb;
+
+                    return this; // fluent chain
+                })
+            };
+
+            spectator.component.setSubGridEvent(mockSubGrid as never);
+        });
+
+        it('should call store.subGridOnDropped and onDragStop when not suppressed', () => {
+            const subGridOnDroppedSpy = jest.spyOn(store, 'subGridOnDropped');
+            const onDragStopSpy = jest.spyOn(spectator.component, 'onDragStop');
+            const el = document.createElement('div');
+            const newNode = { el, grid: mockSubGrid };
+
+            handlers['dropped']({}, {}, newNode);
+
+            expect(subGridOnDroppedSpy).toHaveBeenCalled();
+            expect(onDragStopSpy).toHaveBeenCalled();
+            expect(mockSubGrid.removeWidget).not.toHaveBeenCalled();
+        });
+
+        it('should removeWidget and skip store.subGridOnDropped when suppressStoreUpdates is true', () => {
+            const subGridOnDroppedSpy = jest.spyOn(store, 'subGridOnDropped');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (spectator.component as any).suppressStoreUpdates = true;
+
+            const el = document.createElement('div');
+            const newNode = { el, grid: mockSubGrid };
+
+            handlers['dropped']({}, {}, newNode);
+
+            expect(mockSubGrid.removeWidget).toHaveBeenCalledWith(el, true, false);
+            expect(subGridOnDroppedSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not throw when newNode.el is null during cancel window', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (spectator.component as any).suppressStoreUpdates = true;
+            const newNode = { el: null, grid: mockSubGrid };
+
+            expect(() => handlers['dropped']({}, {}, newNode)).not.toThrow();
         });
     });
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.spec.ts
@@ -431,6 +431,93 @@ describe('TemplateBuilderComponent', () => {
             });
     });
 
+    describe('disabled input', () => {
+        it('should not render the disabled overlay by default', () => {
+            expect(spectator.query(byTestId('template-builder-disabled-overlay'))).toBeFalsy();
+        });
+
+        it('should render the disabled overlay when disabled is set to true', () => {
+            spectator.setInput('disabled', true);
+            spectator.detectChanges();
+            expect(spectator.query(byTestId('template-builder-disabled-overlay'))).toBeTruthy();
+        });
+
+        it('should hide the disabled overlay when disabled is set back to false', () => {
+            spectator.setInput('disabled', true);
+            spectator.detectChanges();
+            spectator.setInput('disabled', false);
+            spectator.detectChanges();
+            expect(spectator.query(byTestId('template-builder-disabled-overlay'))).toBeFalsy();
+        });
+
+        describe('grid interactions', () => {
+            let mockGrid: {
+                disable: jest.Mock;
+                enable: jest.Mock;
+                el: { querySelectorAll: jest.Mock };
+            };
+
+            beforeEach(() => {
+                mockGrid = {
+                    disable: jest.fn(),
+                    enable: jest.fn(),
+                    el: { querySelectorAll: jest.fn().mockReturnValue([]) }
+                };
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                spectator.component.grid = mockGrid as any;
+            });
+
+            it('should call grid.disable() when disabled becomes true', () => {
+                spectator.setInput('disabled', true);
+                expect(mockGrid.disable).toHaveBeenCalled();
+            });
+
+            it('should dispatch a document Escape keydown event when disabled becomes true', () => {
+                const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+                spectator.setInput('disabled', true);
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({ type: 'keydown', key: 'Escape' })
+                );
+                dispatchSpy.mockRestore();
+            });
+
+            it('should call grid.enable() when disabled becomes false', () => {
+                spectator.setInput('disabled', true);
+                spectator.setInput('disabled', false);
+                expect(mockGrid.enable).toHaveBeenCalled();
+            });
+
+            it('should disable all subgrids when disabled becomes true', () => {
+                const subGridDisable = jest.fn();
+                const subGridEnable = jest.fn();
+                mockGrid.el.querySelectorAll.mockReturnValue([
+                    { gridstack: { disable: subGridDisable, enable: subGridEnable } }
+                ]);
+
+                spectator.setInput('disabled', true);
+                expect(subGridDisable).toHaveBeenCalled();
+            });
+
+            it('should enable all subgrids when disabled becomes false', () => {
+                const subGridDisable = jest.fn();
+                const subGridEnable = jest.fn();
+                mockGrid.el.querySelectorAll.mockReturnValue([
+                    { gridstack: { disable: subGridDisable, enable: subGridEnable } }
+                ]);
+
+                spectator.setInput('disabled', true);
+                spectator.setInput('disabled', false);
+                expect(subGridEnable).toHaveBeenCalled();
+            });
+
+            it('should not call grid methods if grid is not yet initialized', () => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                spectator.component.grid = undefined as any;
+                expect(() => spectator.setInput('disabled', true)).not.toThrow();
+            });
+        });
+    });
+
     describe('Scroll on Drag', () => {
         beforeEach(() => {
             spectator.component.templateContainerRef = {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -337,10 +337,18 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
             }
 
             // Close any PrimeNG overlays (container pickers, dropdowns) that were opened
-            // before the canvas locked. These panels are appended to <body> and therefore
+            // before the canvas locked. These panels are appended to <body> and are therefore
             // outside the [inert] subtree and above the disabled overlay in z-order —
             // dispatching Escape is the standard PrimeNG mechanism to close them.
             // Note: GridStack 8.4.0 does not honour Escape for drag cancellation.
+            //
+            // Known limitation: PrimeNG DynamicDialog also responds to document Escape
+            // (primeng-dynamicdialog.mjs:740-747). A user who opens the "Add style classes"
+            // dialog during the 5-second debounce window will have it dismissed here.
+            // The practical impact is low: any style-class change inside the dialog resets
+            // the debounce, so the dialog is only at risk if the user sits idle in it for
+            // the full 5 s without confirming. Fixing this precisely would require checking
+            // for an open DynamicDialog before dispatching, which is not worth the complexity.
             document.dispatchEvent(
                 new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
             );

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -31,6 +31,7 @@ import {
 
 import { DividerModule } from 'primeng/divider';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { ToolbarModule } from 'primeng/toolbar';
 
 import { filter, take, map, takeUntil, skip } from 'rxjs/operators';
@@ -89,6 +90,7 @@ import {
         DynamicDialogModule,
         ToolbarModule,
         DividerModule,
+        ProgressSpinnerModule,
         AddWidgetComponent,
         TemplateBuilderActionsComponent,
         TemplateBuilderSectionComponent,
@@ -112,6 +114,9 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
 
     @Input()
     containerMap!: DotContainerMap;
+
+    @Input()
+    disabled = false;
 
     @Output()
     templateChange: EventEmitter<DotTemplateDesigner> = new EventEmitter<DotTemplateDesigner>();
@@ -271,6 +276,42 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
                 isAnonymousTemplate: currentTemplate?.anonymous || this.template.anonymous // We createa a custom template for the page
             });
         }
+
+        if (changes.disabled !== undefined && this.grid) {
+            this.applyGridDisabled(!!changes.disabled.currentValue);
+        }
+    }
+
+    /**
+     * @description Enables or disables drag, resize, and external drop on the main grid
+     * and all of its subgrids. Called synchronously from ngOnChanges so GridStack
+     * blocks (or restores) interactions in the same tick the input changes — before
+     * any Angular render cycle.
+     *
+     * @param {boolean} disabled
+     * @memberof TemplateBuilderComponent
+     */
+    private applyGridDisabled(disabled: boolean): void {
+        if (disabled) {
+            this.grid.disable();
+            // Cancel any in-progress drag (internal row move or external toolbar widget drag-in).
+            // GridStack's DDDraggable registers a document keydown listener and calls cancel()
+            // on Escape, removing the drag clone from the DOM so the overlay becomes visible.
+            // PrimeNG dropdowns also close on Escape, covering the open-dropdown edge case.
+            document.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+            );
+        } else {
+            this.grid.enable();
+        }
+
+        const subGridEls = this.grid.el.querySelectorAll(
+            '.grid-stack'
+        ) as NodeListOf<GridHTMLElement>;
+
+        subGridEls.forEach((el) => {
+            el.gridstack?.[disabled ? 'disable' : 'enable']();
+        });
     }
 
     /**

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -160,6 +160,21 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
     public draggingElement: HTMLElement | null;
     public scrollDirection: SCROLL_DIRECTION = SCROLL_DIRECTION.NONE;
 
+    // Full grid layout captured at drag-start. If the canvas is locked mid-drag,
+    // we dispatch mouseup (which commits the drag at the wrong cursor position) and
+    // immediately restore this snapshot via grid.load() — equivalent to dropping the
+    // row/column in its original position. Cleared on every normal drag completion.
+    private preDragState: GridStackWidget[] | null = null;
+
+    // The specific GridStack instance (main grid or a subgrid) that owns the dragged
+    // widget. Needed so column drags restore the correct subgrid, not just the top-level grid.
+    private preDragGrid: GridStack | null = null;
+
+    // When true, store write calls inside GridStack event handlers are skipped.
+    // Set for the synchronous window between mouseup dispatch and grid.load() so that
+    // the forced drag-commit and the subsequent layout restore do not corrupt the store.
+    private suppressStoreUpdates = false;
+
     grid!: GridStack;
 
     addBoxIsDragging = false;
@@ -293,14 +308,44 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
      */
     private applyGridDisabled(disabled: boolean): void {
         if (disabled) {
-            this.grid.disable();
-            // Cancel any in-progress drag (internal row move or external toolbar widget drag-in).
-            // GridStack's DDDraggable registers a document keydown listener and calls cancel()
-            // on Escape, removing the drag clone from the DOM so the overlay becomes visible.
-            // PrimeNG dropdowns also close on Escape, covering the open-dropdown edge case.
+            if (this.draggingElement) {
+                // Snapshot the references before the cancel window clears them.
+                const preDragState = this.preDragState;
+                const preDragGrid = this.preDragGrid ?? this.grid;
+                this.preDragState = null;
+                this.preDragGrid = null;
+
+                // Suppress store writes for the entire synchronous cancel window:
+                // mouseup fires change/dropped synchronously (GridStack commits the drag),
+                // and grid.load() fires change again (to restore positions).
+                // Both sets of events must be dropped to keep the store consistent.
+                this.suppressStoreUpdates = true;
+
+                // Terminate the in-progress drag. DDDraggable's document mouseup listener
+                // runs synchronously: _mouseUp → dragstop → onDragStop() → change → moveRow.
+                document.dispatchEvent(
+                    new MouseEvent('mouseup', { bubbles: true, cancelable: true })
+                );
+
+                // Restore the layout to the state it was in when the drag started.
+                // For row drags preDragGrid is the main grid; for column drags it is the subgrid.
+                if (preDragState) {
+                    preDragGrid.load(preDragState);
+                }
+
+                this.suppressStoreUpdates = false;
+            }
+
+            // Close any PrimeNG overlays (container pickers, dropdowns) that were opened
+            // before the canvas locked. These panels are appended to <body> and therefore
+            // outside the [inert] subtree and above the disabled overlay in z-order —
+            // dispatching Escape is the standard PrimeNG mechanism to close them.
+            // Note: GridStack 8.4.0 does not honour Escape for drag cancellation.
             document.dispatchEvent(
                 new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
             );
+
+            this.grid.disable();
         } else {
             this.grid.enable();
         }
@@ -328,7 +373,9 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
         }, 350);
 
         this.grid = GridStack.init(gridOptions).on('change', (_: Event, nodes: GridStackNode[]) => {
-            this.store.moveRow(nodes as DotGridStackWidget[]);
+            if (!this.suppressStoreUpdates) {
+                this.store.moveRow(nodes as DotGridStackWidget[]);
+            }
         });
 
         GridStack.setupDragIn('dotcms-add-widget', {
@@ -343,16 +390,22 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
 
         this.grid
             .on('dropped', (_: Event, previousNode: GridStackNode, newNode: GridStackNode) => {
+                // External drag-ins (toolbar → grid) always need removeWidget so the DOM is
+                // cleaned up — even during the cancel window. Only store.addRow is suppressed.
                 if (!newNode.el || previousNode) return;
 
                 newNode.grid?.removeWidget(newNode.el, true, false);
 
-                this.store.addRow({
-                    y: newNode.y
-                });
+                if (!this.suppressStoreUpdates) {
+                    this.store.addRow({
+                        y: newNode.y
+                    });
+                }
             })
             .on('dragstart', ({ target }) => {
                 this.draggingElement = target as HTMLElement;
+                this.preDragState = this.grid.save(false) as GridStackWidget[];
+                this.preDragGrid = this.grid;
             })
             .on('dragstop', () => this.onDragStop());
 
@@ -549,11 +602,26 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
     setSubGridEvent(subGrid: GridStack): void {
         subGrid
             .on('dropped', (_: Event, oldNode: GridStackNode, newNode: GridStackNode) => {
+                if (this.suppressStoreUpdates) {
+                    // Cancel window: GridStack committed the drop (external box from toolbar,
+                    // or cross-row move) but the store must not be updated. Remove the
+                    // placeholder/widget GridStack added so no ghost box appears in the layout.
+                    if (newNode.el) {
+                        newNode.grid?.removeWidget(newNode.el, true, false);
+                    }
+
+                    this.onDragStop();
+
+                    return;
+                }
+
                 this.store.subGridOnDropped(oldNode, newNode);
                 this.onDragStop();
             })
             .on('change', (_: Event, nodes: GridStackNode[]) => {
-                this.store.updateColumnGridStackData(nodes as DotGridStackWidget[]);
+                if (!this.suppressStoreUpdates) {
+                    this.store.updateColumnGridStackData(nodes as DotGridStackWidget[]);
+                }
             })
             .on('resizestart', (_: Event, el: GridItemHTMLElement) => {
                 this.store.setResizingRowID(String(el.gridstackNode.grid.parentGridItem.id));
@@ -563,6 +631,10 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
             })
             .on('dragstart', ({ target }) => {
                 this.draggingElement = target as HTMLElement;
+                // Save the subgrid's own column layout — not the main grid — so that
+                // a column drag cancelled mid-flight restores only the affected row.
+                this.preDragState = subGrid.save(false) as GridStackWidget[];
+                this.preDragGrid = subGrid;
             })
             .on('dragstop', () => this.onDragStop());
     }
@@ -574,6 +646,8 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
      */
     onDragStop() {
         this.draggingElement = null;
+        this.preDragState = null;
+        this.preDragGrid = null;
         this.scrollDirection = SCROLL_DIRECTION.NONE;
     }
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -350,6 +350,10 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
             this.grid.enable();
         }
 
+        // GridStack's built-in disable(recurse=true) only walks node.subGrid — it does not
+        // reach subgrids that were created via GridStack.addGrid() (as this component does),
+        // because addGrid() populates the DOM but not the engine's subGrid references.
+        // This manual querySelectorAll loop closes that gap.
         const subGridEls = this.grid.el.querySelectorAll(
             '.grid-stack'
         ) as NodeListOf<GridHTMLElement>;
@@ -470,6 +474,12 @@ export class TemplateBuilderComponent implements OnDestroy, OnChanges, OnInit {
                     this.setAddBoxIsDragging(false);
                 });
         });
+
+        // Apply the current disabled state to the freshly created grid. Without this,
+        // if [disabled]=true arrives via ngOnChanges before setUpGridStack() runs
+        // (the grid init is deferred via requestAnimationFrame), the canvas boots enabled
+        // behind an active overlay.
+        this.applyGridDisabled(this.disabled);
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
## Summary

Fixes dotCMS/core#36197 — UVE Layout tab data loss caused by the GridStack canvas never being locked while a layout save is in flight.

### Root cause

Every layout change emits `templateChange` → `updateTemplate$` → 5-second debounce → `POST /api/v1/page/{id}/layout`. The canvas remained fully interactive during the entire debounce window, the in-flight POST, and the `pageReload()` + `updateOldRows()` re-hydration cycle. Any edit made in that window was silently discarded when the server response overwrote local state. Because the backend performs a destructive diff (deletes any container absent from the incoming payload), mid-flight edits could permanently remove content.

---

## Changes

### `TemplateBuilderComponent` (`template-builder.component.ts` / `.html`)

- **`@Input() disabled = false`** — new input that locks the canvas.
- **`applyGridDisabled(disabled)`** — called synchronously from `ngOnChanges` (before any render cycle):
  - `grid.disable()` / `grid.enable()` on the main grid and every subgrid — blocks drag, resize, and external drop at the GridStack event level.
  - Dispatches `keydown Escape` on `document` — closes any open PrimeNG dropdowns (container pickers, etc.) that are appended to `<body>` outside the `[inert]` subtree.
  - **Drag cancellation** — if a drag is in progress when the canvas locks, dispatches a synthetic `document mouseup` to terminate it. `suppressStoreUpdates` is set for the synchronous cancel window so that GridStack's forced commit events (and the subsequent `grid.load()` restore) do not write to the store. Placeholder widgets committed by the cancelled drag are removed via `removeWidget` before the lock completes.
  - **`preDragGrid` tracking** — records the specific GridStack instance (main grid or subgrid) that owns the dragged widget. Row drags restore the main grid; column/box drags restore only the affected subgrid via its own `save(false)` snapshot.
- **`suppressStoreUpdates` flag** — silences `moveRow`, `addRow`, `updateColumnGridStackData`, and `subGridOnDropped` calls inside GridStack event handlers during the cancel window, keeping the store consistent with pre-drag state.
- **Visual overlay** — `@if (disabled)` block rendered after the grid content with `bg-white/50 backdrop-blur-[2px]` and a centered `p-progress-spinner`. `[attr.inert]` on both the toolbar and the grid container blocks all keyboard/pointer interaction.

### `EditEmaLayoutComponent` (`edit-ema-layout.component.ts` / `.html`)

- **Component-local `#layoutSaveInFlight = signal(false)`** — replaces the `computed(() => uveStore.uveStatus() === LOADING)` approach. Decouples the canvas-disabled state from the global UVE status so that unrelated LOADING events (workflow lock toggles, page-api re-fetches via `withWorkflow.ts`) cannot unlock the canvas mid-POST or trigger a spurious spinner.
- **`nextTemplateUpdate` guard** — returns early when `#layoutSaveInFlight` is true, dropping any `templateChange` events that fire after the canvas is frozen (in-progress drags, open dropdown selections).
- **`tap` before `debounceTime`** — gates the Page Properties nav item immediately on any edit (`setUveStatus(LOADING)`) so users cannot navigate to page settings while layout changes are pending, while the actual canvas lock (`#layoutSaveInFlight`) only engages when the POST is actually sent.
- **`catchError` → `EMPTY`** — keeps the `switchMap` subscription alive on HTTP error so a failed save doesn't permanently disable autosave.

---

## Lock lifecycle

```
User edits → tap fires → setUveStatus(LOADING)   [Page Properties nav gated]
  → 5 s debounce settles
  → #layoutSaveInFlight = true                    [canvas locks + overlay appears]
  → POST /api/v1/page/{id}/layout
    (any new edit dropped by nextTemplateUpdate guard)
  → handleSuccessSaveTemplate()
  → #layoutSaveInFlight = false                   [canvas unlocks]
  → pageReload()
```

---

## Test plan

- [ ] Edit layout (move a row) → wait 5 s → "Saving…" toast appears → canvas shows overlay + spinner → cannot drag/add/resize during save + reload cycle → canvas unlocks after reload
- [ ] Start dragging a row → hold during save → row disappears on lock, no ghost row created, no row added to layout → canvas unlocks cleanly
- [ ] Start dragging toolbar "Add Box" → hold during save → box disappears on lock, no ghost box created → canvas unlocks cleanly
- [ ] Start dragging toolbar "Add Row" → hold during save → Row widget disappears, no row added to layout → canvas unlocks cleanly
- [ ] Edit layout → open "+" container dropdown in a box → wait 5 s → dropdown closes (Escape), overlay appears → canvas is frozen
- [ ] Edit layout → save fails (disconnect network) → canvas unlocks, `uveStatus` set to `ERROR`, user can retry
- [ ] `pnpm nx test portlets-edit-ema-portlet --testPathPattern=edit-ema-layout`
- [ ] `pnpm nx test template-builder --testPathPattern=template-builder.component`

---

https://github.com/user-attachments/assets/b77977ad-8b99-43ff-83f4-faa5705b2a4d

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36197