### PR TITLE
fix(core-web): recycle Jest workers past 1536MB to stop ui:test OOM (#37245)

### DIFF
--- a/core-web/jest.preset.js
+++ b/core-web/jest.preset.js
@@ -2,6 +2,27 @@ const nxPreset = require('@nx/jest/preset').default;
 
 module.exports = {
     ...nxPreset,
+    /*
+     * Recycle a Jest worker once its heap passes this limit, instead of letting it grow
+     * until V8 aborts the process (#37245: `ui:test` died at 3706 MB against V8's 4144 MB
+     * default ceiling, with `current mu = 0.067` — 93% of the time spent in GC).
+     *
+     * Why 1536MB, measured with `--logHeapUsage` on `libs/ui` (105 specs):
+     *   - Per-spec footprint in a fresh worker: median 169 MB, mean 193 MB.
+     *   - One outlier: dot-folder-list-view.component.spec.ts at 1564 MB (206 tests in a
+     *     single file), 4x the next-heaviest spec (365 MB).
+     *   - Accumulated peak with no limit: 1995 MB (2 workers) / 2384 MB (apps/dotcms-ui).
+     * The worst case after a recycle is `limit + largest single-spec footprint`, i.e.
+     * 1536 + 1564 = ~3.1 GB, leaving ~1 GB under the 4144 MB ceiling. Raising this to
+     * 2048 MB would put the worst case at ~3.6 GB — right where CI already aborted.
+     * At a 169 MB median it also lets a worker run ~9 specs before recycling, so the
+     * respawn cost stays negligible.
+     *
+     * Setting this also forces Jest to use worker processes rather than running in-band
+     * (see shouldRunInBand in @jest/core): on a runner where `maxWorkers <= 1` Jest would
+     * otherwise run every spec in the main process, where nothing can recycle it.
+     */
+    workerIdleMemoryLimit: '1536MB',
     coverageDirectory: '../../../target/core-web-reports/',
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.ts', 'src/**/*.tsx', '!src/**/*.module.ts', '!src/index.ts'],


### PR DESCRIPTION
Fixes #37245

## What changed

One line of real change in `core-web/jest.preset.js`:

```js
workerIdleMemoryLimit: '1536MB',
```

Jest now recycles a worker once its heap passes 1536 MB instead of letting it grow until V8 aborts the process. No spec was skipped, deleted, disabled, or rewritten — test counts are byte-for-byte identical before and after (see the table below).

## Why the OOM happened, and why this setting fixes it

Two separate mechanisms were at play, and `workerIdleMemoryLimit` addresses both:

1. **Nothing recycled a growing worker.** A Jest worker accumulated heap across every spec it ran until it hit V8's ~4.1 GB default ceiling. The failing job reached 3706 MB with `current mu = 0.067` — ~93% of the time in GC — the signature of exhausted headroom, not one runaway allocation.

2. **On a low-core runner Jest was not using workers at all.** `shouldRunInBand()` in `@jest/core` returns `true` when `maxWorkers <= 1`, which puts every spec in the *main* process, where no recycling is possible by construction. Setting `workerIdleMemoryLimit` is explicitly special-cased there:

   ```js
   return (
     // When specifying a memory limit, workers should be used
     workerIdleMemoryLimit === undefined && (oneWorkerOrLess || oneTestOrLess || ...)
   );
   ```

   So the setting also guarantees worker processes exist to be recycled, regardless of runner core count.

The metric Jest compares against the limit is `process.memoryUsage().heapUsed` (`jest-worker/build/processChild.js:250`) — exactly what `--logHeapUsage` prints, so every number below is directly comparable to the threshold.

## Measurements

All runs: `pnpm nx test <project> --logHeapUsage --skip-nx-cache --maxWorkers=2`, local V8 heap ceiling 4144 MB (same as CI). `--maxWorkers=2` approximates the CI runner's low core count; the workstation default of 15 workers spreads specs too thinly to reproduce the accumulation.

### Before / after

| Project | Specs | Peak heap before | Peak heap after | Δ | Wall before | Wall after |
|---|---|---|---|---|---|---|
| `ui` | 105 | 1995 MB | **1567 MB** | −21% | 48.0s | 47.2s |
| `dotcms-ui` | 228 | 2384 MB | **1512 MB** | −37% | 179.8s | 171.0s |
| `edit-content` | 114 | 2002 MB | **1503 MB** | −25% | 130.0s | 112.0s |
| `data-access` | 85 | 840 MB | 900 MB | +7% (noise) | 19.9s | 15.9s |

`data-access` never approaches the limit (peak well under 1536 MB), so the setting never trips there; the +60 MB is GC-timing noise between runs, not a regression caused by this change.

### Test behavior unchanged

| Project | Before | After |
|---|---|---|
| `ui` | 105 passed / 1 skipped suites, 1411 passed tests | identical |
| `dotcms-ui` | 227 passed / 1 skipped suites, 2229 passed tests | identical |
| `edit-content` | 114 passed suites, 2282 passed tests | identical |
| `data-access` | 83 passed / 2 skipped suites, 809 passed tests | identical |

### Runtime

Summed wall clock across the four heaviest projects: **377.7s → 346.1s (8.4% faster)**. Well inside the "no more than 10% regression" bar — it is an improvement, not a regression, because a recycled worker does less GC thrashing than one running near its ceiling. The respawn cost is more than paid for.

`pnpm nx run-many -t test --projects=ui,dotcms-ui,edit-content,data-access` completes green in 332s.

## Which `libs/ui` specs contribute the largest retention

Measured by forcing a fresh worker per spec (`--workerIdleMemoryLimit=0`, the "always restart" special case), which isolates each file's own footprint:

| Spec | Standalone heap |
|---|---|
| `dot-folder-list-view/dot-folder-list-view.component.spec.ts` | **1564 MB** |
| `dot-asset-picker/dot-asset-picker.component.spec.ts` | 365 MB |
| `dot-content-type-filter/dot-content-type-filter.component.spec.ts` | 356 MB |
| `dot-workflow-push-publish/dot-workflow-push-publish.component.spec.ts` | 348 MB |
| `dot-workflow-actions/dot-workflow-actions.component.spec.ts` | 281 MB |

Across all 105 specs: **min 97 MB, median 169 MB, mean 193 MB, max 1564 MB.**

The distribution is not "105 heavy specs" — it is one dominant outlier. `dot-folder-list-view.component.spec.ts` is 2982 lines with 206 tests in a single file, and alone accounts for 9x the median and 4.3x the next-heaviest spec. It is also the slowest at 17.5s. Splitting that file is worth doing on its own merits, but it is a separate change and is deliberately not in this PR — the guardrail has to hold regardless of which spec goes heavy next.

## Coverage cost measurement, and the decision on `collectCoverage`

Measured on `ui:test` at 2 workers, with and without coverage:

| Configuration | Peak heap | Wall clock |
|---|---|---|
| `collectCoverage: true` (current) | 1995 MB | 48.0s |
| `--coverage=false` | 2026 MB | 46.5s |

**Coverage is not a material contributor.** The no-coverage run measured 31 MB *higher* — the delta is inside run-to-run GC noise, i.e. effectively zero. Time cost is ~3%.

**Decision: `collectCoverage: true` stays on.** It is not causing the OOM, and turning it off would cost the `target/core-web-reports/` lcov/html reports for no memory benefit.

Verified those reports still land and are non-empty after the change:

```
target/core-web-reports/TEST-results.xml   577767 bytes
target/core-web-reports/lcov.info          191509 bytes
target/core-web-reports/index.html         101075 bytes
target/core-web-reports/lcov-report/       (populated)
```

## Justification for 1536 MB

The binding constraint is the worst case *after* a recycle: a worker that sits just under the limit and then loads the heaviest single spec.

```
limit + largest single-spec footprint  <  V8 ceiling
1536   + 1564                          =  3100 MB   vs 4144 MB   → ~1 GB spare
```

For comparison, 2048 MB would put the worst case at 2048 + 1564 = 3612 MB — essentially the 3706 MB point where CI already aborted. That is why the value is not simply rounded up to 2 GB.

At the other end, the 169 MB median means a worker still runs roughly 9 specs before recycling, so respawns are infrequent and their cost stays negligible — confirmed by the wall-clock numbers above.

## Applies everywhere, no overrides

- 46 of 47 `jest.config.ts` files in `core-web` set `preset: '../../jest.preset.js'` and inherit this.
- `grep -rn "workerIdleMemoryLimit"` over `core-web` (excluding `node_modules`) returns exactly one hit — the preset. No project overrides it.
- The one config that does not inherit is `libs/dotcms-webcomponents/jest.config.ts`, which uses `preset: '@stencil/core/testing'`. That is a pre-existing, separate test runner, unrelated to this issue, and is left untouched.

## Verification

- [x] `pnpm nx test ui --logHeapUsage` — passes, no OOM, peak 1567 MB
- [x] `pnpm nx run-many -t test --projects=ui,dotcms-ui,edit-content,data-access` — green
- [x] `pnpm nx format:check` — clean
- [x] `pnpm run lint:dotcms` — clean
- [x] Coverage reports present and non-empty in `target/core-web-reports/`
- [x] No spec skipped, deleted, disabled, or rewritten; test counts identical

Two acceptance criteria can only be closed by CI on this PR, not locally:

- A CI run with `libs/ui` in the affected set (44 projects) completing green.
- The `Merge Group Test / Frontend Unit Tests` job passing for this branch.

Since the failure is intermittent, the job should be re-run a few times before this is considered proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37245