### PR TITLE
fix(dotcms-ui): restore inner padding in toolbar overlay popovers (#37247)

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-overlay/dot-toolbar-btn-overlay.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-overlay/dot-toolbar-btn-overlay.component.html
@@ -26,5 +26,7 @@
     [appendTo]="'body'"
     (onShow)="handlerShow()"
     (onHide)="handlerHide()">
-    <ng-content />
+    <div class="p-4">
+        <ng-content />
+    </div>
 </p-popover>


### PR DESCRIPTION
This PR fixes: #37247

### Proposed Changes
* Add a single `p-4` (1rem, the previous PrimeNG Lara default) content wrapper inside the shared `dot-toolbar-btn-overlay` popover, restoring the inner padding that the toolbar Announcements and Notifications overlays lost when the shared Lara preset zeroed `.p-popover-content` padding globally.
* The padding lives once in the shared host rather than duplicated per consumer; `dot-toolbar-btn-overlay` has exactly two consumers (announcements and notifications), verified by repo-wide search of selector and class usages.
* `theme.config.ts` is untouched — the global popover rule is intentional; per its convention each popover's content owns its spacing.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
Existing specs for `dot-toolbar-btn-overlay`, `dot-toolbar-announcements` and `dot-toolbar-notifications` pass unchanged (55 tests, 4 suites). Verified in the running app: both popovers render with the same spacing they had before the preset change. No security implications — template-only styling change.

This PR fixes: #37247