### PR TITLE
fix(cicd): grant the post-merge plan job the permissions its executor needs

### DIFF
--- a/.github/workflows/ai_claude-post-merge-test-plan.yml
+++ b/.github/workflows/ai_claude-post-merge-test-plan.yml
@@ -65,7 +65,9 @@ jobs:
           # "Area : Backend" with spaces around the colon. Verified via
           # `gh api repos/dotCMS/core/labels`. A gate written without the
           # spaces matches nothing.
-          MERGED=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json merged -q .merged)
+          # `--json merged` is not a valid field for `gh pr view` (gh lists mergedAt/mergedBy/state
+          # but no bare `merged`), and under `set -e` that aborts this step on every run. Use state.
+          MERGED=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q '.state == "MERGED"')
           LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels -q '.labels[].name')
 
           echo "PR #$PR_NUMBER merged=$MERGED"

--- a/.github/workflows/ai_claude-post-merge-test-plan.yml
+++ b/.github/workflows/ai_claude-post-merge-test-plan.yml
@@ -284,11 +284,17 @@ jobs:
     name: Generate and post the plan
     needs: [preflight, prep]
     if: needs.prep.outputs.has_work == 'true'
+    # Must match what the nested executor requests, not what this job appears to need.
+    # claude-orchestrator delegates to claude-executor, which requests contents: write and
+    # pull-requests: write; GitHub only allows permissions to NARROW down a reusable-workflow
+    # chain, so granting less here makes the nested call illegal and the whole workflow file
+    # invalid — it fails at startup before any job runs, with no logs. Same set as the sibling
+    # ai_claude-rollback-safety.yml, which calls the same orchestrator.
     permissions:
-      contents: read
+      contents: write
       id-token: write
       issues: write
-      pull-requests: read
+      pull-requests: write
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}


### PR DESCRIPTION
### Proposed Changes

* Grant the `claude` job `contents: write` and `pull-requests: write` so the nested
  `claude-executor` call is legal.

The post-merge test-plan workflow **has never run**. Every run since it merged ended in
`startup_failure` — no jobs, no logs:

```
Invalid workflow file: .github/workflows/ai_claude-post-merge-test-plan.yml#L242
The nested job 'claude' is requesting 'contents: write, pull-requests: write',
but is only allowed 'contents: read, pull-requests: read'.
```

`claude-orchestrator` delegates to `claude-executor`, which requests `contents: write` and
`pull-requests: write`. GitHub only lets permissions **narrow** down a reusable-workflow chain, so
scoping this job to `read` made the nested call illegal — and that invalidates the *whole workflow
file*, not just that job. It therefore fails before any job starts, which is why there were no logs
to diagnose from.

This grants the same four permissions the sibling `ai_claude-rollback-safety.yml` already grants for
the same orchestrator. `preflight`, `prep` and `finalize` keep least privilege; only the job that
hands off to the executor is widened.

### Checklist
- [x] Tests — n/a, workflow permissions only; verified against the orchestrator's nested contract
- [x] Translations — n/a
- [x] Security Implications Contemplated — notes below

### Additional Info

**Security note.** This is a genuine widening, so it is worth being explicit rather than waving it
through. The write scopes are consumed by `claude-executor` inside `dotCMS/ai-workflows`, not by
anything in this repository, and they are the same scopes `ai_claude-rollback-safety.yml` has been
running with against the same orchestrator. The three jobs this workflow actually owns stay
read-only apart from the issue comment it exists to post. The workflow also remains dormant behind
`POST_MERGE_TEST_PLAN_ENABLED`, so merging this does not by itself start posting anything.

**Why this got through review.** Nothing in the local toolchain catches it: YAML parsing, `bash -n`
on every embedded script, and `actionlint` all report the file clean, because the constraint lives
in a reusable workflow in another repository. The only signal is GitHub's own planner at run time.
For future workflows that call `ai-workflows`, copy the permissions block from a sibling that
already works rather than deriving it from what the job appears to need.

**Still unproven.** With the workflow never having started, everything downstream of instantiation
is still untested — Bedrock OIDC, the executor call, and whether the model's output matches the
comment skeleton. The plan remains: `workflow_dispatch` against a closed PR with posting pointed at
a scratch issue, then set `POST_MERGE_TEST_PLAN_ENABLED=true`.

This PR fixes: #37225

This PR fixes: #37225