### PR TITLE
ci: point the Claude reviewer pilot at the current accounts

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          PILOT_AUTHORS='["dsolistorres","gortiz-dotcms","dsilvam"]'
+          PILOT_AUTHORS='["dsolistorres","gortiz-dotcms","dsilvam","danielsolis-dotcms"]'
           if echo "$PILOT_AUTHORS" | jq -e --arg a "$AUTHOR" 'index($a) != null' > /dev/null; then
             echo "authorized=true" >> $GITHUB_OUTPUT
             echo "✅ $AUTHOR is in the pilot list"

--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          PILOT_AUTHORS='["dsolistorres","gortiz-dotcms","dsilvam","danielsolis-dotcms"]'
+          PILOT_AUTHORS='["gortiz-dotcms","danielsolis-dotcms","danielsilva-dotcms"]'
           if echo "$PILOT_AUTHORS" | jq -e --arg a "$AUTHOR" 'index($a) != null' > /dev/null; then
             echo "authorized=true" >> $GITHUB_OUTPUT
             echo "✅ $AUTHOR is in the pilot list"


### PR DESCRIPTION
### Proposed Changes

Updates `PILOT_AUTHORS` in `.github/workflows/ai_claude-backend-reviewer.yml`:

```diff
- PILOT_AUTHORS='["dsolistorres","gortiz-dotcms","dsilvam"]'
+ PILOT_AUTHORS='["gortiz-dotcms","danielsolis-dotcms","danielsilva-dotcms"]'
```

Two of the listed logins are **no longer members of the dotCMS organization**, so they cannot open a PR here and their entries had no effect. Meanwhile two accounts that do open PRs here were not listed, so the reviewer was skipping them.

Replaced rather than appended, so the list reflects who can currently receive a review. `gortiz-dotcms` is unchanged.

### Checklist
- [ ] Tests — n/a, CI config
- [ ] Translations — n/a
- [x] Security Implications Contemplated — the allowlist gates who *receives* an automated review; it grants no permissions and exposes no secrets. Removing two non-members changes no access.

### Additional Info

Found because the reviewer silently skipped #37288. Gate 1 logs `ℹ️ … is not in the pilot list` and exits, but nothing surfaces on the PR — so a gated skip is indistinguishable from a broken bot.

The workflow's own comment suggests the durable fix: *"To expand: add logins to PILOT_AUTHORS or replace with a team membership check."* A team check would keep this in step with org membership automatically. Not attempted here — it needs a token with `read:org`, which `secrets.GITHUB_TOKEN` does not provide.

Related to #37294, which tracks that change. **This PR does not close it** — it is the interim correction to the hardcoded list, and #37294 remains open until the allowlist is replaced by a team membership check.

Requires `@dotCMS/dotDevelopers` review per CODEOWNERS.
