### PR TITLE
fix(users): isolate the Users Beta portlet URL so legacy /c/users still opens

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/app.routes.ts
+++ b/core-web/apps/dotcms-ui/src/app/app.routes.ts
@@ -215,7 +215,7 @@ const PORTLETS_ANGULAR: Route[] = [
             import('@dotcms/portlets/dot-agents/portlet').then((m) => m.dotAgentsRoutes)
     },
     {
-        path: 'users',
+        path: 'users-beta',
         canActivate: [MenuGuardService],
         canActivateChild: [MenuGuardService],
         data: { reuseRoute: false },

--- a/core-web/libs/data-access/src/lib/dot-router/dot-router.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-router/dot-router.service.spec.ts
@@ -336,10 +336,15 @@ describe('DotRouterService', () => {
         );
     });
 
-    it('should resolve the /users URL slug to the users-beta portlet ID', () => {
-        expect(service.getPortletId('/users')).toBe('users-beta');
-        expect(service.getPortletId('/c/users')).toBe('users-beta');
-        expect(service.getPortletId('#/users?test=value')).toBe('users-beta');
+    it('should resolve the Angular Users (Beta) URL to the users-beta portlet ID', () => {
+        expect(service.getPortletId('/users-beta')).toBe('users-beta');
+        expect(service.getPortletId('#/users-beta?test=value')).toBe('users-beta');
+    });
+
+    it('should resolve the legacy /c/users URL to the users portlet ID', () => {
+        expect(service.getPortletId('/c/users')).toBe('users');
+        expect(service.getPortletId('#/c/users?test=value')).toBe('users');
+        expect(service.getPortletId('/c/users/123')).toBe('users');
     });
 
     it('should navigate replacing URL params', () => {

--- a/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
@@ -480,10 +480,5 @@ const PORTLET_ID_RESOLVERS: Record<string, (urlSegments: string[]) => string> = 
     // URL is kebab-case; backend portlet-name stays snake_case for DB compat (#35809).
     'velocity-playground': () => {
         return 'velocity_playground';
-    },
-    // The Angular Users portlet is registered under `users-beta` in portlet.xml
-    // with a `<portlet-url>/users</portlet-url>` override, so the URL is `/users`
-    // while the menu id stays `users-beta`. Without this mapping the
-    // MenuGuardService can't match the menu entry and bounces to Getting Started.
-    users: () => 'users-beta'
+    }
 };

--- a/dotCMS/src/main/webapp/WEB-INF/portlet.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/portlet.xml
@@ -533,7 +533,7 @@
         <portlet-name>users-beta</portlet-name>
         <display-name>Users (Beta)</display-name>
         <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
-        <portlet-url>/users</portlet-url>
+        <portlet-url>/users-beta</portlet-url>
     </portlet>
 
     <portlet>


### PR DESCRIPTION
## Summary

The legacy **User Admin** portlet could not be opened from the left nav — clicking it (or hitting `/c/users` directly) redirected to Getting Started. This PR takes the Angular Users (Beta) portlet off the URL slug it was sharing with the legacy portlet, which removes the collision entirely.

Fixes #37311

## What was broken

`users-beta` shipped with a `<portlet-url>/users</portlet-url>` override, claiming the exact slug of the legacy `users` portlet id. `DotRouterService.getPortletId()` strips the `/c/` prefix before consulting `PORTLET_ID_RESOLVERS`, so **both** URLs hit the same resolver:

```ts
users: () => 'users-beta'   // matched /users AND /c/users
```

`MenuGuardService` then called `isPortletInMenu('users-beta', checkJSPPortlet = true)`, which requires `id === menuId && !angular`. `users-beta` *is* an Angular portlet, so the match could never succeed → `goToFirstPortlet()`.

Net effect: the legacy Users portlet was unreachable for anyone whose layout contains it — and it is the only user-management UI available to anyone who has not opted into the Beta portlet. Secondarily, `currentPortlet.id` was wrong on the legacy URL, so the nav highlight pointed at the wrong entry.

Introduced in `49a41f0e35` (#36862), which added the `users-beta` block. The legacy `users` entry was never modified — the URL override alone caused this.

## The fix

Give the Beta portlet its own slug so its URL matches its portlet name, and delete the resolver that existed only to paper over the mismatch:

| File | Change |
|---|---|
| `portlet.xml:536` | `<portlet-url>/users</portlet-url>` → `/users-beta` |
| `app.routes.ts:218` | `path: 'users'` → `'users-beta'` |
| `dot-router.service.ts` | `users` entry removed from `PORTLET_ID_RESOLVERS`; `getPortletId()` itself is unchanged |
| `dot-router.service.spec.ts` | Beta test retargeted to `/users-beta`; new test pins `/c/users` → `users` |

`/users-beta` → `users-beta` and `/c/users` → `users` now both resolve with no special-casing.

This is the same fix already applied to Roles for the identical collision — `77f61721d9`, *"isolate beta portlet URL"*, renamed `/roles` → `/roles-beta` so it would stop colliding with the legacy Dojo `roles` portlet. That is why `roles-beta` needs no resolver entry, and now neither does `users-beta`.

### Considered and rejected

Keeping `/users` and teaching the resolver to distinguish legacy from Angular URLs. It works, but it preserves the collision and leaves a per-portlet special case in the router. A blanket "skip resolvers for `/c/*` URLs" is not viable either — `/c/edit-page` → `site-browser` and `/c/velocity-playground` → `velocity_playground` legitimately resolve through that map.

## Breaking change

The Beta portlet's URL changes from `/users` to `/users-beta`. It is an opt-in, unreleased Beta portlet, and this is the same tradeoff already accepted for `roles-beta`. Nothing in the repo hardcodes `/users` as a route — the portlet's own `lib.routes.ts` is fully relative.

## Verification

| Check | Result |
|---|---|
| `nx run-many -t test` — data-access, dotcms-ui, global-store, portlets-dot-users-portlet | 3425 passed, 43 skipped, 0 failed |
| `nx run-many -t lint` — the 3 affected projects | clean |
| `nx format:check` | clean |
| `nx build dotcms-ui --configuration=production` | success |
| `portlet.xml` XML parse | OK |

`PortletUrlTest.java` builds its XML inline rather than reading the real `portlet.xml`, so it is unaffected. `SerializationHelperTest` asserts portlet *ids* (`users`, `users-beta`), which are unchanged.

## QA

- [ ] Log in as an admin whose layout has **User Admin** only → click it in the left nav → legacy portlet loads, no bounce to Getting Started.
- [ ] Same user → paste `/dotAdmin/#/c/users` in the address bar → legacy portlet loads.
- [ ] Log in as a user whose layout has **Users (Beta)** only → click it → Angular portlet loads at `/users-beta`.
- [ ] Log in as a user with both portlets → open **User Admin**, then **Users (Beta)**, then back → each loads its own implementation every time.
- [ ] With both present, confirm the left-nav highlight follows the portlet actually open.
- [ ] Inside the legacy portlet, open a user detail view and confirm the deep-linked URL survives a page refresh.
- [ ] Log in as a limited user with neither portlet → they still land on the first portlet available to them.
- [ ] Smoke-check two other legacy iframe portlets (**CMS Maintenance**, **Categories**) for routing regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37311