### PR TITLE
fix(evergreen-tracks): make dry-run unmissable in the admin dispatch UI

### DIFF
--- a/.github/actions/core-cicd/evergreen-tracks/README.md
+++ b/.github/actions/core-cicd/evergreen-tracks/README.md
@@ -53,6 +53,33 @@ window. A tag moved on a Tuesday has no effect until that window. Nothing in the
 watches the tags continuously (no Argo CD Image Updater / Keel, no floating-tag references,
 no `imagePullPolicy: Always` on customer pods).
 
+## State: the three marker tags
+
+There is no database. Every decision the planner makes is derived from tags in the registry:
+
+| Tag | Written by | Means |
+|---|---|---|
+| `latest` / `standard` / `trailing` | promote | the release this track currently resolves to |
+| `<version>_tainted` | `admin --action taint` | no track may **advance** onto this version |
+| `<track>_hold` | `admin --action hold` | this track is frozen; promote reconciles the track tag to this digest instead of planning |
+
+The two markers are independent guards, and a hold is the stronger one: a held track skips the
+planner entirely, and the planner is the only thing that reads taint markers.
+
+### `force`
+
+`hold` refuses to point a track at a tainted version unless `force` is set. It is the
+last-resort control for when **every candidate is bad and you must pick the least-bad one** —
+retreating from a release that is breaking customers onto an older one already tainted for
+something milder.
+
+Because a forced hold bypasses the planner, the track is not just parked on a known-bad
+release, it is **actively re-pinned there every promote run** until someone runs
+`release-hold`. The tainted check also runs *only* at hold time — tainting a version later
+does not release a hold that already points at it.
+
+Full procedure, rules, and exit path: [RUNBOOK → `force`](RUNBOOK.md#force--holding-onto-a-tainted-version).
+
 ## Operator procedures
 
 See [RUNBOOK.md](RUNBOOK.md) for tainting a release, holding a track, and holding a single

--- a/.github/actions/core-cicd/evergreen-tracks/RUNBOOK.md
+++ b/.github/actions/core-cicd/evergreen-tracks/RUNBOOK.md
@@ -85,8 +85,41 @@ skips the track and self-heals the floating tag back to the held digest if it dr
    | `track` | `standard`, `trailing`, or `latest` |
    | `version` | the version to freeze on, e.g. `26.06.22-03` |
    | `mode` | `dry-run` → then `apply` |
-2. Holding onto a **tainted** version is refused unless you also set `force` = `true`. Don't,
-   unless you're deliberately choosing the least-bad option and have said so in the ticket.
+2. Holding onto a **tainted** version is refused unless you also set `force` = `true`.
+   See [`force`](#force--holding-onto-a-tainted-version) below before you do.
+
+### `force` — holding onto a tainted version
+
+`force` lifts exactly one guard: the check that stops `hold` pointing a track at a version
+carrying a `<version>_tainted` marker. It does nothing for `taint`, `untaint`, or
+`release-hold` — on those actions the checkbox is inert.
+
+**Why it exists.** Taint and hold answer different questions. Taint says *"no track may
+advance onto this."* Hold says *"this track sits here, now."* Those only collide in one
+situation: **every candidate is bad and you have to pick the least-bad one.** A track is on a
+release that is actively breaking customers, and the only older release you can retreat to is
+itself already tainted for something milder. Retreating is still correct. `force` is how you
+say so out loud.
+
+**What it costs.** The `_tainted` marker stays, but it stops protecting *this* track. A held
+track bypasses the planner completely — the planner is the only thing that reads taint markers
+— and promote instead reconciles the floating tag back to the hold digest on every run. So the
+track is not merely parked on a known-bad release; it is **actively re-pinned there** until
+someone runs `release-hold`. Other tracks are unaffected: the marker still excludes that
+version for them.
+
+**Rules**
+
+- Never for convenience. If any untainted version is acceptable, hold onto that instead.
+- Record why in the incident ticket, naming **both** defects — the one you fled and the one
+  you knowingly accepted.
+- Treat it as temporary. Exit by `release-hold` once a good release exists — **not** by
+  untainting the version to make the warning go away.
+
+> **The guard is a one-time check, at hold time.** If you hold onto a good version and it is
+> tainted *later*, the hold survives and promote keeps reconciling the track onto it. Nothing
+> re-validates, and no notification fires. **Tainting a version does not release a hold that
+> already points at it** — so whenever you taint, check the holds.
 
 ### Verify
 
@@ -182,6 +215,9 @@ Plus the Argo CD UI (Application = the **customer**, not the env) for Synced / H
   without Redis session sharing enabled) — they will not roll even when subscribed.
 - **Registry and env state are separate.** A track hold (2) does not pause an environment, and
   an env pause (3) does not stop the track from moving for everyone else.
+- **Taint does not override an existing hold.** The tainted check runs only when a hold is
+  created. A track already held onto a version you later taint stays there and is re-pinned
+  every promote run. After tainting, confirm no `<track>_hold` marker points at that version.
 - **Dry-run is the default** on both `evergreen-tracks-promote` and `evergreen-tracks-admin`.
   Use it every time; the plan output is cheap and the mistakes are not.
 - **Update the CX "Maintenance Pause List & Evergreen Tracks" sheet** when you pause or
@@ -198,6 +234,7 @@ Plus the Argo CD UI (Application = the **customer**, not the env) for Synced / H
 | Advance them off-cycle / review a plan first | `evergreen-tracks-promote` | dispatch → approve gate (break-glass) |
 | Stop any track landing on a bad release | `evergreen-tracks-admin` | `taint` |
 | Freeze a track / pull it off a bad release | `evergreen-tracks-admin` | `hold` |
+| Retreat a track onto a release that is itself tainted | `evergreen-tracks-admin` | `hold` + `force` — [last resort](#force--holding-onto-a-tainted-version) |
 | Resume a frozen track | `evergreen-tracks-admin` | `release-hold` |
 | Stop one env from updating | IaC manifest PR | add `maintenance-pause: 'true'` |
 | Move one env to a different track | IaC manifest PR | change `evergreen-track` value |

--- a/.github/actions/core-cicd/evergreen-tracks/RUNBOOK.md
+++ b/.github/actions/core-cicd/evergreen-tracks/RUNBOOK.md
@@ -38,9 +38,11 @@ from eligibility, so no track will advance onto it.
    | `repo` | `dotcms/dotcms` |
    | `action` | `taint` |
    | `version` | the bad GA version, e.g. `26.07.06-3` |
-   | `apply` | `false` ← **dry-run first** |
-2. Read the output, confirm it targets the version you intended.
-3. Re-run with `apply` = `true`.
+   | `mode` | `dry-run` ← **the default; changes nothing** |
+2. Read the output, confirm it targets the version you intended. A dry-run logs
+   `DRY-RUN would point ...` and the run is titled `DRY-RUN (no changes)`.
+3. Re-dispatch with `mode` = `apply`. Only then does the marker actually get pushed
+   (`pointing ... -> sha256:...`).
 
 ### Verify
 
@@ -82,7 +84,7 @@ skips the track and self-heals the floating tag back to the held digest if it dr
    | `action` | `hold` |
    | `track` | `standard`, `trailing`, or `latest` |
    | `version` | the version to freeze on, e.g. `26.06.22-03` |
-   | `apply` | `false` → then `true` |
+   | `mode` | `dry-run` → then `apply` |
 2. Holding onto a **tainted** version is refused unless you also set `force` = `true`. Don't,
    unless you're deliberately choosing the least-bad option and have said so in the ticket.
 

--- a/.github/workflows/cicd_evergreen-tracks-admin.yml
+++ b/.github/workflows/cicd_evergreen-tracks-admin.yml
@@ -38,8 +38,11 @@ on:
         description: 'Track (for hold/release-hold): latest|standard|trailing'
         required: false
         default: ''
+      # Only consulted by `hold`; inert on taint/untaint/release-hold. Lifts the guard
+      # against pinning a track to a KNOWN-BAD release, and a held track bypasses the
+      # planner, so promote actively re-pins it there until release-hold. See RUNBOOK.
       force:
-        description: 'Allow holding onto a tainted version'
+        description: 'hold only — pin onto a TAINTED version (last resort, see RUNBOOK)'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/cicd_evergreen-tracks-admin.yml
+++ b/.github/workflows/cicd_evergreen-tracks-admin.yml
@@ -1,7 +1,26 @@
 name: evergreen-tracks-admin
+
+# The run title carries the mode, so a dry-run is distinguishable from a real
+# mutation in the Actions list and at the top of the run page — not just buried
+# in the step log. A dry-run that was meant to apply has been mistaken for a
+# completed taint before (2026-08-31, run 33434507975).
+run-name: >-
+  ${{ inputs.mode == 'apply' && 'APPLY' || 'DRY-RUN (no changes)' }}
+  — ${{ inputs.action }} ${{ inputs.version }}${{ inputs.track }}
+
 on:
   workflow_dispatch:
     inputs:
+      # FIRST input deliberately: the dispatch form renders inputs in declaration
+      # order, and this one was previously last — under five other fields, as a
+      # free-text box pre-filled with the word "false", which is easy to skim past.
+      # A choice dropdown spelling out "dry-run" forces a deliberate pick.
+      mode:
+        description: 'Mode — dry-run prints the plan and changes NOTHING; apply mutates tags'
+        required: true
+        type: choice
+        default: 'dry-run'
+        options: [dry-run, apply]
       repo:
         description: 'Docker repo to operate on'
         required: true
@@ -22,11 +41,8 @@ on:
       force:
         description: 'Allow holding onto a tainted version'
         required: false
-        default: 'false'
-      apply:
-        description: 'Actually mutate tags (false = dry-run)'
-        required: true
-        default: 'false'
+        type: boolean
+        default: false
 
 # Share the registry-mutation lock with the promote workflows so an admin
 # taint/hold can never overlap a promote run on the same tags.
@@ -53,16 +69,20 @@ jobs:
           # delete calls read them); other steps/actions don't need them.
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
-          REPO: ${{ github.event.inputs.repo }}
-          ACTION: ${{ github.event.inputs.action }}
-          VERSION: ${{ github.event.inputs.version }}
-          TRACK: ${{ github.event.inputs.track }}
-          FORCE: ${{ github.event.inputs.force }}
-          APPLY: ${{ github.event.inputs.apply }}
+          REPO: ${{ inputs.repo }}
+          ACTION: ${{ inputs.action }}
+          VERSION: ${{ inputs.version }}
+          TRACK: ${{ inputs.track }}
+          FORCE: ${{ inputs.force }}
+          MODE: ${{ inputs.mode }}
         run: |
           EXTRA=""
           if [ "$FORCE" = "true" ]; then EXTRA="$EXTRA --force"; fi
-          if [ "$APPLY" = "true" ]; then EXTRA="$EXTRA --apply"; fi
+          if [ "$MODE" = "apply" ]; then
+            EXTRA="$EXTRA --apply"
+          else
+            echo "::notice::DRY-RUN — printing the plan only. Nothing in the registry will change. Re-dispatch with mode=apply to make it real."
+          fi
           uv run evergreen-tracks admin \
             --repo "$REPO" \
             --action "$ACTION" \

--- a/.github/workflows/cicd_evergreen-tracks-admin.yml
+++ b/.github/workflows/cicd_evergreen-tracks-admin.yml
@@ -6,7 +6,7 @@ name: evergreen-tracks-admin
 # completed taint before (2026-08-31, run 33434507975).
 run-name: >-
   ${{ inputs.mode == 'apply' && 'APPLY' || 'DRY-RUN (no changes)' }}
-  — ${{ inputs.action }} ${{ inputs.version }}${{ inputs.track }}
+  — ${{ inputs.action }}${{ inputs.track && format(' {0}', inputs.track) || '' }}${{ inputs.version && format(' {0}', inputs.version) || '' }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Closes: #37314

Two related gaps in the `evergreen-tracks-admin` operator surface: the dispatch form hid its dry-run default, and `force` was documented as "Don't" without ever saying what it does.

## 1. Dry-run was invisible in the dispatch UI

Dry-run is the right default, but the form hid it well enough that a dry-run was mistaken for a completed taint on 2026-08-31 ([run 33434507975](https://github.com/dotCMS/core/actions/runs/33434507975) — green, titled the same as a real run, with `DRY-RUN would point ...` buried in the step log).

| Before | After |
|---|---|
| `apply` — last of six inputs, untyped string pre-filled `false` | `mode` — **first** input, `choice` dropdown: `dry-run` \| `apply` |
| Run titled `evergreen-tracks-admin` either way | `DRY-RUN (no changes) — taint 26.08.28-01` vs `APPLY — taint 26.08.28-01` |
| Dry-run silent except in the step log | `::notice::` annotation on the run summary |
| `force` untyped string `false` | `type: boolean` (renders a checkbox) |

Safe default is preserved: `dry-run` is the first option, so it stays preselected.

## 2. `force` had no what or why

The RUNBOOK said *"Don't, unless you're deliberately choosing the least-bad option"* — a prohibition with no explanation. The README never mentioned it. Verified against the code and documented in both:

- **What** — `force` lifts exactly one guard: `hold` onto a version carrying a `_tainted` marker. It is inert on `taint`, `untaint`, and `release-hold`.
- **Why** — taint and hold collide in exactly one situation: every candidate is bad and you must pick the least-bad one. You are fleeing a release actively breaking customers, and the only older release you can retreat to is itself tainted for something milder.
- **What it costs** — a held track bypasses the planner, and the planner is the only thing that reads taint markers. Promote reconciles the track tag to the hold digest every run, so the track is **actively re-pinned** to the known-bad release until someone runs `release-hold`.

**Latent trap found while verifying this**, now documented in both files and the Gotchas list: the tainted check runs *only* at hold time (`cli.py:210`). Hold onto a good version, taint it later, and the hold survives — promote keeps re-pinning the track onto a version you just declared bad. Nothing re-validates and nothing notifies. Worth a follow-up issue to make `taint` fail or warn when a `<track>_hold` marker points at the version being tainted.

The README also gains a short table of the three registry markers, which it previously never explained.

## Verification

Screenshots and run titles in the comments below, captured from a secrets-free copy of this dispatch surface in [dotCMS/core-workflow-test](https://github.com/dotCMS/core-workflow-test/actions/workflows/evergreen-tracks-admin-ui-demo.yml) plus the live authenticated Run workflow panel. That demo caught a real bug in the first `run-name` (`hold 26.08.14-01standard` — `hold` sets both `version` and `track`), fixed in 165140547f.

## Scope

Only `cicd_evergreen-tracks-admin.yml` and the two evergreen-tracks docs. `cicd_evergreen-tracks-promote.yml` has no `apply` input — it uses a `plan` -> `gate` (required reviewer) -> `apply` job structure, so the same confusion cannot arise there.

The operator runbook in the **#dot-releases** channel canvas has been updated with the same `force` guidance, since it had no evergreen-tracks section at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)