### PR TITLE
feat(test-plan): read the spec for an issue when spec-driven work exists

### DIFF
--- a/.claude/skills/dot-test-plan/README.md
+++ b/.claude/skills/dot-test-plan/README.md
@@ -19,6 +19,22 @@ skeleton (marker, ownership table, four-column summary, full plan in `<details>`
 lean: no assumptions table, no per-issue coverage index, no out-of-scope list, and no completion
 block, since the ownership table already carries both statuses.
 
+## Specs
+
+When spec-driven work exists for an issue — `specs/<issue>-<slug>/spec.md` — the skill reads it in
+preference to the issue's acceptance criteria. A spec is written to be testable: its Acceptance
+Scenarios are already *Given / When / Then*, which map almost directly onto steps and expected
+results, and its user-story priorities inform risk. Cases cite the scenario they came from
+(`US1-AS3: …`) so a reviewer can check one against the other.
+
+Two limits keep it honest. The **diff still wins** where spec and code disagree — a spec is approved
+before the code exists. And because a spec covers a whole feature while a PR often implements one
+increment of it, the plan covers **what this diff built**; spec scenarios with no counterpart in the
+diff are noted in the Summary rather than turned into cases for untested behaviour.
+
+Only `spec.md` is read, bounded to 3 specs and 400 lines each. Most issues have no spec, which
+changes nothing.
+
 ## What it does *not* do
 
 - Write or run tests, or record their results.

--- a/.claude/skills/dot-test-plan/SKILL.md
+++ b/.claude/skills/dot-test-plan/SKILL.md
@@ -204,7 +204,47 @@ publishes no Out of Scope list, so only the cases you keep appear. Still walk ev
 deliberately: silently forgetting an axis and consciously excluding it produce the same plan, and
 only one of them is right.
 
-**Acceptance criteria come first.** Before the matrix, extract every bullet from each issue's
+### The spec, when there is one
+
+dotCMS is moving to spec-driven development, and a spec is a far better source of test material than
+an issue body — it is written to be testable and it was reviewed and approved on its own. Check for
+one **before** reading acceptance criteria:
+
+```bash
+ls -d specs/<issue>-*/ 2>/dev/null      # one per issue in the set; the dir is named <issue>-<slug>
+```
+
+Read only `spec.md`. Skip `data-model.md`, `contracts/`, `plan.md` and `tasks.md` — implementation
+detail, little test value, real token cost. Most issues have no spec; that is the normal case and
+never blocks anything.
+
+What to take from it:
+
+| In the spec | Becomes |
+|---|---|
+| **Acceptance Scenarios** — *Given … When … Then …* | A case: Given/When → `Steps To Reproduce`, Then → `Expected Result` |
+| **Independent Test** on a user story | A single case proving that story stands on its own |
+| **Edge Cases** | `Edge` / `Boundary` scenario cases |
+| Story **Priority** (P1/P2/P3) | An input to `Risk` — not a mechanical mapping |
+| **Success Criteria** / measurable outcomes | What the expected result should actually assert |
+
+Cite the scenario in the case name the way AC bullets are cited — `US1-AS3: site selector lists only
+sites` — so the reviewer can check a case against the exact scenario it came from.
+
+**Two rules that matter more than the mapping:**
+
+- **The diff still wins.** The spec says what was intended; the diff says what was built. Where they
+  disagree, plan against the diff and note the gap. A spec is approved before the code exists, and
+  the code is what a person will be testing.
+- **A spec describes a whole feature; this PR may implement a slice of it.** Spec-driven work lands
+  in increments — an issue titled "4/7" is one step of an epic whose spec covers all seven. Cover
+  what **this diff** implements. Where a spec scenario has no counterpart in the diff, that is
+  **one line in the Summary**, not an invented case. Writing cases for unbuilt scenarios is the
+  fastest way to make a plan untrustworthy.
+
+Bound it: read at most **3** specs and **400 lines** each. If you truncate, say so in the Summary.
+
+**Acceptance criteria come first when there is no spec.** Extract every bullet from each issue's
 "Acceptance Criteria" / "Definition of Done" section. Every bullet describing a user-visible outcome
 must map to ≥1 case, and the case name references it (e.g. `AC-3: Content Drive shows all subfolders`).
 An AC bullet with no case is a coverage gap. The only acceptable reasons to leave one out are: it is

--- a/.github/prompts/qa-postfix-test-plan.md
+++ b/.github/prompts/qa-postfix-test-plan.md
@@ -54,6 +54,18 @@ Do **not** use `git show {{MERGE_SHA}}` — the repository here is checked out s
 pull-request ref, and the squash-merge commit is not in it, so that command fails. `gh pr diff`
 reads the API and always works. The merge SHA above is for the comment marker, not for git.
 
+Check whether any related issue has a spec. dotCMS keeps spec-driven work under `specs/`, one
+directory per issue named `<issue>-<slug>`:
+
+```
+ls -d specs/<number>-*/ 2>/dev/null
+```
+
+If one exists, read its `spec.md` only — not `data-model.md`, not `contracts/`. Its Acceptance
+Scenarios, Independent Tests and Edge Cases are better test material than the issue body, and
+SKILL.md section 6 says how to turn them into cases. Most issues have no spec; that is normal, and
+absence blocks nothing.
+
 Read each related issue for its description and acceptance criteria:
 
 ```


### PR DESCRIPTION
### Proposed Changes

* When an issue has spec-driven work under `specs/<issue>-<slug>/`, read its `spec.md` and build the
  plan from it in preference to the issue's acceptance criteria.

A spec is written to be testable, and reviewed and approved on its own. For issue #37208:

| | `spec.md` | issue body |
|---|---|---|
| Acceptance Scenarios (*Given/When/Then*) | **26** | 0 |
| User stories with an Independent Test | **5** | – |
| Edge cases | **9** | 0 |
| Measurable success criteria | **10** | 0 |
| AC checkboxes | – | 24 |

Given/When becomes `Steps To Reproduce`, Then becomes `Expected Result`, and story priority
(P1/P2/P3) informs `Risk`. Cases cite the scenario they came from — `US1-AS3: …` — alongside the
existing `AC-3:` convention, so a reviewer can check a case against the exact scenario.

### Checklist
- [x] Tests — lookup verified against three real PRs (with spec / without / mixed)
- [x] Translations — n/a
- [x] Security Implications Contemplated — notes below

### Additional Info

**The two rules that matter more than the mapping.**

* **The diff still wins.** A spec is approved *before* the code exists. Where spec and diff disagree,
  the plan follows the diff and notes the gap — unchanged from how the PR description is treated.
* **A spec covers a whole feature; a PR often implements a slice.** An issue titled "AssetPicker
  4/7" is one increment of an epic whose spec covers all seven. The plan covers what **this diff**
  built; a spec scenario with no counterpart in the diff is one line in the Summary, never an
  invented case. Writing cases for unbuilt behaviour is the fastest way to make a plan untrustworthy.

**Verified against real PRs**, including the mixed case that will be the norm during SDD adoption:

```
PR #37220 — 1 issue,  spec found (246 lines)
PR #37112 — 1 issue,  no spec — falls back to issue ACs, unchanged
PR #36944 — 8 issues, exactly one (#36834) has a spec
```

**Bounded**: `spec.md` only — not `data-model.md`, not `contracts/`, not `plan.md`/`tasks.md`. Capped
at 3 specs and 400 lines each; truncation is stated in the Summary. The largest spec in the repo is
42 KB, so an unbounded read across a multi-issue PR would swamp the prompt.

**Absence is the normal case.** Ten issues have specs today. A missing spec blocks nothing and
changes nothing.

**No workflow change.** The `claude` job already checks out the full repository, and reading repo
files goes through the Read tool rather than `--allowedTools`, which gates Bash patterns only. The
prompt already depends on this to read `SKILL.md` itself.

This PR fixes: #37225

This PR fixes: #37225