### PR TITLE
fix(docs): remove fabricated Spring claim from CLAUDE.md's Tech Stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ How it's built + upgrade re-apply notes: [.specify/CUSTOMIZATIONS.md](.specify/C
 
 ## Tech Stack
 
-- **Backend**: Java 25 (runtime + core compile target, override-able), Maven, Spring/CDI
+- **Backend**: Java 25 (runtime + core compile target, override-able), Maven, CDI
 - **Frontend**: Angular 22+, Nx, PrimeNG, Tailwind CSS, Jest/Spectator — [core-web/CLAUDE.md](core-web/CLAUDE.md)
 - **Infrastructure**: Docker, PostgreSQL, Elasticsearch, GitHub Actions
 


### PR DESCRIPTION
## Summary

Small follow-up to #37258 (M1 of the Backend AI-Context Rock, #37124). That PR fixed the same "Spring/CDI" fabrication in `ARCHITECTURE_OVERVIEW.md` and `CODE_STRUCTURE.md`, but missed the identical claim in root `CLAUDE.md`'s own Tech Stack line — since `CLAUDE.md`'s backend sections were in scope for that work, this closes the gap.

Verified: zero `org.springframework` usage anywhere in this codebase — no hits in any `pom.xml`, none in `dotCMS/src/main/java`. The real DI mechanism is CDI only.

## How this was found

Running the post-merge behavioral verification for #37258 (asking a fresh Claude Code session real questions about the fixed docs — see #37126), the question "Does dotCMS use Spring anywhere for dependency injection?" correctly flagged that `CLAUDE.md` itself still made the claim, even though the sibling docs had already been corrected. Good example of the kind of gap this verification approach is meant to catch.

## Test plan

- [x] Grepped `CLAUDE.md` for any remaining "spring" mentions — none
- [x] Re-verified zero Spring usage across all `pom.xml` files and `dotCMS/src/main/java`

Part of #37124.

This PR fixes: https://github.com/dotCMS/core/issues/37126