### PR TITLE
fix(ci): select the nightly build ref along main's first-parent line

### DIFF
--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -92,9 +92,10 @@ jobs:
         with:
           # Bounded shallow checkout: Find Build Commit walks `git log` on main
           # back to midnight UTC. The window that matters is commits landing
-          # between midnight and run time (~3h); max observed is ~19 commits/day,
-          # so 1000 commits is ~52 days of volume and can't realistically overrun
-          # the midnight boundary. use-latest-commit only needs HEAD. Avoids the
+          # between midnight and run time (~3h). Under merge commits every branch
+          # commit lands on main, so volume is ~40 commits/day (118 across
+          # v26.08.28-01...v26.08.31-01), making 1000 commits ~25 days — still far
+          # past the midnight boundary. use-latest-commit only needs HEAD. Avoids the
           # fetch-depth: 0 full fetch (~2k+ branches, ~1.1 GB pack) when only
           # main's recent history is consulted.
           fetch-depth: 1000
@@ -113,13 +114,17 @@ jobs:
             # Default for both scheduled and manual dispatch: use the last commit
             # at or before midnight UTC. This ensures repeatability — manually
             # re-running later in the day to investigate a failure gives the same build.
+            # --first-parent is load-bearing: squash merging is disabled, so every
+            # feature-branch commit lands on main verbatim. Without it, `git log`
+            # walks into a merged branch and can select a commit that was never
+            # main's tip — building a tree no one ever tested on main.
             MIDNIGHT=$(date -u +"%Y-%m-%dT00:00:00")
-            BUILD_REF=$(git log --before="${MIDNIGHT}" --format="%H" -1)
+            BUILD_REF=$(git log --first-parent --before="${MIDNIGHT}" --format="%H" -1)
             if [[ -z "${BUILD_REF}" ]]; then
               # No commits before today's midnight — use the absolute last commit.
               # This handles edge cases (e.g., very new repos) without falling back to
               # current HEAD which might include post-midnight commits.
-              BUILD_REF=$(git log --format="%H" -1)
+              BUILD_REF=$(git log --first-parent --format="%H" -1)
               echo "⚠️ No commit found before ${MIDNIGHT}, using last available commit: ${BUILD_REF}"
             else
               echo "Building from commit at midnight UTC (${MIDNIGHT}): ${BUILD_REF}"


### PR DESCRIPTION
## Why

`.github/workflows/cicd_4-nightly.yml` picks the nightly build ref with:

```bash
BUILD_REF=$(git log --before="${MIDNIGHT}" --format="%H" -1)
```

`git log` walks the whole reachable graph in **commit-date order**, not main's mainline. Under squash merging that was harmless — one commit per PR, dated at merge time. Squash merging is now **disabled** on this repo (`allow_squash_merge: false`), so every feature-branch commit lands on `main` verbatim, carrying the commit date it had *on the branch*. A commit authored days ago but merged *after* the nightly ran can win the `-1` — and it was never `main`'s tip.

## Reproduced on real history

All three most recent nightly windows select a non-mainline commit today:

| window | without `--first-parent` | with `--first-parent` |
|---|---|---|
| `2026-08-29` | `dfadb3e180` **Merge branch 'main' into issue-36855-deterministic-id-...** | `7a7708ee35` feat(users): API Tokens tab … |
| `2026-08-31` | `e379884d35` **Merge branch 'main' into nicobytes/issue-36850-node-24-...** | `31928163af` fix(clustering): propagate system table set() … |
| `2026-09-01` | `f7294b1ac0` test(block-editor): cover codeBlock … | `be94fd0a7f` fix(evergreen-tracks): make dry-run unmissable … |

Two of the three are `Merge branch 'main' into <feature-branch>` commits — the nightly would build a **feature branch**, not `main`.

## What actually shipped

The scheduled 03:30 runs got the right answer, but only by timing. Confirmed from the run logs:

- run `33354100873` (Aug 31) → `31928163afd5345a59898ce4dbd1a4c1c8d698f9` ✅
- run `33466553920` (Sep 1) → `be94fd0a7fed542c6977aeaff6857653a09268c2` ✅

`e379884d35` is dated `2026-08-30T14:59Z` but did not enter `main` until `2026-08-31T21:35Z`, so the 03:31 run could not yet see it.

**The exposure is the repeatability guarantee**, which is the documented reason this branch of the script exists:

> This ensures repeatability — manually re-running later in the day to investigate a failure gives the same build.

Re-running the 2026-08-31 nightly **today** builds `e379884d35`, a feature branch. So the investigate-a-failure path is broken right now, and the scheduled path is exposed any time a PR merges between midnight and 03:30 carrying commits dated before midnight — which is routine.

## What changed

`--first-parent` on both `git log` calls: the midnight selection and the empty-result fallback. Ten-line diff, no logic restructuring.

Also refreshes the commits/day figure the `fetch-depth: 1000` bound is justified against — the comment cited "~19 commits/day" from the squash era; it is ~40/day now (118 commits across `v26.08.28-01...v26.08.31-01`), making 1000 commits ~25 days rather than ~52. Still far past the midnight boundary, so the bound holds. `--first-parent` only *narrows* the walk, so it cannot make the shallow depth less safe.

## Testing

No unit-test harness exists for this workflow. Verified by running both forms of the command against real `origin/main` history for three consecutive nightly windows (table above), and by confirming the actual shipped `BUILD_REF` from the two most recent run logs. The `--ancestry-path` check confirming `e379884d35` entered `main` after the Aug 31 run is in the commit message.

Closes: #37202

Part of dotCMS/private-issues#673 — item 4 of 4. Item 1 (#37203) is closed, item 2 (#37200) landed in #37219, item 3 (#37201) is #37213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)