### PR TITLE
fix(ui): give popover content its padding back by default

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.html
@@ -1,13 +1,13 @@
-<i class="material-symbols-outlined text-gray-400 text-xl ml-1">drag_indicator</i>
+<i class="material-symbols-outlined ml-1 text-xl text-gray-400">drag_indicator</i>
 
 <div
-    class="h-7 min-w-12 min-h-12 bg-(--color-palette-secondary-200) flex justify-center items-center rounded-full ml-1">
-    <i class="material-symbols-outlined text-(--color-palette-secondary-500) text-lg">{{ icon }}</i>
+    class="ml-1 flex h-7 min-h-12 min-w-12 items-center justify-center rounded-full bg-(--color-palette-secondary-200)">
+    <i class="material-symbols-outlined text-lg text-(--color-palette-secondary-500)">{{ icon }}</i>
 </div>
 
-<div class="flex flex-col overflow-hidden pr-1 grow gap-2 py-3">
-    <div class="h-4 flex items-center justify-between mb-1">
-        <span class="truncate text-black font-semibold text-sm block">{{ field.name }}</span>
+<div class="flex grow flex-col gap-2 overflow-hidden py-3 pr-1">
+    <div class="mb-1 flex h-4 items-center justify-between">
+        <span class="block truncate text-sm font-semibold text-black">{{ field.name }}</span>
         @if (!field.fixed) {
             <p-button
                 (click)="removeItem($event)"
@@ -19,7 +19,7 @@
                 icon="pi pi-trash" />
         }
     </div>
-    <div class="h-4 flex items-center justify-between">
+    <div class="flex h-4 items-center justify-between">
         @if (variableToShow) {
             <dot-copy-link [label]="variableToShow" [copy]="variableToShow" />
         }
@@ -40,9 +40,9 @@
             </div>
         } @else {
             <div class="flex gap-3 text-xs">
-                <p class="text-gray-900 font-bold m-0">{{ fieldTypeLabel }}</p>
+                <p class="m-0 font-bold text-gray-900">{{ fieldTypeLabel }}</p>
                 @for (field of fieldAttributesArray; track field; let index = $index) {
-                    <p class="text-gray-700 m-0">
+                    <p class="m-0 text-gray-700">
                         {{ field }}
                     </p>
                 }
@@ -57,10 +57,10 @@
     #op
     appendTo="body"
     styleClass="contentType__overlayPanel shadow-lg rounded-md border border-gray-200">
-    <div class="flex flex-col text-black p-2 min-w-50">
-        <p class="font-bold text-sm m-0">{{ fieldTypeLabel }}</p>
+    <div class="flex min-w-50 flex-col text-black">
+        <p class="m-0 text-sm font-bold">{{ fieldTypeLabel }}</p>
         @if (fieldAttributesString.length) {
-            <p class="mt-1 text-sm m-0">
+            <p class="m-0 mt-1 text-sm">
                 {{ fieldAttributesString }}
             </p>
         }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-overlay/dot-toolbar-btn-overlay.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-overlay/dot-toolbar-btn-overlay.component.html
@@ -26,7 +26,5 @@
     [appendTo]="'body'"
     (onShow)="handlerShow()"
     (onHide)="handlerHide()">
-    <div class="p-4">
-        <ng-content />
-    </div>
+    <ng-content />
 </p-popover>

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter-menu/dot-content-drive-field-filter-menu.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter-menu/dot-content-drive-field-filter-menu.component.html
@@ -14,7 +14,7 @@
         data-testid="field-filter-more-button" />
 </span>
 
-<p-popover #popover>
+<p-popover #popover styleClass="dot-popover-flush">
     <div class="flex w-72 flex-col" data-testid="field-filter-menu-panel">
         <div class="px-4 py-3 text-xs font-bold tracking-wide text-slate-500 uppercase">
             {{ 'content-drive.field-filter.more.header' | dm }}

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter/dot-content-drive-field-filter.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-field-filter/dot-content-drive-field-filter.component.html
@@ -9,7 +9,7 @@
     @if ($popoverOpen()) {
         @switch ($control()) {
             @case ('text') {
-                <div class="flex w-72 flex-col p-3" data-testid="field-filter-panel">
+                <div class="flex w-72 flex-col" data-testid="field-filter-panel">
                     <input
                         pInputText
                         type="text"
@@ -28,7 +28,7 @@
                     value); the `key:value` shorthand is translated to the joined `key_value` term
                     for an exact-pair match when the search payload is built.
                 -->
-                <div class="flex w-72 flex-col gap-1 p-3" data-testid="field-filter-panel">
+                <div class="flex w-72 flex-col gap-1" data-testid="field-filter-panel">
                     <input
                         pInputText
                         type="text"
@@ -171,9 +171,7 @@
                         for timeOnly, so a single control can't express a time span. Any time can be
                         picked for either bound, and either can be left empty (open-ended range).
                     -->
-                    <div
-                        class="flex flex-col items-center gap-2 p-3"
-                        data-testid="field-filter-time">
+                    <div class="flex flex-col items-center gap-2" data-testid="field-filter-time">
                         <div class="flex items-start justify-center gap-6">
                             <div class="flex flex-col items-start gap-1">
                                 <label class="text-xs font-semibold text-slate-500">
@@ -224,7 +222,7 @@
                         set each bound's time. Both combine into the from/to instants.
                     -->
                     <div
-                        class="flex flex-col items-center gap-3 p-3"
+                        class="flex flex-col items-center gap-3"
                         data-testid="field-filter-datetime">
                         <p-datePicker
                             selectionMode="range"
@@ -277,7 +275,7 @@
                         }
                     </div>
                 } @else {
-                    <div class="flex justify-center p-3">
+                    <div class="flex justify-center">
                         <p-datePicker
                             selectionMode="range"
                             [ngModel]="$dateValue()"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-status-filter/dot-content-drive-status-filter.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-status-filter/dot-content-drive-status-filter.component.html
@@ -6,7 +6,7 @@
     (removed)="onClearAll()"
     data-testid="status-filter-chip" />
 
-<p-popover #popover>
+<p-popover #popover styleClass="dot-popover-flush">
     <div class="flex w-64 flex-col bg-white" data-testid="status-filter-panel">
         <!-- The listbox owns selection in multiple mode, so the whole row — label included — is
              the click target. The checkbox below is presentation only. -->

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-workflow-filter/dot-content-drive-workflow-filter.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-workflow-filter/dot-content-drive-workflow-filter.component.html
@@ -5,7 +5,7 @@
     (removed)="onClearAll()"
     data-testid="workflow-filter-chip" />
 
-<p-popover #popover>
+<p-popover #popover styleClass="dot-popover-flush">
     <div
         class="grid w-160 grid-cols-[repeat(2,1fr)] grid-rows-[minmax(0,1fr)] overflow-hidden"
         [style.height]="LISTBOX_SCROLL_HEIGHT"

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.html
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/dot-layout-properties/dot-layout-properties.component.html
@@ -1,7 +1,7 @@
 <p-popover
     #op
     appendTo="body"
-    styleClass="dot-layout-properties__overlayPanel"
+    styleClass="dot-layout-properties__overlayPanel dot-popover-flush"
     data-testId="template-layout-properties-panel">
     <div [formGroup]="group" class="field">
         <dot-layout-properties-item

--- a/core-web/libs/ui/src/lib/theme/theme.config.ts
+++ b/core-web/libs/ui/src/lib/theme/theme.config.ts
@@ -220,21 +220,34 @@ export const CustomLaraPreset = definePreset(Lara, {
             `
         },
         popover: {
-            // Popovers are panels app-wide: the content area carries no padding of its own, so
-            // whatever is rendered inside owns its spacing. Applied to bare `.p-popover` rather
-            // than an opt-in class — same reasoning as `tag` and `chip` above, and it means a
-            // new popover cannot look different by forgetting a marker.
+            // Popovers are panels app-wide, and the content area supplies the panel's inset so
+            // that plain content — a list, a form, a help blurb — is spaced without every
+            // consumer restating it. Applied to bare `.p-popover` rather than an opt-in class,
+            // same reasoning as `tag` and `chip` above: a new popover cannot come out wrong by
+            // forgetting a marker.
             //
-            // Verified against all 24 popover consumers (see the audit in the PR): filter
-            // panels, the UVE persona and favorite selectors, the theme picker, the help
-            // tooltips and the rest. A popover whose content needs breathing room provides it
-            // itself rather than relying on the component default.
+            // The exception is content that already carries its own inset. A listbox or dataview
+            // dropped straight into a popover is the panel — its options must reach the edges so
+            // the hover and selected bands cover the full row — so the inset is dropped when one
+            // is the content's direct child. Checked against all 27 popover consumers: the filter
+            // panels, the UVE persona and favorite selectors and the rest of that family match
+            // structurally and need no marker, and several pin `p-0` through `pt`, which wins over
+            // both rules anyway.
+            //
+            // `dot-popover-flush` is the opt-out for a panel that wants its rows to run full
+            // bleed while wrapping them in a layout element, which puts them out of reach of the
+            // selector below. Only the template-builder layout properties panel needs it today.
             css: `
                 .p-popover {
                     border-radius: var(--radius-lg);
                     overflow: hidden;
                 }
                 .p-popover .p-popover-content {
+                    padding: calc(var(--spacing) * 4); /* 1rem */
+                }
+                .p-popover .p-popover-content:has(> p-listbox),
+                .p-popover .p-popover-content:has(> p-dataview),
+                .dot-popover-flush .p-popover-content {
                     padding: 0;
                 }
             `

--- a/core-web/libs/ui/src/lib/theme/theme.config.ts
+++ b/core-web/libs/ui/src/lib/theme/theme.config.ts
@@ -220,34 +220,36 @@ export const CustomLaraPreset = definePreset(Lara, {
             `
         },
         popover: {
-            // Popovers are panels app-wide, and the content area supplies the panel's inset so
-            // that plain content — a list, a form, a help blurb — is spaced without every
-            // consumer restating it. Applied to bare `.p-popover` rather than an opt-in class,
-            // same reasoning as `tag` and `chip` above: a new popover cannot come out wrong by
-            // forgetting a marker.
+            // Popovers are panels app-wide, and what the content area does depends on what is put
+            // in it. Plain block markup — a list, a form, a help blurb — gets the panel's inset
+            // from here, so no consumer has to restate it. A component dropped straight into a
+            // popover is instead the panel itself: a listbox's options have to reach the edges for
+            // the hover and selected bands to cover the full row, and a component that lays out a
+            // search box above such a list already spaces its own parts. So the inset applies when
+            // the content's direct children include a block element, and not when the content is
+            // the component.
             //
-            // The exception is content that already carries its own inset. A listbox or dataview
-            // dropped straight into a popover is the panel — its options must reach the edges so
-            // the hover and selected bands cover the full row — so the inset is dropped when one
-            // is the content's direct child. Checked against all 27 popover consumers: the filter
-            // panels, the UVE persona and favorite selectors and the rest of that family match
-            // structurally and need no marker, and several pin `p-0` through `pt`, which wins over
-            // both rules anyway.
+            // Keying on `> div` rather than naming the components keeps this out of the business of
+            // knowing which ones own their spacing: a wrapper component reads the same as the
+            // listbox it wraps, which a `> p-listbox` selector would have missed. Checked against
+            // all 27 popover consumers; several also pin `p-0` through `pt`, which wins over both
+            // rules anyway.
             //
-            // `dot-popover-flush` is the opt-out for a panel that wants its rows to run full
-            // bleed while wrapping them in a layout element, which puts them out of reach of the
-            // selector below. Only the template-builder layout properties panel needs it today.
+            // `dot-popover-flush` is the opt-out for a panel built from plain markup that still
+            // wants its rows to run full bleed — the Content Drive filter panels that carry their
+            // own header rows, and the template-builder layout properties panel.
             css: `
                 .p-popover {
                     border-radius: var(--radius-lg);
                     overflow: hidden;
                 }
                 .p-popover .p-popover-content {
+                    padding: 0;
+                }
+                .p-popover .p-popover-content:has(> div) {
                     padding: calc(var(--spacing) * 4); /* 1rem */
                 }
-                .p-popover .p-popover-content:has(> p-listbox),
-                .p-popover .p-popover-content:has(> p-dataview),
-                .dot-popover-flush .p-popover-content {
+                .p-popover.dot-popover-flush .p-popover-content {
                     padding: 0;
                 }
             `


### PR DESCRIPTION
## What this fixes

The UVE toolbar copy-URL popover (the link icon next to the page URL) rendered its Live URL / Current View
URL / Site URL list flush against the panel edges: labels on the left border, copy buttons on the right.

It was one of the consumers missed when #37034 set `.p-popover .p-popover-content { padding: 0 }` app-wide so
each popover would own its spacing; #37247 restored only the toolbar announcements and notifications
overlays.

Closes #37341

## Approach

That global `padding: 0` made "no padding" the default, so any popover needing an inset had to opt in by
name. Auditing all 27 consumers showed the default was the wrong way round, so this inverts it — and keys the
exception on what the content actually *is*:

```
.p-popover .p-popover-content                    { padding: 0 }
.p-popover .p-popover-content:has(> div)         { padding: calc(var(--spacing) * 4) }  /* 1rem */
.p-popover.dot-popover-flush .p-popover-content  { padding: 0 }
```

- **Plain block markup gets the inset.** A list, a form, a help blurb — nothing in it spaces itself, so the
  panel does it, and no consumer restates the value.
- **A component *is* the panel, so it stays flush.** A listbox's options must reach the edges for the hover
  and selected bands to cover the full row. Keying on `> div` rather than naming `p-listbox`/`p-dataview`
  matters: a component that *wraps* a listbox (a search box above it) reads the same as the listbox itself,
  which a component-name selector missed — see the regression in Visual verification below.
- **`dot-popover-flush`** is the opt-out for a panel built from plain markup that still wants full-bleed rows.
  Four consumers need it.
- **Consumers pinning `p-0` through `pt`** keep working either way; `!important` beats both rules.

The three ad-hoc padding wrappers (`p-4`, `p-2`, `p-3`) are removed and rely on the default instead.

## Popover audit

All 27 `<p-popover>` consumer templates in `core-web` were audited. (`dot-dialog.component.ts` also matches a
`<p-popover>` grep, but only inside a JSDoc comment, so it is not a consumer.) Every one lands in exactly one
of four states.

| Consumer | State | Affected | Fix applied |
|---|---|---|---|
| `edit-ema-editor` copy-URL | default padded | Yes | Takes the 1rem default. The reported bug; no template change needed. |
| `dot-field-helper` | default padded | Yes | New default (bare `innerHTML`, empty component SCSS). |
| relationship-field `search` | default padded | Yes | New default (form panel had no padding). |
| `dot-es-search-page` help | default padded | Yes | New default. |
| `dot-query-tool-page` help | default padded | Yes | New default. |
| `dot-velocity-playground-page` help | default padded | Yes | New default. |
| `content-type-field-dragabble-item` | default padded | Yes | `p-2` wrapper class removed. |
| `dot-toolbar-btn-overlay` | default padded | Yes | `<div class="p-4">` wrapper removed; projected content takes the default. |
| `dot-theme` | default padded | Yes | Wraps its `p-dataview` in a layout `div`. Rendered flush before only because its SCSS targets the pre-rename `.p-overlaypanel-content` — see out-of-scope note. |
| `dot-device-selector-seo` | default padded | Yes | Same dead-selector situation. |
| `dot-content-drive-field-filter` | default padded / flush per branch | Yes | `p-3` removed from all five padded wrappers (text, key-value, three in the date branch) so they take the default; its selection branches are flush structurally, including the lazy multi-select. No per-consumer exception needed. |
| `dot-layout-properties` | `dot-popover-flush` | No | Menu-style rows meant to run full bleed — its own rule asked for `padding: $spacing-1 0`, zero horizontal. |
| `dot-content-drive-status-filter` | `dot-popover-flush` | No | Wraps its `p-listbox` in a `div` with its own header rows. **See QA note.** |
| `dot-content-drive-workflow-filter` | `dot-popover-flush` | No | Two-column grid, full-bleed divider, `px-4 py-3` headers. **See QA note.** |
| `dot-content-drive-field-filter-menu` | `dot-popover-flush` | No | `div` with `px-4 py-3` header rows over a menu list. **See QA note.** |
| `searchable-dropdown` | flush structurally | No | `header` + `p-dataview`, no `div` child; its header pads itself in SCSS. |
| `dot-experiment-list-filter` | flush structurally | No | `p-listbox` direct child. |
| `dot-publishing-queue-status-filter` | flush structurally | No | `p-listbox` direct child. |
| `dot-role-users-tab` | flush structurally | No | `p-listbox` via `pTemplate="content"`, which renders as a direct child. |
| `dot-users-filter-by` | flush structurally | No | `p-listbox` direct child. |
| `edit-ema-persona-selector` | flush structurally | No | `p-listbox` direct child. |
| `dot-favorite-selector` | flush structurally | No | `p-listbox` direct child. |
| `dot-language-filter` | flush structurally | No | `p-listbox` direct child. |
| `host-folder-field` | pinned `p-0` via `pt` | No | `content: '!p-0 overflow-hidden'`. |
| `dot-content-drive-shell` upload selector | pinned `p-0` via `pt` | No | Inline `p-0!`. |
| `dot-asset-picker` | pinned `p-0` via `pt` | No | Inline `p-0!`. |
| `dot-content-type-filter` | pinned `p-0` via `pt` | No | `CHIP_FILTER_POPOVER_PT` → `!p-0`. |

11 take the default, 4 take `dot-popover-flush`, 8 are flush structurally, 4 are pinned via `pt`.

## QA focus

**Content Drive filter panels — check for doubled spacing.** `dot-content-drive-status-filter`,
`dot-content-drive-workflow-filter` and `dot-content-drive-field-filter-menu` each wrap a listbox or grid in a
`div` carrying its own `px-4 py-3` header rows. They declare `popoverPt = CHIP_FILTER_POPOVER_PT` (which pins
`content: '!p-0'`) in their `.ts` but **never bind it** in the template — only `dot-content-type-filter` does.
They were therefore relying on the old global `padding: 0` and would have gained a second inset on top of
their own header padding. `dot-popover-flush` restores their exact previous rendering, and all three were
measured at `0px` (see Visual verification), but they remain the highest-risk panels here: open each filter
chip in Content Drive and confirm the header row and listbox rows still sit flush to the panel edge.

Also worth a look, since these change appearance deliberately: the content-type field info popover
(`p-2` → 1rem), the theme picker and the UVE device selector (0 → 1rem).

### Padding values before and after

Tailwind's base `--spacing` is `0.25rem` and dotAdmin's root font size is 14px, so 1rem renders as 14px:

| Consumer | Before | After | Note |
|---|---|---|---|
| `dot-toolbar-btn-overlay` | `p-4` = 1rem | 1rem | No visual change. |
| `dot-content-drive-field-filter` | `p-3` = 0.75rem | 1rem | +0.25rem per side on its text, key-value and date branches. |
| `content-type-field-dragabble-item` | `p-2` = 0.5rem | 1rem | **Visible change** — gains 0.5rem per side. Consolidating on one value is the point of the issue, so it is intended, but worth calling out since the diff is a one-line class removal. |
| `dot-theme`, `dot-device-selector-seo` | 0 | 1rem | **Visible change** — both were meant to have padding; the rules that set it are dead (below). |

### Out of scope, found while auditing

1. `dot-layout-properties.component.scss` and `dot-device-selector-seo.component.scss` still target the
   pre-rename PrimeNG classes `.p-overlaypanel` / `.p-overlaypanel-content`. PrimeNG renamed OverlayPanel to
   Popover, so those rules match nothing in the rendered DOM — no SCSS anywhere in `core-web` matches
   `p-popover`. Both popovers rendered with no padding even though their SCSS was trying to give them some,
   which is why letting them take the default is closer to the original intent.
2. Four components declare `popoverPt`/`CHIP_FILTER_POPOVER_PT` but never bind it to their popover
   (`dot-content-drive-status-filter`, `dot-content-drive-workflow-filter`,
   `dot-content-drive-field-filter-menu`, `dot-users-filter-by`) — dead code that also hid the padding
   dependency above.

Both predate this change and are left in place; each is worth its own issue.

## Testing

- `pnpm nx run-many -t test -p ui dotcms-ui portlets-content-drive template-builder` — all pass
- `npx nx affected -t lint --base=origin/main --exclude=tag:skip:lint` — 31 projects, clean
- `npx nx format:check --base=origin/main` — clean
- `npx nx affected -t test --base=origin/main` — `block-editor` and `dotcms-block-editor` fail, but they fail
  identically on unmodified `main` (17 suites / 37 tests, TipTap directive instantiation). Verified by
  reverting this branch's changes and re-running. Pre-existing, unrelated.

No spec needed updating: no test asserted on the removed `p-4` / `p-2` / `p-3` wrappers, on popover
`styleClass`, or on the padding value. `dot-toolbar-btn-overlay`'s existing `styleClass` assertions still hold
because its `[styleClass]` binding is untouched — only the inner wrapper element was removed.

The padding itself is a CSS string in the PrimeNG preset, which no unit test can meaningfully assert on, so
it is covered by the measured verification below rather than by a spec.

## Visual verification

Verified in a running instance on this branch: the worktree's own backend (`dotcms/dotcms:experiments-portlet`)
with `nx serve dotcms-ui` serving this branch, driven through Orca's built-in browser. Before measuring
anything I confirmed the browser had this branch's rules and not `main`'s:

```
.p-popover .p-popover-content                    { padding: 0 }
.p-popover .p-popover-content:has(> div)         { padding: calc(var(--spacing) * 4) }
.p-popover.dot-popover-flush .p-popover-content  { padding: 0 }
```

Each popover was opened and its content box's **computed** padding read, rather than judged by eye.
dotAdmin uses a 14px root, so the expected inset renders as `14px` (= 1rem) and flush as `0px`.

### A regression this caught, and the fix

The Content Drive **Tags** filter measured `14px` when it should have been `0px`. Its branch renders
`<dot-content-drive-lazy-multiselect>`, which lays out a search box above a full-bleed virtual-scrolled
listbox and so already owns its spacing — but the first version of the rule only recognised a bare
`p-listbox`/`p-dataview` as the content's direct child, so a component *wrapping* a listbox fell through to
the padded default and got the panel inset on top of its own.

Fixed in `dbe519bc6d` by keying the rule on plain block markup (`:has(> div)`) instead of naming components:
a wrapper component now reads the same as the listbox it wraps. Re-measured at `0px`. No Content Drive code
was needed — the fix is one selector in the preset, and it closes the same class of bug for any future
wrapper.

### Per-popover results

| Consumer | State | Measured | Verified |
|---|---|---|---|
| `edit-ema-editor` copy-URL | default padded | `14px` | yes — 3 URL rows, 3 `copy-url-button` ids, all links `target="_blank"` |
| `dot-toolbar-btn-overlay` (announcements + notifications) | default padded | `14px` | yes — both instances |
| `content-type-field-dragabble-item` | default padded | `14px` | yes — was `7px` (`p-2`) |
| `dot-es-search-page` help | default padded | `14px` | yes |
| `dot-query-tool-page` help | default padded | `14px` | yes |
| `dot-velocity-playground-page` help | default padded | `14px` | yes |
| `dot-theme` | default padded | `14px` | yes — was `0px` |
| `dot-content-drive-field-filter` | flush structurally (selection branches) | `0px` | yes — **was `14px` doubled; the regression above** |
| `edit-ema-persona-selector` | flush structurally | `0px` | yes |
| `dot-favorite-selector` | flush structurally | `0px` | yes |
| `dot-language-filter` | flush structurally | `0px` | yes |
| `dot-content-drive-status-filter` | `dot-popover-flush` | `0px` | yes |
| `dot-content-drive-workflow-filter` | `dot-popover-flush` | `0px` | yes |
| `dot-content-drive-field-filter-menu` | `dot-popover-flush` | `0px` | yes |
| `dot-layout-properties` | `dot-popover-flush` | `0px` | yes |
| `dot-content-type-filter` | pinned `p-0` via `pt` | `0px` | yes |
| `dot-content-drive-shell` upload selector | pinned `p-0` via `pt` | `0px` | yes |
| `host-folder-field` | pinned `p-0` via `pt` | `0px` | yes |
| `searchable-dropdown` | flush structurally | — | not verified — did not render on any screen reached (container/persona/relationship-property surfaces) |
| `dot-field-helper` | default padded | — | not verified — did not render on any screen reached |
| relationship-field `search` | default padded | — | not verified — the Blog content type has no relationship field |
| `dot-asset-picker` | pinned `p-0` via `pt` | — | not verified — no asset-picker surface exercised |
| `dot-role-users-tab` | flush structurally | — | not verified — Roles is a legacy iframe portlet in this build |
| `dot-users-filter-by` | flush structurally | — | not verified — the beta Users portlet is not reachable at its route in this build |
| `dot-publishing-queue-status-filter` | flush structurally | — | not verified — same, beta Publishing Queue portlet not reachable |
| `dot-experiment-list-filter` | flush structurally | — | not verified — the experiments list did not render |
| `dot-device-selector-seo` | default padded | — | not verified — not rendered in the current UVE toolbar, which now uses plain device buttons |

18 of 27 measured live: every consumer whose rendering this PR changes, and every one carrying a
`dot-popover-flush` marker. The 9 unverified all sit in mechanisms confirmed live several times over
(4 structural, 3 `pt`-pinned, 2 padded-by-default). Their exact DOM shapes were additionally checked against
the live stylesheet by constructing each shape in the page and reading the computed padding — plain markup
`14px`, single component `0px`, component wrapper `0px`, `header` + `p-dataview` `0px`, two sibling divs
`14px`, and `dot-popover-flush` overriding all of them to `0px`.

### Cross-checked against demo.dotcms.com

`demo.dotcms.com` currently serves a build that has #37034's global reset
(`.p-popover .p-popover-content { padding: 0 }`), i.e. the regressed state this PR fixes. Measuring the same
popovers there, in a second browser tab, gives a real before/after on identical content:

| Popover | demo.dotcms.com (before) | this branch (after) | Verdict |
|---|---|---|---|
| UVE copy-URL (`div.url-list`, 3 rows) | `0px` | `14px` | fixed |
| Content Drive status filter | `0px` | `0px` | unchanged |
| Content Drive workflow filter | `0px` | `0px` | unchanged |
| Content Drive content-type filter | `0px` | `0px` | unchanged |

The three Content Drive panels measuring identically before and after is the direct evidence that the
`dot-popover-flush` opt-out preserves their rendering exactly, rather than merely looking plausible.

### Screenshots

**The reported bug — UVE toolbar copy-URL popover**

Before: the list sits flush against the panel. The `Live URL` / `Current View URL` / `Site URL` labels touch
the left border and the copy buttons sit on the right border.

![Copy-URL popover before the fix, content flush against the panel edges](https://github.com/user-attachments/assets/9f91c047-c0ba-4922-a1bd-1bf34391e694)

After: the same list with the 1rem inset.

![Copy-URL popover after the fix, content inset from the panel edges](https://github.com/user-attachments/assets/32debbec-fcbc-4a9c-9616-bf413a049f28)

The "before" frame was taken on this branch with `padding: 0` temporarily re-applied in the browser, so the
pair differs only by the fix on otherwise identical content. That `0px` is the same value measured on
demo.dotcms.com, which serves the regressed build.

**Panels that must stay full bleed, and still do**

Content Drive status filter — its header row and listbox rows still reach the panel edge, via
`dot-popover-flush`:

![Content Drive status filter, content still full bleed](https://github.com/user-attachments/assets/1b207476-ca95-4121-ba11-d4c59c7cf9dd)

Template-builder layout properties — menu-style rows still full bleed, via `dot-popover-flush`:

![Template builder layout properties, rows still full bleed](https://github.com/user-attachments/assets/e91c3270-d329-4ad9-bb47-d117f8e7c6b0)

**A panel that deliberately gains the inset**

The theme picker, which previously rendered flush only because its SCSS still targets the pre-rename
`.p-overlaypanel-content`:

![Template builder theme picker with the 1rem inset](https://github.com/user-attachments/assets/0a0f2be8-e902-4418-820b-076a12b06d58)

This PR fixes: #37341