### PR TITLE
docs(content-drive): add backend and frontend specs for bulk file upload (#37166)

### DIFF
--- a/specs/37166-bulk-file-upload-frontend/spec.md
+++ b/specs/37166-bulk-file-upload-frontend/spec.md
@@ -1,0 +1,653 @@
+# Feature Specification: Content Drive bulk file upload — frontend
+
+**Feature Branch**: `37166-content-drive-bulk-file-upload-multi-file-selection-uploads-only-the-first-file`
+
+**Created**: 2026-08-31
+
+**Status**: Draft
+
+**Type**: New Feature
+
+**Input**: GitHub issue [dotCMS/core#37166](https://github.com/dotCMS/core/issues/37166) — "Content Drive: bulk file upload (multi-file selection uploads only the first file)", frontend half.
+
+---
+
+## Context
+
+An author picks thirty files on their computer to upload into Content Drive. They are warned that
+"only one file will be uploaded", and then one file is uploaded. The other twenty-nine are
+discarded. This specification covers the browser-side half of fixing that.
+
+Throughout this document, **choosing** files means picking them on the author's own computer, in
+the system file chooser or by dragging them in. It never means selecting rows in the Content Drive
+listing, which is a different act with a different purpose and is called **selecting rows** here.
+
+**This specification covers the client only.** The server side is delivered separately by another
+developer and is specified in `specs/37166-bulk-file-upload/spec.md` (PR
+[#37300](https://github.com/dotCMS/core/pull/37300)). The two halves meet at that spec's *Contract
+Consumed by the Client* (C-001 … C-006), restated here from the consumer's side in §Contract
+Consumed. Nothing about server behaviour is re-specified here.
+
+Fixing the upload exposes a second problem that this feature also settles. Content Drive currently
+announces "this is running" in four different ways depending on which operation the author
+triggered: a persistent marker in the portlet's toolbar, a transient notification, replacing the
+entire content listing with placeholder rows, and saying nothing at all. A bulk upload is a long
+operation and needs one of these to be right, so this feature picks the one that is right and
+converts the others to it.
+
+**Two different drags, and this feature touches both.** Content Drive accepts a drag from *outside*
+the browser — files coming in from the author's computer, which is an **upload** and is what this
+feature is for — and a drag from *inside* the listing — an existing item dragged from one folder to
+another, which is a **move** and creates nothing. They are unrelated operations that happen to share
+a gesture. Upload is the subject of this feature. Move appears only in §Requirements FR-014, as one
+of the operations converted to the shared in-flight reporting, and is the case that demonstrates two
+runs can be in flight at once (User Story 7) — which an upload on its own cannot show.
+
+It also settles a third, smaller problem that the same work uncovers. Some operations report their
+outcome by naming what ran and what it ran on ("**Publish** ran on 12 items"); others report
+"Workflow Executed" and leave the author to guess. The copy for the missing half was written and
+never connected.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Written as author-visible behaviour in the Content Drive interface. Each is verifiable in the
+  browser against a server honouring §Contract Consumed, with no knowledge of how the server
+  implements it.
+-->
+
+### User Story 1 - Every chosen file is uploaded (Priority: P1)
+
+An author brings several files in from their computer — by choosing them in the system file
+chooser, or by dropping them onto a folder — and every one of them is uploaded to that folder.
+Nothing is silently dropped, and nothing warns that the product cannot do what the author just
+asked it to do.
+
+**Why this priority**: This is the reported defect and the reason the feature exists. It is also a
+silent data-loss bug: the author is told the upload happened and believes thirty files landed when
+one did. No other story in this feature has value while this is broken.
+
+**Independent Test**: Choose ten files through the upload control, and separately drag ten files in
+from the computer and drop them onto a folder. Confirm all ten exist in that folder afterwards, in both cases, and that no "not
+supported" warning appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** an author viewing a folder they may add children to, **When** they choose several
+   files through the upload button, **Then** all of the chosen files are submitted as one batch and
+   all of them appear in the folder when the batch finishes.
+2. **Given** the same author, **When** they drag several files from their computer onto the folder,
+   **Then** the batch behaves identically to the button path.
+3. **Given** an author choosing files through the upload button, **When** the file chooser opens,
+   **Then** it permits selecting more than one file.
+4. **Given** several files chosen at once, **When** they are submitted, **Then** no message claims that
+   multiple-file upload is unsupported.
+5. **Given** a single file chosen, **When** it is submitted, **Then** the author's experience is
+   unchanged from today.
+6. **Given** an author viewing a folder they may **not** add children to, **When** they look for a
+   way to upload into it, **Then** every route in is offered disabled with the reason shown, rather
+   than hidden or left to fail after they have chosen files.
+7. **Given** that same folder, **When** the author drops files onto it anyway, **Then** nothing is
+   submitted and they are told why.
+
+---
+
+### User Story 2 - The author is told what actually happened (Priority: P1)
+
+When a batch finishes, the author is told how many files were created and how many were not. If
+some failed, the message names them and says why, and stays on screen long enough to be read.
+
+**Why this priority**: A partial failure is the normal case for a batch of thirty files, not the
+exception: one will be too large, one will have a file type that is not allowed, one will collide
+with an existing name. Uploading all thirty (Story 1) while reporting "upload complete" over three
+silent failures reproduces the original defect in a new place.
+
+**Independent Test**: Submit a batch containing valid files, one oversized file and one whose file
+type is not allowed. Confirm the resulting message reports the true counts and names both failing
+files with a distinguishable reason each.
+
+**Acceptance Scenarios**:
+
+1. **Given** a finished batch where every file succeeded, **When** the outcome is reported,
+   **Then** the count shown is the count the server reported, never the number of files the author
+   chose.
+2. **Given** a finished batch where some files failed, **When** the outcome is reported, **Then**
+   the message names each failed file and gives a reason for each.
+3. **Given** a finished batch where some files failed, **When** the outcome is reported, **Then**
+   it remains readable for longer than a fully successful outcome does.
+4. **Given** a batch where every file failed, **When** the outcome is reported, **Then** it is
+   presented as a failure and not as a completed operation.
+5. **Given** a finished batch, **When** the outcome is reported, **Then** the content listing
+   refreshes exactly once, not once per file.
+
+---
+
+### User Story 3 - Work in progress is reported without taking over the screen (Priority: P1)
+
+While any long operation runs, the author can see what is running and what it is running on, in one
+consistent place, and can carry on looking at their content while it does.
+
+**Why this priority**: A bulk upload runs long enough that the author will look for evidence it is
+happening, so this is load-bearing for Story 1 rather than decorative. It also removes the worst of
+the current behaviours: firing a workflow action on one right-clicked row today replaces the entire
+listing with placeholder rows, which hides the very row the author acted on and is
+indistinguishable from an ordinary page load.
+
+**Independent Test**: Start a batch upload, then move existing items between folders, then fire a
+workflow action from the row context menu. In all three cases confirm the in-flight state appears
+in the same place, the listing stays rendered, and no transient notification announces the start.
+
+**Acceptance Scenarios**:
+
+1. **Given** any operation that outlives the surface that triggered it, **When** it starts, **Then**
+   its in-flight state is reported in the portlet's persistent toolbar indicator.
+2. **Given** any such operation, **When** it starts, **Then** no transient notification announces
+   that it has started.
+3. **Given** a workflow action fired from a row's context menu, **When** it is running, **Then** the
+   content listing remains rendered and the acted-on row remains visible.
+4. **Given** an operation running on exactly one item, **When** its in-flight state is shown,
+   **Then** it names both the action and the item it is running on.
+5. **Given** an operation running on several items, **When** its in-flight state is shown, **Then**
+   it names the action and the number of items.
+6. **Given** a run whose progress the server reports, **When** it is in flight, **Then** the
+   indicator shows how far it has got; **and given** a run whose progress is not reported, **Then**
+   it shows activity without claiming a false position.
+7. **Given** an operation started from a dialog, **When** that dialog closes, **Then** the operation
+   continues and its in-flight state remains visible.
+
+---
+
+### User Story 4 - Leaving does not lose the batch (Priority: P2)
+
+An author who starts a large upload and then goes to do something else still learns how it went.
+
+**Why this priority**: The direct consequence of making upload a long operation. An author who must
+sit and watch a thirty-file upload has been given a worse product than the one that uploaded one
+file quickly.
+
+**Independent Test**: Start a batch, navigate away from the folder and from the portlet, and
+confirm the outcome still reaches the author when the batch finishes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running batch, **When** the author browses to another folder, **Then** the batch
+   continues and its in-flight state remains visible.
+2. **Given** a running batch, **When** the author leaves the portlet entirely, **Then** the batch
+   continues and its outcome still reaches them when it finishes.
+3. **Given** a batch that finished while the author was elsewhere, **When** they are notified,
+   **Then** the notification does not disturb whatever they are in the middle of doing.
+4. **Given** a run started by a different author or a different session, **When** its outcome is
+   broadcast, **Then** this author's interface does not report it as their own.
+
+---
+
+### User Story 5 - A running batch can be stopped (Priority: P4 — OPTIONAL, deferred to the task manager)
+
+An author who realises they picked the wrong folder, or the wrong hundred files, can stop the batch
+without waiting for it to finish.
+
+**Why this priority**: Deliberately deferred, and it is the one story that may not ship with this
+feature. The *need* is real — it is the cost of making upload a long operation — but the *design* is
+not settled, and it is already owned elsewhere.
+[#33331](https://github.com/dotCMS/core/issues/33331) — *"[EPIC] Task manager UI to manage large
+uploads and moves"* — covers exactly this, and says so in its own words: *"From this task manager
+UI, we can also enable the user to cancel individual file uploads, or cancel the whole upload or
+move."* A list of running tasks is the natural home for stopping one: it is where the author goes to
+act on background work, it can show every run rather than only the one this portlet started, and it
+does not have to squeeze a destructive-adjacent control into a status indicator. Building a stop button on the toolbar now risks building the wrong thing in the wrong
+place, and then having to remove it.
+
+Deferring is cheap and reversible. The server capability is fully specified and will exist whether
+or not this ships (backend FR-025 … FR-028, C-004), so adopting it later — here or in #33331 —
+needs no server work and no change to anything else in this feature. Nothing else here
+depends on it. Build what is certain first.
+
+Depends on Story 3, since the indicator is the only surface still present once the dialog that
+started the run has closed, which is also why its design is the open question.
+
+**Independent Test** *(applies only if this story is built)*: Start a batch of many files, stop it
+partway, and confirm the author is told it was stopped and how far it reached.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running batch, **When** the author asks to stop it, **Then** the request is accepted
+   and the batch stops.
+2. **Given** a cancelled batch, **When** its outcome is reported, **Then** it is presented as
+   cancelled rather than as a success or a failure, and reports how far it reached.
+3. **Given** a cancelled batch, **When** the listing refreshes, **Then** the files already created
+   are present.
+4. **Given** an operation that cannot be stopped, **When** it is in flight, **Then** no stop control
+   is offered for it.
+
+---
+
+### User Story 6 - Every outcome says what ran and what it ran on (Priority: P2)
+
+Whatever the author did — a workflow action, a folder created, a folder renamed, a lock — the
+message afterwards names the operation and the thing it happened to.
+
+**Why this priority**: Independent of the upload work and shippable on its own, which is why it is
+not P1. It is in this feature because the upload work sets the standard the rest should match, and
+because the copy for the missing cases was already written and never connected, so the gap is a
+loose end rather than a new design.
+
+**Independent Test**: Trigger a workflow action from the context menu, create a folder, rename a
+folder, and fail a lock. Confirm each resulting message names the operation and the item.
+
+**Acceptance Scenarios**:
+
+1. **Given** any completed operation, **When** its outcome is reported, **Then** the message names
+   the operation and the item or count it applied to.
+2. **Given** any failed operation, **When** its outcome is reported, **Then** the message likewise
+   names the operation and the item.
+3. **Given** any operation's outcome, **When** it is shown, **Then** every word of it is
+   translatable, with no untranslated literal text.
+4. **Given** an operation that failed on the server, **When** the author is told, **Then** they are
+   shown resolved product copy rather than a raw server message, and the raw detail is available to
+   support through the logs.
+
+---
+
+### User Story 7 - One operation does not block another (Priority: P3)
+
+An author who starts a long upload can still lock a row, fire a workflow action, or move existing
+items between folders while it runs.
+
+**Why this priority**: A refinement rather than a defect on its own, but it is what stops the
+upload work from making the portlet feel *worse*. Today only one operation may be in flight at a
+time, which is tolerable when operations take a second and unacceptable when one of them takes
+minutes.
+
+**Independent Test**: Start a batch upload of many files, and while it runs, successfully fire a
+workflow action on rows selected in the listing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running batch upload, **When** the author starts an unrelated operation, **Then** it
+   is accepted and runs.
+2. **Given** two operations in flight, **When** their in-flight state is shown, **Then** the author
+   can tell that two things are running and what they are.
+3. **Given** a running operation, **When** the author tries to fire the same operation again over
+   the same items, **Then** it is refused.
+4. **Given** several operations finishing, **When** each reports its outcome, **Then** each outcome
+   names its own operation and is not confused with another's.
+
+---
+
+### Edge Cases
+
+- An author selects more files than the configured maximum, or a set of files whose total size
+  exceeds the configured ceiling. Either refusal says which limit was hit rather than failing
+  opaquely: "too many files" and "too much data" are different problems with different fixes. The
+  count refusal lands before anything is uploaded. The size refusal only does so when the client
+  declares the batch total (FR-038); the server's authoritative check runs while it reads the
+  content (backend FR-013c.2), so an undeclared over-ceiling batch is refused only after the author
+  has watched it upload. That is the case the copy has to survive.
+- The connection drops while a batch is being submitted, so the author cannot tell whether it
+  landed. Retrying is safe and the interface says so, rather than leaving them to check the folder
+  and guess.
+- An author selects zero files, or cancels the file chooser after opening it. Nothing is submitted
+  and nothing is reported.
+- A batch is submitted and the server refuses it for lack of permission on the target. The author is
+  told they lack permission, distinguishably from a malformed submission.
+- The connection carrying progress drops mid-run. The author is not told the run failed, because the
+  client has no evidence that it did.
+- A run finishes while the author has a dialog open. The outcome does not interrupt them mid-task.
+- A finished run reports counts that do not add up to the number of files submitted. No count is
+  invented to fill the gap.
+- A content item's title contains markup. It is displayed as text wherever the interface names it,
+  and cannot alter the surrounding interface.
+- An author uploads to the root of a site rather than into a folder. The site is the target.
+- The same author has the portlet open in two tabs. A run submitted in one is not reported as the
+  other's.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Choosing files and submitting them**
+
+- **FR-001**: Both ways of bringing files in from the author's computer — the upload control, which
+  opens the system file chooser, and dropping files onto a folder — MUST accept more than one file.
+- **FR-002**: Every file the author chose MUST be submitted as one batch. No file may be discarded, and no
+  file may be uploaded without the author having chosen it.
+- **FR-003**: One upload type MUST be resolved for the whole batch before submitting. Where the
+  target folder does not determine it, the author MUST be asked once for the batch, not once per
+  file.
+- **FR-004**: The interface MUST NOT tell the author that multi-file upload is unsupported, and the
+  copy saying so MUST be removed.
+- **FR-005**: The single-file upload experience MUST remain unchanged.
+- **FR-006**: The client MAY refuse a batch that exceeds the configured maximum file count, or the
+  configured total size ceiling, before submitting it, as a convenience. The server remains the
+  point of enforcement, and the client MUST NOT treat its own check as authoritative.
+- **FR-038**: The client MUST declare the batch's total size when it submits. The server's fast
+  refusal of an over-ceiling batch exists only where the caller declares a total (backend
+  FR-013c.1); without one the only enforcement left is the authoritative check taken while the
+  content is read (backend FR-013c.2), which refuses the batch after the author has already uploaded
+  it. The declared total is a courtesy to the author, not a limit the client enforces: FR-006 still
+  applies, and the client MUST NOT treat its own arithmetic as authoritative.
+- **FR-037**: When the connection is lost or the answer is uncertain while a batch is being
+  submitted, the client MUST be able to resubmit the same batch, and MUST NOT make the author work
+  out whether the first attempt landed. Resubmitting cannot produce a second copy of their files:
+  the server either recognises the resubmission as the same batch or refuses the duplicates
+  (backend FR-040, C-002a). The client therefore treats an uncertain submission as retryable, not
+  as a failure the author has to reason about, and never asks them to check the folder first.
+  Where the server takes the collision branch, the client depends on a duplicate resubmission being
+  distinguishable from a genuinely all-collided batch (backend FR-040a, C-002a), and MUST report
+  such a retry as the success it is rather than as "every file failed, file already exists".
+- **FR-034**: The existing permission gate MUST continue to hold, unchanged, for every route into an
+  upload: the upload control, the create menu, and dropping files onto a folder. An author without
+  the right to add children to the target MUST be shown that route disabled **with the reason
+  given**, rather than the route being hidden or being offered and then failing after they have
+  chosen their files. A drop onto a target they may not add children to MUST be refused before
+  anything is submitted, with the reason. This includes the site root, whose permission is resolved
+  separately from a folder's because the root has no folder to carry it. As with FR-006, this gate
+  is an affordance: the server remains the point of enforcement (backend FR-003, FR-004), and the
+  client MUST NOT treat its own check as authoritative.
+
+  *This requirement protects existing behaviour rather than adding any. It is stated because this
+  feature changes the upload control and the drop path directly, so the gate is squarely in the
+  blast radius.*
+
+**Reporting work in progress**
+
+- **FR-007**: Any asynchronous operation that outlives the surface that triggered it MUST report its
+  in-flight state in the portlet's persistent toolbar indicator.
+- **FR-008**: In-flight state MUST NOT be reported as a transient notification. Transient
+  notifications are reserved for terminal states.
+- **FR-009**: The content listing's own loading state MUST mean only that the listing is being
+  fetched. No operation may use it to report its own progress.
+- **FR-010**: The in-flight indicator MUST name the operation and what it is being applied to: the
+  item, when there is one item; the number of items otherwise.
+- **FR-011**: Any content-supplied text the indicator displays MUST be rendered as text and MUST NOT
+  be able to introduce markup into the interface.
+- **FR-012**: The indicator MUST show a run's position when the server reports progress, and MUST
+  show activity without claiming a position when it does not.
+- **FR-013**: A run MUST survive the closing of the dialog, menu or control that started it, and
+  MUST survive the author browsing to another folder within the portlet.
+- **FR-035**: The in-flight indicator MUST remain announced to assistive technology, and the
+  additions this feature makes to it MUST NOT make it noisy. Specifically: a run starting, reaching a
+  terminal state, or being stopped are worth announcing; continuous progress is not, and MUST NOT be
+  announced on every update. Where progress is shown, its current value MUST be available to
+  assistive technology on request, so a user can ask for it without having it pushed at them
+  repeatedly. This holds when several runs are in flight, which is when the risk of a chatty live
+  region is highest.
+- **FR-014**: The following MUST be converted to FR-007: bulk upload; moving existing Content Drive
+  items from one folder to another by dragging them; and firing a workflow action from a row's
+  context menu.
+
+**Several operations at once**
+
+- **FR-015**: More than one operation MUST be able to be in flight at the same time, and one MUST
+  NOT prevent an unrelated one from starting.
+- **FR-016**: The guard preventing an operation being fired twice over the same items MUST apply to
+  that operation and those items, not to the portlet as a whole.
+- **FR-017**: The indicator MUST have a defined behaviour for several concurrent runs that lets the
+  author tell how many things are running and what they are.
+
+**Stopping a run** *(this whole group is OPTIONAL — see User Story 5. Stopping is expected to be
+delivered by the task manager epic [#33331](https://github.com/dotCMS/core/issues/33331) rather than
+by this feature.)*
+
+- **FR-018** *(optional)*: A run the server reports as stoppable MAY offer the author a way to stop
+  it, from the in-flight indicator. Deferred pending a settled design for that control.
+- **FR-019** *(optional)*: A run that reaches a stopped state SHOULD be reported as stopped,
+  distinctly from success and from failure, and report how far it reached. Deferred with the rest of
+  this group. The safety net while it is deferred is FR-024: a stopped run is a terminal state the
+  client does not handle, so it degrades to an error rather than to a green success.
+- **FR-020** *(optional, applies only if FR-018 is built)*: A run that cannot be stopped MUST NOT
+  offer a control that does nothing.
+
+**Reporting the outcome**
+
+- **FR-021**: A terminal state — finished, partially finished, failed, or stopped — MUST be reported
+  to the author as a transient notification.
+- **FR-022**: Every count reported MUST be the server's count. The number of items the author
+  selected MUST NOT be used as a stand-in for the number the operation actually affected.
+- **FR-023**: A partial outcome MUST name the items that did not succeed and give a reason for each,
+  and MUST remain readable longer than a clean success does. This holds for **both** surfaces the
+  outcome reaches: the transient notification shown while the author is present, and the durable
+  record they can read afterwards (C-006). Neither may degrade to counts alone, because the file
+  names are what tell an author which files to choose again.
+- **FR-023a**: Reasons MUST be **grouped**, not repeated once per file: "3 files were larger than
+  the limit, 1 already existed" rather than four rows carrying four reasons. A batch of 50 that
+  wholly fails MUST read as one statement about the batch, not as 50 identical rows. Failing file
+  names MUST still be recoverable from the outcome; grouping governs how it reads, not what it
+  carries.
+- **FR-036**: Every failure reason the server can return MUST have its own product copy on the
+  client. The server sends a machine-readable reason plus a diagnostic message; the reason is what
+  the client maps to text for the author, and the message is never shown (FR-030, backend FR-016a).
+  The reasons the client MUST be able to speak to are: the file is larger than the limit; the file
+  type is not allowed; a file with that name already exists; the author may not create that file;
+  the staged content is no longer available; and an unclassified failure. A reason with no copy is
+  a hole the author sees, so the unclassified case MUST also read as a real sentence rather than a
+  fallback for a reason nobody wrote. **Adding a reason later is a change to both halves**, never
+  to the server alone. A name collision is **case-insensitive** (backend FR-042a): `Report.pdf` and
+  `report.pdf` are one contended name, so the client MUST NOT present collision as case-sensitive,
+  and any alternative name it suggests MUST differ by more than case.
+- **FR-039**: Copy about what may be uploaded MUST describe a **file type** rule, never a file
+  extension one: the server resolves the media type by detection and content sniffing rather than by
+  trusting the name, so renaming a file does not get it past the rule (backend FR-012a). Where the
+  media type cannot be resolved the server skips the check and accepts the file (backend FR-012b),
+  so no copy may tell the author that every file is checked.
+- **FR-024**: An outcome the client cannot account for — counts that do not close, a response
+  carrying no outcome, or a terminal state the client does not recognise — MUST be reported as an
+  error. No number may be invented to fill a gap, and an unrecognised outcome MUST NOT be reported
+  as a success. This is what makes deferring FR-019 safe.
+- **FR-025**: The content listing MUST refresh once when a run reaches a terminal state, not per
+  item.
+- **FR-026**: An outcome arriving while the author is in the middle of something else MUST NOT
+  interrupt them.
+- **FR-027**: The client MUST only report outcomes for runs it started. An outcome broadcast to this
+  author from another session, tab or context MUST NOT be reported as this one's.
+
+**What the outcome says**
+
+- **FR-028**: Every operation's outcome MUST name the operation and the item or count it applied to,
+  on success and on failure alike.
+- **FR-029**: All author-visible text MUST be translatable. No literal untranslated text may reach
+  the interface.
+- **FR-030**: Raw server messages MUST NOT be shown to the author. Resolved product copy is shown;
+  the raw detail is logged.
+- **FR-031**: Message definitions that this work makes reachable MUST be connected, and definitions
+  it makes obsolete MUST be removed. No definition may be left defined and unreferenced.
+
+**Reuse**
+
+- **FR-032**: The capability for following a long server-side run — submit, follow, report progress,
+  report the terminal state and outcome, stop — MUST be expressed generically, with no knowledge of
+  uploads or of Content Drive, so that the folder copy and bulk delete work
+  ([#37062](https://github.com/dotCMS/core/issues/37062) /
+  [#37063](https://github.com/dotCMS/core/issues/37063)) can adopt it unchanged.
+- **FR-033**: The interface MUST NOT require a general-purpose background-jobs screen for any of the
+  above.
+
+### Key Entities
+
+- **Chosen files**: What the author picked on their own computer before submitting — the files
+  themselves, the target folder or site in Content Drive to put them in, and the one upload type
+  for the batch.
+- **Run**: One operation the author started that the interface is still tracking. Holds what is
+  being applied, what it is being applied to, its position when known, and whether it can be
+  stopped. Several may exist at once. Outlives the surface that created it.
+- **Run outcome**: A run's terminal state and what came of it — the server's counts, and the
+  per-item results with a reason for each that did not succeed.
+
+---
+
+## Contract Consumed *(mandatory — the boundary with the server half)*
+
+The server half is specified in `specs/37166-bulk-file-upload/spec.md`. This is that spec's
+*Contract Consumed by the Client*, restated from this side so the boundary is reviewable from
+either document. Each item is a dependency of this feature, not a requirement of it.
+
+- **C-001** — Submit several files with one target and one upload type, answered immediately with a
+  handle. *Consumed by* FR-002.
+- **C-002** — Distinguishable submission refusals: no files, bad upload type, missing target, too
+  many files, batch over the total size ceiling, permission denied. *Consumed by* FR-006, FR-034
+  and the edge cases.
+- **C-002a** — A defined answer to "the connection dropped while I was submitting, may I retry?"
+  The client may resubmit without risking a second copy of the author's files. *Consumed by*
+  FR-037. Which mechanism provides it, the same handle returned or the duplicates refused as
+  collisions, is fixed in the plan; the client only depends on retry being safe. If the plan takes
+  the collision branch, the client additionally depends on a duplicate resubmission being
+  distinguishable from a genuinely all-collided batch (backend FR-040a). Without that, a successful
+  retry reports as "every file failed" and FR-037 cannot hold.
+- **C-002b** — A stable set of failure reasons, each mapped to product copy on the client side. The
+  server's message is diagnostic and is not displayed. *Consumed by* FR-036. Adding a reason later
+  changes both halves.
+- **C-003** — Readable progress for a run in flight. *Consumed by* FR-012.
+- **C-004** — A way to stop a run in flight. **Not consumed in this pass.** The whole stopping group
+  (FR-018 … FR-020) is optional and expected to be delivered by the task manager epic #33331. Noted
+  here so the boundary stays complete and so it is clear that adopting it later requires no server
+  change.
+- **C-005** — A readable terminal state and outcome: counts plus per-item results with a reason and
+  a message. *Consumed by* FR-021 … FR-024.
+- **C-006** — A pushed completion signal carrying the run's outcome, reaching the browser without
+  the client polling, plus a durable record of that same outcome. **Outcome means counts *and* the
+  per-file results**, each failure carrying its reason: that is what backend FR-014 … FR-016
+  record, and what backend FR-020 entitles the author to read after the fact. *Consumed by*
+  FR-023, FR-026, FR-033.
+
+**What C-006 buys this feature**: the outcome survives the author walking away without the client
+building anything to make that true. The client renders the pushed signal while the author is
+present; the durable record is the server's responsibility. This is why FR-033 can hold.
+
+**Why the wording matters**: both specs previously summarised this as "the run's counts", which says
+less than backend FR-014 … FR-016 actually record. A counts-only durable record would leave an
+author who stepped away with "27 of 30 created" and no way to learn which three, which FR-023
+forbids. The per-file results are already in the contract; this states it so no plan reads the
+summary and builds the thinner thing.
+
+**Not settled at this altitude**: the concrete submission format — field names, the endpoint, and
+the shape of the handle. Both halves are being built by different developers, so this MUST be
+agreed and written down during planning, and both plans MUST reference the same definition. It is
+recorded here as a planning obligation so it cannot be discovered during review.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An author choosing N files on their computer gets N files uploaded. Today they get
+  one, and this is measured from what the author picked, not from what the interface chose to
+  submit.
+- **SC-002**: The number of distinct ways the product reports "this is running" in Content Drive
+  goes from four to one.
+- **SC-003**: No operation removes the content listing from the screen in order to report its own
+  progress. Measured as zero occurrences across every operation the portlet offers.
+- **SC-004**: Every author-visible outcome names the operation and what it applied to. Measured as
+  100% of outcome messages, success and failure alike.
+- **SC-005**: Every count an author is shown matches the count the server reported for that run, in
+  every case including partial failure and cancellation.
+- **SC-006**: An author who starts a batch and leaves the portlet still learns its outcome.
+- **SC-007**: Starting a long operation never prevents an author from starting an unrelated one.
+- **SC-008**: The run-following capability is adopted by #37062 / #37063 without modification to it.
+- **SC-009**: No message definition used by Content Drive is left defined and unreferenced, and none
+  referenced is left undefined.
+- **SC-010**: An author without the right to add children to a target cannot reach an upload into it
+  by any route, and in every case is told why rather than being left to discover it.
+- **SC-011**: An author using a screen reader learns that work started and how it ended, and is not
+  interrupted repeatedly while it runs.
+- **SC-012**: Every failure reason the server can return renders as product copy the author can act
+  on. Measured as zero reasons that fall through to a blank, a code, or a raw server message.
+
+---
+
+## Legacy Considerations *(dotCMS-specific — mandatory)*
+
+- **Existing behavior touched**: The Content Drive portlet, which is modern rather than legacy
+  surface. Three shared pieces are also touched, and each has a second consumer that must not
+  regress: the folder list view and the upload control are both shared with the AssetPicker work
+  ([#36702](https://github.com/dotCMS/core/issues/36702),
+  [#37207](https://github.com/dotCMS/core/issues/37207)); the shared execution state is consumed by
+  the Action Center. Two of the operations sharing the toolbar indicator — adding to a bundle and
+  push publishing — reach older server endpoints that report their outcome in a different shape.
+  Those endpoints are not changed here, but the indicator and outcome rules apply to them, so their
+  existing reporting behaviour must be preserved as it is adapted.
+- **Backward-compatibility expectations**: The single-file upload experience must be unchanged
+  (FR-005). The AssetPicker must not regress through the shared components. Message definitions may
+  be removed only where they are proven unreferenced (FR-031). No new permission concept is
+  introduced: the right to upload a batch is the existing right to add children to the target, and
+  the existing gate on every route into an upload must survive this work unchanged (FR-034).
+- **Known related decisions**: The bulk reindex work established the precedent this feature follows
+  — a long operation is submitted, answered immediately, and its completion is pushed to the author
+  rather than polled for. The Action Center established the other one: execution state is held by
+  the portlet rather than by the dialog that started it, so a run survives its dialog closing. This
+  feature generalises both rather than inventing a third approach. `/speckit-plan` will consult
+  `dotCMS/platform-adrs` formally.
+
+---
+
+## Out of Scope
+
+- **The server-side implementation of #37166.** Delivered separately; this feature consumes
+  §Contract Consumed and specifies nothing about how the server satisfies it.
+- **Per-item in-flight marking in the listing.** Showing *which* individual rows an operation is
+  acting on, rather than only *what* is running, is a separate mechanism with its own semantics to
+  settle. It is excluded because **this feature cannot exercise it**: an upload has no rows, since
+  the items do not exist until the run creates them. Its real first consumers are the context menu,
+  the drag-and-drop move between folders, and the Action Center. Filed as
+  [#37322](https://github.com/dotCMS/core/issues/37322).
+- **Bulk reindex's reporting.** Its exclusion from the in-flight indicator is a deliberate existing
+  decision, and the notification record already covers its outcome. Unchanged here.
+- **Directory upload.** Dropping a whole folder from the author's computer and recreating its
+  hierarchy inside Content Drive. Deferred by #37166.
+- **Resumable or chunked single-file upload.**
+- **A general-purpose background-jobs management screen** (FR-033). One is owned by
+  [#33331](https://github.com/dotCMS/core/issues/33331) and is the expected home for stopping a run
+  (User Story 5), but this feature must not depend on it existing, and does not build it.
+- **Mixing upload types within one batch** (FR-003).
+
+---
+
+## Planning Obligations
+
+- **Test coverage** (Constitution V). The plan MUST name which layers this feature exercises and
+  which it does not, with the reason for each omission. Silence is not an acceptable answer to
+  Principle V. At minimum it MUST say what is covered by component and store unit tests
+  (Jest/Spectator), what is covered end to end (Playwright, extending the existing
+  `apps/dotcms-ui-e2e/src/tests/content-drive` suite), and how the pushed completion signal (C-006)
+  and the in-flight reporting (User Story 3) are exercised, since neither is reachable from a unit
+  test of a single component. The per-story **Independent Test** steps above are acceptance criteria
+  for a reviewer, not a substitute for this.
+- **The submission format**, already recorded in §Contract Consumed: field names, the endpoint and
+  the shape of the handle are not settled at this altitude, and the two halves are being built by
+  different developers, so both plans MUST reference one written definition. This now also covers
+  how the client declares the batch total that FR-038 requires.
+- **Progress readback is the riskiest dependency.** User Story 3 is P1 and rests on C-003, which the
+  backend spec now carries as its *first* Planning Obligation and its largest piece of hidden work:
+  the job framework's outcome shape is emitted once at the terminal state and cannot serve a run
+  that must read its own progress back, so a store for it is either a framework capability or
+  feature-owned. The frontend plan MUST NOT assume progress readback is free, and MUST say what
+  User Story 3 degrades to if it arrives later than the rest of the feature.
+
+---
+
+## Assumptions
+
+- The server half honours §Contract Consumed. Where it does not yet, this feature's stories are
+  blocked rather than worked around: no client-side polling loop, retry ladder or count estimation
+  is introduced to compensate.
+- Because C-006 provides a pushed signal, the client does not poll for a run's completion. It may
+  still read progress while the author is present.
+- The concurrent-run display (FR-017) defaults to naming each run while there are few, and
+  collapsing to a count beyond that. The exact threshold is a design choice for planning, not a
+  requirement.
+- Stopping a run is expected to arrive with the task manager epic #33331 rather than in this
+  feature. If it were instead built here, it would live on the in-flight indicator, since once the
+  dialog that started a run has closed the indicator is the only surface still representing it.
+  That placement is the open question, and #33331 is the likelier answer to it.
+- An outcome is reported once, by whichever part of the interface is responsible for presenting it,
+  rather than by each surface that knows about the run.
+- Removing a message definition is safe only where it is unreferenced across the whole client, not
+  merely within Content Drive.
+- The per-batch file count and per-file size limits are configured and enforced on the server. The
+  client learns of them through refusals rather than holding its own copy.
+- Authors reaching this are back-office users on a maintained desktop browser; no additional
+  compatibility target is introduced.

--- a/specs/37166-bulk-file-upload/spec.md
+++ b/specs/37166-bulk-file-upload/spec.md
@@ -1,0 +1,757 @@
+# Feature Specification: Content Drive bulk file upload — backend
+
+**Feature Branch**: `37166-content-drive-bulk-file-upload-multi-file-selection-uploads-only-the-first-file`
+
+**Created**: 2026-08-31
+
+**Status**: Draft
+
+**Type**: New Feature
+
+**Input**: GitHub issue [dotCMS/core#37166](https://github.com/dotCMS/core/issues/37166) — "Content Drive: bulk file upload (multi-file selection uploads only the first file)".
+
+---
+
+## Context
+
+Content Drive already lets a user select or drag several files at once. It accepts the whole
+selection, warns that "only one file will be uploaded", uploads **the first file**, and silently
+discards the rest. Every layer above the upload request already carries the full set — what is
+missing is a way to submit a batch, and anything on the server able to receive one.
+
+**This specification covers the server side only.** The browser-side work of #37166 — removing
+the "not supported" stub, showing batch progress, and reporting the outcome in the interface — is
+delivered separately by another developer. The two halves meet at the contract this spec defines
+(§Contract Consumed by the Client), which is therefore a mandatory, not incidental, output.
+
+The same contract is reused by the folder copy and bulk delete work
+([#37062](https://github.com/dotCMS/core/issues/37062) /
+[#37063](https://github.com/dotCMS/core/issues/37063)). Neither of those is built yet, so **this
+feature generalizes the outcome shape the bulk refresh work already ships and they consume it**
+(decision recorded in §Decisions, Q1 — note this reverses the dependency direction #37166 states,
+which is why that issue needs amending).
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  These are the server's behavior, described from the perspective of the author whose action
+  reaches it. Each is verifiable against the server alone — by integration/Postman tests — with
+  no browser involved.
+-->
+
+### User Story 1 - A batch of files is accepted and every file is created (Priority: P1)
+
+An author's multi-file selection reaches the server as one batch naming a target folder and one
+upload type. The server accepts it immediately, creates every file in that folder, and records
+the outcome of the run.
+
+**Why this priority**: This is the reported gap, and nothing else in the feature has value until
+the batch actually uploads. Today the product silently drops user data — the author believes 30
+files were uploaded when 29 were discarded.
+
+**Independent Test**: Submit a batch of 10 valid files against a folder the author can add
+children to; confirm the submission is accepted at once, and that all 10 exist in that folder
+when the run reports itself finished.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid batch of 10 files and a folder the author may add children to, **When** the
+   batch is submitted, **Then** the server accepts it immediately with a handle the caller can
+   use to follow and cancel the run — it does not hold the caller until the files are created.
+2. **Given** an accepted batch of 10 files, **When** the run finishes, **Then** all 10 files
+   exist in the target folder.
+3. **Given** any file in a batch, **When** it is created, **Then** the resulting content is
+   indistinguishable from uploading that same file through the existing single-file upload — same
+   resolved content type, same permissions applied, same workflow behavior.
+4. **Given** a batch submitted at a site root rather than inside a folder, **When** the run
+   finishes, **Then** the files land on that site, matching existing single-file behavior.
+5. **Given** the existing single-file upload, **When** this feature ships, **Then** its endpoint
+   and behavior are unchanged.
+
+---
+
+### User Story 2 - A failing file does not take the batch down with it (Priority: P1)
+
+A batch routinely contains a file that is too large, has a disallowed file type, or collides with an
+existing name. The run continues past it and records, per file, what happened and why.
+
+**Why this priority**: Partial failure is the normal case at these batch sizes, not an edge case.
+A run that aborts at the first bad file, or records only "upload failed", leaves the author unable
+to tell what landed — barely better than today.
+
+**Independent Test**: Submit 5 files of which 2 are invalid (one over the size limit, one with a
+disallowed file type); confirm the 3 valid files are created and the recorded outcome reports 3
+succeeded / 2 failed, naming both failures with a distinguishable reason.
+
+**Acceptance Scenarios**:
+
+1. **Given** a batch containing a file that fails validation, **When** the run proceeds, **Then**
+   every remaining file is still attempted.
+2. **Given** a finished run, **When** its outcome is read, **Then** it carries a success count, a
+   failure count, a skipped count, and a per-file record.
+3. **Given** a file that failed, **When** its record is read, **Then** it names the file, marks it
+   failed, and carries both a machine-readable reason and a human-readable message.
+4. **Given** a batch where every file fails, **When** the run finishes, **Then** the outcome shows
+   zero successes and names every failure — the run is not recorded as a success.
+5. **Given** a file its content type would reject for size, **When** the run reaches it, **Then**
+   that file is recorded as failed with a size-specific reason and the batch continues — and the
+   same file uploaded alone is rejected too, for the same reason.
+6. **Given** a file whose name collides with an existing asset in the target folder, **When** the
+   run reaches it, **Then** it is recorded as that file's failure — never a silent success and
+   never a silent overwrite.
+7. **Given** a content type that declares no size ceiling, and a file larger than the configurable
+   fallback, **When** the run reaches it, **Then** that file is recorded as failed for size and the
+   batch continues — **and the same file uploaded alone succeeds**. This is the one place the
+   feature knowingly diverges from single-file behavior (FR-011a); it has a scenario precisely
+   because it is the case most likely to be reported as a defect by whoever meets it first.
+
+---
+
+### User Story 3 - The author is told the batch finished, even if they walked away (Priority: P1)
+
+The submission is answered long before the work is done, so something has to close the loop. When
+the run reaches a terminal state the submitter is told — pushed to them if they are still looking,
+and recorded durably so the outcome survives navigating away or closing the tab.
+
+**Why this priority**: P1, not P2. Without it the author has no way to learn how a batch ended
+except by staring at the screen for its duration, which defeats the point of accepting the batch
+asynchronously. The product already has this exact mechanism in use (§Legacy Considerations), so
+this is reuse rather than new invention.
+
+**Independent Test**: Submit a batch as a given user, let it finish with no client listening, and
+confirm that user has a durable record of the outcome afterwards, worded on what actually
+happened.
+
+**Acceptance Scenarios**:
+
+1. **Given** a batch that reaches any terminal state — finished, cancelled, or permanently failed
+   — **When** it does, **Then** the submitting author is notified of the outcome with its counts.
+2. **Given** a batch that finished while the author was on another screen or had closed the tab,
+   **When** the author next looks, **Then** the outcome is still available to them.
+3. **Given** a finished batch, **When** the author is notified, **Then** the wording reflects what
+   happened — full success, partial failure, total failure, or cancellation - and is not a fixed
+   "completed" message.
+4. **Given** a batch, **When** it is notified, **Then** only its submitting author is notified —
+   not every administrator, and not other users.
+5. **Given** a notification that cannot be delivered, **When** that happens, **Then** it is logged
+   and the run's own outcome is unaffected — the work has already succeeded by that point.
+
+---
+
+### User Story 4 - A running batch can be followed and cancelled (Priority: P2)
+
+While a batch runs, its progress can be read, and it can be stopped. Stopping it leaves the files
+already created in place and records how far it got.
+
+**Why this priority**: The feature is correct without it — every file uploads and the outcome is
+reported — but a 200-file batch with no visible progress and no stop button is the difference
+between usable and merely correct. It also feeds the client-side progress capability #37166 asks
+this work to enable.
+
+**Independent Test**: Submit a batch large enough to observe more than one progress change, read
+progress mid-run, cancel it, and confirm already-created files remain and the outcome states the
+point reached.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running batch, **When** its progress is read, **Then** it advances as files are
+   completed.
+2. **Given** a running batch, **When** it is cancelled, **Then** files already created stay in
+   place — nothing is rolled back.
+3. **Given** a cancelled batch, **When** its outcome is read, **Then** files never attempted are
+   distinguishable from files that failed, and the outcome states the run was cancelled.
+4. **Given** a running batch, **When** cancellation is requested, **Then** it takes effect between
+   files — a file is never left half-created.
+
+---
+
+### User Story 5 - An interrupted batch finishes without duplicating anything (Priority: P1)
+
+A restart, a crash, or a lost worker does not cost the author their batch and does not leave them
+with two copies of half of it. The run picks up where it stopped, and the author is told once, at
+the end, what happened overall.
+
+**Why this priority**: P1, and it is a data-integrity requirement rather than a convenience. The
+job framework re-queues a run whose worker stopped reporting, so "what happens on a restart" is
+already answered — it is retried. Retrying a batch that created 30 of 50 files, without resuming,
+creates 30 duplicate assets. Silently duplicating a user's content is worse than the defect this
+feature exists to fix.
+
+**Independent Test**: Start a batch of 20 files, stop the run once part of it has been created,
+let it be picked up again, and confirm the folder holds exactly 20 files — not more — and that the
+outcome reports 20 succeeded, once.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run that created some of its files and was then interrupted, **When** it resumes,
+   **Then** it creates only the files it had not yet created.
+2. **Given** a resumed run, **When** it finishes, **Then** the target holds exactly one copy of
+   each submitted file.
+3. **Given** a resumed run, **When** its outcome is read, **Then** the counts cover the whole
+   batch across every attempt, and files created before the interruption read as succeeded rather
+   than skipped.
+4. **Given** a batch interrupted and resumed, **When** it finishes, **Then** the submitter is
+   notified **once**, not once per attempt.
+5. **Given** a client that lost the connection while submitting and resubmits the same batch,
+   **When** the resubmission is handled, **Then** the author does not end up with two copies of
+   the files — either the resubmission is recognised as the same batch, or the duplicates are
+   rejected as collisions.
+
+---
+
+### User Story 6 - Two batches racing for the same name produce one file, not two (Priority: P2)
+
+Two authors, or one author twice, upload a file of the same name into the same folder at the same
+time. One wins, the other is told its file collided. Neither silently overwrites the other, and the
+folder never ends up with two files of the same name.
+
+**Why this priority**: P2 — it needs a deliberate answer, but it is a narrower window than User
+Story 5's, and the feature is usable before it is closed. Recorded rather than left implicit
+because the product's existing collision rule is a check followed by a create, so under
+concurrency it can pass for both runs.
+
+**Independent Test**: Start two batches at the same time, each containing a file of the same name
+targeting the same folder, and confirm the folder ends with exactly one such file and the other
+run reports a collision failure for it.
+
+**Acceptance Scenarios**:
+
+1. **Given** two runs that would create the same file name in the same target, **When** both
+   proceed, **Then** exactly one succeeds and the other records a collision failure for that file.
+2. **Given** the losing run, **When** its outcome is read, **Then** only the contended file
+   failed — its other files were created normally.
+3. **Given** two runs targeting **different** folders, **When** both proceed, **Then** neither
+   waits on the other.
+
+---
+
+### Edge Cases
+
+- **Upload type not decided by the author.** Resolved before the batch is ever submitted: the
+  target folder either expresses a preferred upload type or expresses none, in which case the
+  interface prompts once for the whole batch. The server receives exactly one type per batch and
+  never has to infer one. No server behavior required.
+- **A requested upload type that is neither Asset nor File.** Refused at submission, before any
+  batch is created. It is a batch-level parameter, so it cannot be a per-file failure.
+- **Zero files in the submission.** Refused at submission; no batch is created.
+- **More files than the configured maximum.** Refused at submission with a message stating the
+  limit; no partial batch is created.
+- **A file over the configured per-file size limit, inside an otherwise valid batch.** That file
+  fails; the batch does not.
+- **The author cannot add children to the target folder.** Refused at submission as a permission
+  error — not as N per-file failures.
+- **A file collides with an existing asset the author cannot edit, or resolves to a content type
+  the author lacks permission to create.** The target-folder check above (FR-003) already passed;
+  this is a narrower permission check that only resolves once the file reaches the reused
+  single-file path (FR-006). Recorded as that file's own permission-denied failure (FR-016), not
+  as a submission-time refusal.
+- **The target folder does not exist.** Refused at submission. Creating folders is out of scope.
+- **Two files in one batch carrying the same name.** Each is attempted; the second is subject to
+  the same collision rule as a pre-existing name.
+- **The run is cancelled before reaching some files.** Those files are recorded as skipped, which
+  is a distinct outcome from failed.
+- **The submitting user cannot be resolved when the run finishes.** Logged; the run's outcome is
+  unaffected.
+- **The server restarts while a batch is running.** The run resumes and creates only what it had
+  not yet created (FR-036). It does not restart from the first file, and it does not orphan.
+- **The connection drops before the client learns whether its submission was accepted.** Covered by
+  FR-040: the client can safely resubmit, and either gets the original batch back or sees the
+  already-created files rejected as collisions. What it must never get is a silent second copy.
+- **Two batches racing for the same name in the same folder.** Exactly one wins; the other records
+  a collision for that file only (FR-041, FR-042).
+- **The batch exceeds the configured total size.** Refused at submission, before anything is
+  staged — distinct from a single file exceeding the per-file ceiling, which is a per-file failure
+  inside an accepted batch.
+- **A file's content type declares no size ceiling.** The configurable fallback applies (FR-011.2),
+  which is deliberately stricter than the single-file upload for that file — see FR-011a.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Submission**
+
+- **FR-001**: The system MUST accept a batch of several files in one submission, carrying a target
+  folder (or site root) and one upload type for the whole batch.
+- **FR-002**: The system MUST answer a valid submission immediately, before the files are created,
+  with a handle the caller can use to follow, cancel, and read the outcome of the run.
+- **FR-003**: The system MUST validate at submission — and refuse before creating any batch — a
+  submission that: carries no files; carries an upload type other than Asset or File; names a
+  target that does not exist; exceeds the configured maximum file count; or comes from an author
+  without permission to add children to the target.
+- **FR-004**: A submission refused for lack of permission MUST be distinguishable from one refused
+  as malformed.
+
+**Creating the files**
+
+- **FR-005**: The system MUST create every file in the batch in the target folder.
+- **FR-006**: Each file MUST be created **observably equivalently** to uploading that same file
+  through the existing single-file upload: identical content type resolution, identical permission
+  enforcement, identical workflow behavior. The requirement is the equivalence, not the sharing of
+  a particular call site — the single-file path is entered over REST and a background run cannot
+  re-enter it, so the reuse point is chosen in the plan. What may not vary is the observable
+  behavior.
+- **FR-007**: A file failing MUST NOT abort the run; every remaining file MUST still be attempted.
+- **FR-008**: The system MUST NOT wait for each file to become searchable before starting the
+  next. Search-index visibility MUST be resolved for the batch, not serialized per file.
+- **FR-009**: The existing single-file upload endpoint and its behavior MUST be left unchanged.
+
+**Limits**
+
+- **FR-010**: The system MUST enforce a configurable maximum number of files per batch, defaulting
+  to **50**. Exceeding it is a submission-time refusal (FR-003). This limit is new — nothing caps a
+  selection today — and MUST be operator-configurable through the product's standard configuration
+  mechanism rather than hardcoded.
+- **FR-011**: A file rejected for its **size** MUST be recorded as that file's own failure with a
+  size-specific reason, and MUST NOT fail the batch. The applicable ceiling is resolved in this
+  order:
+  1. **The content type's own ceiling**, where an operator has declared one on the binary field.
+     This is the rule the single-file upload already applies, so where it is set, a file is
+     accepted or rejected identically whether it arrives alone or in a batch.
+  2. **A configurable fallback ceiling**, where the content type declares none. Without it a
+     batch would have no per-file bound at all, since the content type's rule is unset by default.
+- **FR-011a**: The fallback of FR-011.2 is a **deliberate, recorded exception to FR-006**. Where a
+  content type declares no ceiling, a file large enough to exceed the fallback is rejected in a
+  batch and accepted as a single upload. This is accepted because a batch is a materially larger
+  resource commitment than one upload, and because the alternative — no bound at all — was judged
+  worse. The divergence MUST be documented wherever the limits are documented, so an operator
+  seeing it does not read it as a defect.
+- **FR-012**: A file rejected for its **type** MUST likewise be recorded as that file's own
+  failure and MUST NOT fail the batch. As with size, the allowed-types rule is declared per content
+  type on the binary field and is applied as-is.
+- **FR-012a**: This is a **file-type rule, not a file-extension rule**, and MUST be described that
+  way everywhere it is surfaced. The product resolves the file's media type — by detection and
+  content sniffing, not by trusting the name — and matches it against the content type's allow
+  list, which is written in media-type terms and supports wildcards. Renaming a file to change its
+  extension therefore does not get it past the rule.
+- **FR-012b**: Where the media type **cannot be resolved**, the product skips the allow-list check
+  and accepts the file. This feature inherits that behavior rather than tightening it, since
+  tightening would break FR-006. It MUST NOT be described to the author as though every file were
+  checked, and the plan MUST decide whether an unresolvable type is worth surfacing at all.
+- **FR-013**: The system MUST NOT rely on a size limit supplied by the caller. A caller that omits
+  one would fall back to an unlimited default, so any caller-supplied ceiling can tighten what the
+  system enforces but MUST NOT be the enforcement point.
+- **FR-013a**: Where a chosen staging mechanism imposes its own size ceiling, the effective limit
+  is the stricter of it and FR-011's, and the plan MUST state which is expected to bind — so that
+  a file rejected by staging is not reported to the author as a content-type rule it did not break.
+- **FR-013b**: The system MUST enforce a configurable **maximum total size per batch**. Without it
+  the batch is bounded only by FR-010's file count multiplied by a per-file ceiling that may be
+  unset, which is to say not bounded at all — an authenticated author could stage unbounded bytes
+  on shared storage.
+- **FR-013c**: That ceiling is enforced in two stages, because the content arrives in the same call
+  that carries the batch (Q5) and its true size is only known by reading it:
+  1. **A fast refusal on the declared total**, before reading the body, where the caller declares
+     one. This is a convenience that saves an author uploading gigabytes only to be refused — it is
+     **not** the enforcement point, since a caller can under-declare or omit it (FR-013).
+  2. **The authoritative enforcement while the content is read**, aborting once the ceiling is
+     crossed. The product's staging already works this way, writing through a bounded stream that
+     aborts when the bound is passed.
+- **FR-013d**: Content already staged when a submission is refused — by FR-013c.2 or any other
+  submission-time refusal — MUST be reclaimed. FR-033 covers reclaim for runs that reach a terminal
+  state; a refused submission never becomes a run and would otherwise leak.
+
+**Staged file content**
+
+<!--
+  The submission is answered before the files are created, so the uploaded bytes must live
+  somewhere in between. That gap was unspecified and is where this feature can lose a user's
+  files. These requirements bound it.
+-->
+
+- **FR-031**: The uploaded content of an accepted batch MUST remain available to the run until the
+  run reaches a terminal state, however long the batch waits in queue and however long it takes.
+- **FR-032**: A batch MUST NOT lose files because their staged content expired or was reclaimed
+  while the batch waited or ran. If content cannot be retrieved, it MUST be recorded as that
+  file's own failure with its own distinguishable reason — never a silent loss, and never
+  presented as though the author supplied a bad file.
+- **FR-033**: Staged content MUST be reclaimed once the run reaches any terminal state —
+  completed, failed, or cancelled — including for files the run never reached.
+- **FR-034**: Staged content MUST remain readable to the run when it is picked up by a different
+  node than the one that accepted the submission.
+
+**Surviving interruption, and not duplicating**
+
+<!--
+  The job framework re-queues a run whose worker stopped updating it. Re-running a batch from the
+  start would recreate files it already created, so "it gets retried" is only a safe answer if the
+  run can resume. These requirements make that the contract rather than an implementation detail.
+-->
+
+- **FR-036**: A run interrupted by a restart, a crash, or a lost worker MUST resume rather than
+  restart. Files it already created MUST NOT be created a second time.
+- **FR-037**: To make FR-036 possible, the run MUST record which files it has completed **durably
+  and as it goes**, not only in the final outcome. A record written only at the end is lost in
+  exactly the case it is needed for.
+- **FR-038**: A resumed run MUST produce the same outcome shape as an uninterrupted one — the
+  counts MUST reflect the whole batch across all attempts, not just the final attempt, and a file
+  created before the interruption MUST be reported as succeeded rather than skipped.
+- **FR-039**: A resumed run MUST still honour cancellation and MUST still notify the submitter on
+  its terminal state, once for the batch — an interruption MUST NOT produce a second notification
+  for the same batch.
+- **FR-040**: Resubmitting a batch after a lost or uncertain response MUST NOT silently create
+  duplicates. The system MUST either recognise the resubmission as the same batch and return the
+  original handle, or let the per-file collision rule (FR-041) reject the already-created files —
+  and whichever it does MUST be stated, because a client cannot know whether its submission
+  landed when the connection drops.
+- **FR-040a**: If the collision branch is chosen, a duplicate resubmission MUST be **distinguishable
+  from a genuinely all-collided batch** — by a reason, a flag on the outcome, or both. The two
+  branches protect the author's data equally but do not report equally: under the collision branch
+  a resubmission re-uploads every byte, produces a second handle, and reports *"50 of 50 failed —
+  file already exists"* for a batch that in fact succeeded. Without a way to tell that apart, the
+  client cannot honour its own requirement to treat an uncertain submission as retryable rather
+  than as a failure the author must reason about, which is the whole point of FR-040.
+
+**Concurrency**
+
+- **FR-041**: Where two runs would create the same file name in the same target, **exactly one MUST
+  succeed**. The other MUST be recorded as that file's own collision failure. Two files with the
+  same name in one folder, and a silent overwrite, are both unacceptable outcomes.
+- **FR-042**: FR-041 MUST hold when the two runs overlap in time. **The storage layer already
+  guarantees it**: identifiers are uniquely constrained on parent path, asset name and host, so the
+  second writer of a contended name fails on every existing install. The product's own pre-check is
+  a check followed by a create and can pass for both runs, so it is a courtesy that produces a
+  clean message, not the guarantee. The requirement is therefore to **catch the constraint
+  violation and report it as the same collision failure as the pre-check** — not to build a lock
+  for a race the storage layer already loses on the caller's behalf.
+- **FR-042a**: "The same file name" is **case-insensitive**. `Report.pdf` and `report.pdf` are one
+  contended name, not two. This is existing product behavior rather than a new decision: the
+  operative uniqueness guarantee is a unique index over the lower-cased full path per host, and the
+  pre-check resolves the target through the same lower-cased path, so the two agree. This feature
+  MUST NOT introduce a case-sensitive notion of collision alongside them.
+- **FR-043**: A run MUST NOT be blocked or slowed by unrelated runs on other targets. FR-042's
+  mechanism satisfies this for free — a uniqueness constraint contends only on the contended key —
+  and any additional mechanism MUST preserve it rather than serialize uploads generally.
+
+**Outcome**
+
+- **FR-014**: A finished run MUST record a total, a success count, a failure count, and a skipped
+  count.
+- **FR-015**: A finished run MUST record a per-file result naming the file and its status —
+  succeeded, failed, or skipped (never attempted).
+- **FR-016**: Every failed per-file result MUST carry a machine-readable reason and a
+  human-readable message. The reason MUST distinguish at least: over size limit,
+  disallowed file type (FR-012a — a media-type rule, not an extension one), name collision,
+  permission denied (a per-file check narrower than the target-folder check in FR-003 — see Edge
+  Cases), staged content unavailable (FR-032), and an unclassified error.
+- **FR-016a**: The **reason** is what the client presents, by mapping it to resolved product copy.
+  The **message** is diagnostic and log-only: it MUST NOT be the text shown to the author, which
+  the frontend spec's FR-030 already requires. Every reason a failure can carry MUST therefore
+  have client copy, or the client will have nothing to show for it — so adding a new reason later
+  is a change to both halves, not just this one.
+- **FR-017**: The recorded counts MUST be the authoritative report of the run. The number of files
+  submitted MUST NOT be used as a stand-in for the number created.
+- **FR-018**: This feature MUST **generalize the batch-outcome shape already established by bulk
+  refresh** (#36845 / #37131) into a shared contract, rather than defining a second one. Three
+  deltas are required and are real work:
+  - **A machine-readable reason code.** The shipped per-item record carries a human-readable
+    message only; FR-016 needs both. This is an additive change to a shipped contract.
+  - **A generic item key.** The shipped record is keyed by contentlet identifier and inodes. A file
+    being uploaded has neither — it does not exist until the run creates it — and neither does a
+    folder path. The generic key is the substance of this requirement.
+  - **One spelling of the counters: `failedCount`.** The shipped counter is `failedCount`; #37166
+    originally said `failCount`. `failedCount` wins, matching what already ships. Both halves MUST
+    use it; this is settled here and in #37166's amendment, not left to the plan.
+- **FR-018a**: The generalized shape MUST carry a batch of folder paths as naturally as a batch of
+  files, so #37062 / #37063 adopt it unchanged.
+
+**Notifying the submitter**
+
+- **FR-019**: When a run reaches any terminal state — finished, cancelled, or permanently failed —
+  the system MUST notify the submitting author of the outcome and its counts.
+- **FR-020**: The notification MUST be durable: an author who was not looking when the run
+  finished MUST still be able to learn the outcome afterwards. "The outcome" is the recorded
+  outcome of FR-014 … FR-016, counts **and** the per-file results with their reasons, not a
+  counts-only summary. An author who stepped away would otherwise learn that three files failed
+  without learning which three, leaving them nothing to act on.
+- **FR-021**: The notification MUST be addressed to the submitting author only.
+- **FR-022**: The notification wording MUST reflect the actual outcome — full success, partial
+  failure, total failure, or cancellation — rather than a single fixed message.
+- **FR-023**: Notification MUST be best-effort: a failure to notify MUST be logged and MUST NOT
+  affect the run's recorded outcome or the batch machinery.
+
+**Progress and cancellation**
+
+- **FR-024**: The system MUST report the run's progress as files complete, readable while the run
+  is in flight.
+- **FR-025**: A running batch MUST be cancellable.
+- **FR-026**: Cancelling MUST leave files already created in place — nothing is rolled back.
+- **FR-027**: Cancellation MUST take effect between files, never mid-file.
+- **FR-028**: A cancelled run's outcome MUST distinguish files never attempted from files that
+  failed.
+
+**Documentation**
+
+- **FR-029**: The published API description MUST state that the operation is asynchronous, and
+  point at how to follow, cancel and read the outcome of the run.
+- **FR-030**: The generated API document MUST be regenerated from the annotations and committed
+  alongside the change.
+
+### Key Entities
+
+- **Upload batch**: One author-initiated bulk upload. Holds the target (folder or site root), the
+  chosen upload type, the submitting author, the set of files, its progress, its terminal state,
+  and its outcome. Addressable and observable after the submitting caller is gone.
+- **Batch outcome**: Total, success count, failure count, skipped count, and the list of per-file
+  results. The shared contract of FR-018.
+- **Per-file result**: A file's name, its status (succeeded / failed / skipped), and — when failed
+  — a machine-readable reason and a human-readable message.
+- **Batch limits**: Operator-configured maximum file count per batch, and maximum size per file.
+
+---
+
+## Contract Consumed by the Client *(mandatory — the frontend half of #37166 depends on it)*
+
+The browser-side work is delivered by another developer against this contract. It is listed here
+so the boundary is explicit and reviewable; each item is a restatement of a requirement above,
+from the consumer's point of view.
+
+- **C-001**: A way to submit several files with one target and one upload type, in **a single
+  call** carrying the file content, answered immediately with a handle (FR-001, FR-002, Q5). The
+  client does not stage the content itself and never handles a staging identifier — where the
+  bytes wait for the run is the server's business and can change without touching the client.
+- **C-002**: A distinguishable submission refusal for: no files, bad upload type, missing target,
+  too many files, batch over the total size ceiling, permission denied (FR-003, FR-004, FR-013b).
+- **C-002a**: A defined answer to "I lost the connection while submitting — may I retry?" The
+  client MUST be able to resubmit without risking a second copy of the author's files (FR-040).
+  Which mechanism provides that — the same batch handle returned, or the duplicates rejected as
+  collisions — is fixed in the plan, but the client is entitled to one.
+- **C-002b**: A stable set of failure reasons, each mapped to product copy on the client side. The
+  server's message is diagnostic and is not displayed (FR-016a). Adding a reason later changes both
+  halves.
+- **C-003**: Readable progress for an in-flight run (FR-024).
+- **C-004**: A way to cancel an in-flight run (FR-025).
+- **C-005**: A readable terminal state and outcome — counts plus per-file results with reason and
+  message (FR-014 … FR-017).
+- **C-006**: A pushed completion signal carrying the run's outcome, reaching the browser without
+  the client having to poll, plus a durable record of that same outcome (FR-019, FR-020).
+  **Outcome here means counts *and* the per-file results**, each failure carrying its reason: that
+  is what FR-014 … FR-016 record, and summarising it as "counts" says less than this spec already
+  requires. The client's FR-023 depends on the failing file names being present in both, since
+  those names are what tell an author which files to choose again.
+
+**Not blocking on the client**: FR-019/FR-020 mean the frontend does **not** need to build a jobs
+management screen for the outcome to survive navigation. It needs only to render the pushed signal
+while the user is present; the durable record is the server's responsibility.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Submitting N valid files (within the configured maximum) results in N files created
+  in the target; zero files are silently discarded.
+- **SC-002**: In a batch where some files are invalid, 100% of the valid files are created and
+  100% of the invalid ones appear in the outcome with a reason that distinguishes why.
+- **SC-003**: A batch of 50 files sustains a stated per-file throughput floor, set in the plan as
+  an absolute target rather than as a comparison against today's behavior — today's single-file
+  upload waits for each file to become searchable, which is the very pathology FR-008 removes, so
+  measuring against it would make this criterion true by construction. The batch also does not
+  serialize behind a per-file search-index wait.
+- **SC-004**: An author who was not present when their batch finished can determine the outcome
+  afterwards, in 100% of runs — including cancelled and failed ones.
+- **SC-005**: Cancelling a run leaves every already-created file intact and reports the point
+  reached, in 100% of runs.
+- **SC-006**: The generalized outcome shape is the shipped bulk refresh shape extended, not a
+  second one — verified by the shipped consumer still reading its own results through it, and by
+  expressing a folder-path batch in it during review so #37062 / #37063 can adopt it unmodified.
+- **SC-007**: Existing single-file upload behavior is unchanged, verified by the existing
+  single-file scenarios passing without modification.
+- **SC-008**: A submission that must be refused is refused before any work is done — no batch is
+  created and no file is uploaded, in 100% of refusals.
+- **SC-009**: A batch interrupted at any point and resumed produces exactly one copy of each
+  submitted file — zero duplicates, in 100% of interruptions — and notifies the submitter once.
+- **SC-010**: Two runs contending for the same file name in the same target produce exactly one
+  file, in 100% of races, with the loser reporting a collision for that file only.
+- **SC-011**: No batch can commit more staged bytes than the configured total, and no file can
+  exceed the ceiling that applies to it, in 100% of submissions.
+
+---
+
+## Legacy Considerations *(dotCMS-specific — mandatory)*
+
+- **Existing behavior touched**: Content Drive's file upload (a modern surface) and the
+  asset-creation and permission machinery beneath it, which is long-standing product surface and
+  is also used by the AssetPicker ([#36702](https://github.com/dotCMS/core/issues/36702)). This
+  feature introduces a new submission surface but deliberately does **not** introduce a second way
+  to create an asset: FR-006 binds it to behavior observably equivalent to the single-file upload,
+  with the reuse point chosen in the plan.
+- **Security posture inherited by reuse**: whichever staging mechanism the plan chooses, the
+  product's existing one already contains the caller-supplied filename against path traversal.
+  Reusing it inherits that protection; not reusing it means re-establishing it. Worth stating
+  because it is a real argument in FR-006's favour that would otherwise go unrecorded.
+- **Backward-compatibility expectations**: The existing single-file upload stays exactly as it is
+  (FR-009); the AssetPicker and any external caller keep working unchanged. This feature adds a
+  bulk path beside it and replaces nothing. No existing content, API, or admin workflow changes.
+- **Known related decisions — an in-repo precedent this MUST follow**: the bulk refresh work
+  ([#36845](https://github.com/dotCMS/core/issues/36845), shipped in
+  [#37131](https://github.com/dotCMS/core/pull/37131)) already solved the same shape of problem:
+  an accepted-immediately batch, a per-item outcome with counts, a configurable submission cap, a
+  server-side permission gate, and — the part that answers FR-019/FR-020 — a completion listener
+  that both pushes the outcome to the submitter and records it durably so it survives navigation.
+  This feature adopts that pattern rather than inventing a parallel one, and where the two differ
+  the divergence is justified in the plan. Formal ADR consultation happens in the plan phase.
+
+---
+
+## Out of Scope
+
+- **The browser-side implementation of #37166.** Delivered separately against §Contract Consumed
+  by the Client. This spec's deliverable stops at the server.
+- **Directory (folder tree) upload.** Dropping a desktop folder, creating the hierarchy, and
+  placing assets inside it. Explicitly deferred by #37166 to a follow-up. This feature requires
+  the target to already exist (FR-003).
+- **Creating a missing target folder as part of an upload**, and any interface for choosing that
+  folder's behavior mid-upload. Follows from the line above.
+- **Resumable or chunked single-file upload.** Large-single-file behavior is unchanged.
+- **Mixing upload types within one batch.** One batch, one type (FR-001).
+- **Changing the single-file upload endpoint or its behavior.**
+- **A general-purpose background-jobs management screen.**
+
+---
+
+## Decisions
+
+Recorded from the developer's answers on 2026-08-31; the requirements above already reflect them.
+
+- **Q1 — Ownership of the batch-outcome contract**: **This feature owns it** (FR-018, FR-018a).
+  #37062 and #37063 consume it. Chosen so this work is not blocked by an unbuilt ticket; the cost
+  is that the shape must carry folder paths as naturally as files, which SC-006 verifies.
+
+  Corrected after review: the first draft said this feature *defines* the shape. It does not — the
+  bulk refresh work already ships one, and this feature **generalizes** it. As originally written,
+  a plan author was licensed to invent a second shape, which is the exact outcome FR-018 exists to
+  prevent.
+
+  This reverses the dependency direction #37166 states ("depends on #37062 … which the folder
+  endpoints define first"). Both #37062 and #37063 are open and unbuilt, so the reversal holds —
+  but **#37166 must be amended to match**, or #37062's author defines a third shape in good faith.
+- **Q2 — Limits**: A **maximum file count per batch of 50**, configurable, enforced as a
+  submission-time refusal (FR-010). A file over its applicable size ceiling is a per-file failure
+  that leaves the batch running (FR-011). **Superseded in part by Q7**: the original decision here
+  was that there would be no batch-total size limit; there now is one (FR-013b).
+
+  Refined after review: the size ceiling is **not** a new bulk-specific knob. The product already
+  declares one per content type on the binary field, applied on the single-file path, and FR-006's
+  equivalence requirement means a batch must not reject what a single upload would accept. So this
+  feature applies the existing ceiling and makes its rejection a per-file outcome. The consequence
+  is that where an operator has configured nothing, there is no size ceiling — accepted knowingly,
+  because diverging from the single-file path would be the worse defect.
+- **Q3 — Outcome after navigating away**: The server notifies the submitter on any terminal state,
+  both by push and by a durable record (FR-019 … FR-023), following the bulk refresh precedent.
+  This removes the need for the frontend to build a jobs screen to satisfy #37166's "its outcome
+  is still discoverable".
+- **Q4 — Submission entry point**: A **domain endpoint owning its own multipart handling**, rather
+  than the framework's generic job-upload entry point that #37166 proposes reusing. Two reasons.
+  The generic entry point accepts exactly one file today, so a batch cannot travel through it
+  without changing a shared type used by other consumers. And FR-003/FR-004 require refusing a
+  submission — for a missing target, a bad upload type, or a permission failure — *before* any
+  batch is created; the generic entry point has no notion of a target folder and would enqueue
+  first and fail inside the run instead. Recorded here rather than left to the plan so the
+  single-file constraint is not rediscovered on day one.
+- **Q5 — Client-visible submission shape**: **One call.** The client sends the files and the batch
+  parameters together; staging them for the run is the server's business and stays invisible to
+  the client, as it already is for content import. The alternative — the client stages the content
+  itself and then submits references — was considered and rejected: it makes the staging mechanism
+  part of the contract between the two halves of #37166, so changing it later would require
+  changing the frontend.
+- **Q6 — Interruption**: **Resumable execution.** The run records completed files durably as it
+  goes, so a re-queued run continues rather than restarts (FR-036 … FR-039). The alternative —
+  marking the processor no-retry so an interrupted batch simply fails — was rejected: at batch
+  sizes up to 50 it would make a restart cost the author the whole batch, and resubmitting would
+  then collide against the files the first attempt already created.
+
+  Strengthened after review: no-retry would not even have avoided the duplicates. The abandoned-job
+  sweep re-queues unconditionally and never consults the retry policy, so an interrupted run is
+  retried **whether or not** the processor is marked no-retry. Resumability is therefore the only
+  answer available, not the preferred one of two.
+
+  A caution that follows: the content import processor is marked no-retry and creates content from
+  staged uploads — the same shape as this feature — so it is already exposed to this duplicate
+  risk. That is a defect in import, not a precedent to follow. Import remains a sound precedent for
+  the one-call staging shape (Q5) and for nothing about retry.
+- **Q7 — Size ceilings**: **Both.** A configurable **total per batch**, refused at submission
+  (FR-013b), and **per file** the content type's own ceiling where one is declared, falling back to
+  a configurable value where none is (FR-011). The fallback is a knowing exception to FR-006's
+  equivalence rule and is recorded as FR-011a rather than left to be discovered.
+
+---
+
+## Planning Obligations
+
+Decided in principle above, but carrying enough hidden work that the plan must confront them
+explicitly rather than meet them during implementation.
+
+- **Durable mid-run state for resumability** (FR-036 … FR-038). This is the largest piece of
+  hidden work in this specification and the plan must size it before committing to User Story 5.
+  The job framework persists three things about a run: its parameters, written once at creation and
+  immutable thereafter; its progress, a single number; and its result, harvested once at the
+  terminal state. None of them is a mid-run record of which items are done. The resume path carries
+  nothing forward either — a re-queued run is reset to pending with no result, no progress and no
+  marker that it is a second attempt, and the processor is request-scoped, so it resumes with every
+  counter at zero. FR-037 is therefore **either a new job-framework capability or a durable store
+  owned by this feature**, and FR-038's "counts across all attempts" needs the same thing. If it
+  turns out to require a framework change, that is a separate issue and is far cheaper to find here
+  than in implementation.
+  - **Consequence for FR-018**: a shape designed only to be emitted once at the terminal state will
+    not serve a run that must read its own prior progress back. The generalization and this
+    obligation should be planned together.
+- **A cross-batch cap, or a recorded decision not to have one.** FR-010 and FR-013b bound a single
+  batch; nothing bounds how many batches one author may have in flight, so the staged-bytes total
+  is still unbounded per author. Previously carried as a functional requirement that the system
+  "state a position", which is a decision for the authors rather than behaviour a test can fail.
+  The plan must either set a cross-batch cap or record that there deliberately is none — for
+  instance, that the job queue's own concurrency governs it.
+- **The generalization of the shipped outcome shape** (FR-018) touches a contract other code
+  already depends on. The plan must say whether it extends that type in place or extracts a
+  shared one, and what that means for the shipped consumer.
+- **Deriving stable failure reasons** (FR-016, FR-016a, C-002b, and the client copy that depends on
+  them). The validation layer these outcomes come from distinguishes its cases largely by localized
+  message text: the size rejection and the type rejection are the *same exception class* differing
+  only in a translated string, and all of them arrive through one validation call. Producing a
+  stable, machine-readable reason from that is real work — pre-checking before the create, or
+  extending the validation layer to carry a code — and it is the mechanical foundation of the
+  per-file reporting this whole feature promises. Plan it alongside the FR-018 generalization,
+  which it will travel with.
+- **Staged content lifetime** (FR-031 … FR-034). The available mechanism's lifetime ceiling is a
+  single global value with no per-call override, so satisfying FR-031 by raising it would change
+  behavior for every other consumer. The plan must choose among tolerating the ceiling and
+  reporting expiry as a per-file failure, raising it globally and accepting the blast radius, or
+  taking the content out of that mechanism's reach for the duration of the run.
+- **Test coverage** (Constitution V). The plan must name which layers this feature exercises and
+  which it does not, with the reason for each omission. #37166 already enumerates what it expects:
+  integration coverage for many files succeeding, mixed partial failure, a rejected file type, an
+  oversized file, permission denied, cancellation mid-batch, and a batch large enough to exercise
+  progress reporting. Silence is not an acceptable answer to Principle V.
+
+---
+
+## Assumptions
+
+- The interface resolves one upload type per batch before submitting, and prompts the author when
+  the target folder expresses no preference. The server receives one type and never infers one.
+- Neither the per-file size rule (FR-011) nor the allowed-types rule (FR-012) is new. Both already
+  apply to the single-file upload: they are declared per content type on the binary field and
+  enforced during contentlet validation, which the creation path runs. Both surface as a validation
+  failure the run can catch per file, which is what makes per-file reporting natural rather than
+  bespoke. Both default to unconstrained where an operator has set nothing, so out of the box this
+  feature inherits no size or type ceiling — that is a deliberate consequence of FR-006's
+  equivalence requirement, not an oversight. Only the batch file-count cap (FR-010) is new.
+- The product's existing staging mechanism carries its own size ceiling, unlimited by default and
+  narrowable per call but only downward — and narrowable by the *caller*, which is why FR-013a
+  requires the system to enforce FR-011 itself rather than delegate to it. Its content-lifetime
+  ceiling, by contrast, is a single global value with no per-call override, so it cannot be tuned
+  for this feature alone without changing it for every other consumer. That constraint is the
+  reason FR-031 and FR-032 are stated as outcomes rather than as a configuration change.
+- Enforcement of both limits is authoritative on the server. The client may check the file count
+  to fail fast, but that check is a convenience and not the enforcement point.
+- "Durable record" (FR-020) means the submitting author can learn their own run's outcome after
+  the fact; it does not imply an administrator-facing view of all users' runs.
+- Existing behavior on name collision is preserved and merely surfaced per file. This feature does
+  not introduce overwrite-or-rename semantics.
+- No new permission concept is introduced: the right to submit a batch is the right to add
+  children to the target, which already exists.


### PR DESCRIPTION
This PR fixes the unverified commit signing in https://github.com/dotCMS/core/pull/37300.

Spec-Kit specifications for Content Drive bulk file upload. Content Drive accepts a multi-file selection today, warns that only one file will be uploaded, and discards the rest.

**This PR carries both halves of the specification**, one document each, written by the developer building that half:

| Spec | Author | Covers |
|---|---|---|
| `specs/37166-bulk-file-upload/spec.md` | @dario-daza | Server side: accepting a batch, creating the files, limits, outcome shape, notification |
| `specs/37166-bulk-file-upload-frontend/spec.md` | @zJaaal | Browser side: choosing and submitting files, reporting progress and outcome, unifying in-flight feedback |

They are reviewed together because they meet at one contract and neither is complete without it. The backend spec defines it in "Contract Consumed by the Client" (C-001 to C-006); the frontend spec restates it from the consumer's side in "Contract Consumed", so the boundary is reviewable from either document. The *implementation* of each half lands in its own separate PR.

### Backend spec: decisions recorded

- This feature defines the shared batch-outcome contract (counts plus per-file results); #37062 and #37063 consume it rather than the reverse, so this work is not blocked by an unbuilt ticket.
- A configurable maximum file count per batch, defaulting to **50**, refused at submission. A per-file size ceiling recorded as that file's own failure so the batch keeps running. And a configurable **maximum total size per batch**, enforced in two stages: a fast refusal on the total the caller declares, then authoritative enforcement while the content is read.
- The submitter is notified on any terminal state, both pushed and durably recorded, following the bulk refresh precedent (#36845 / #37131). Both carry counts **and** the per-file results, so an author who stepped away can still learn which files failed and why. This keeps the outcome discoverable after navigation without requiring a client-side jobs screen.

Directory upload and creating a missing target folder stay out of scope, as #37166 specifies.

### Frontend spec: six required stories plus one optional

- **P1** Every chosen file is uploaded, from both entry points. The upload control's file input carries no `multiple` attribute today, so only drag-and-drop delivers a batch; the premise that a multi-file selection already reaches the client held for the drop path only.
- **P1** The outcome is honest: counts come from the server, never from the number of files the author picked, and a partial failure names the files that failed and why.
- **P1** In-flight state is reported in one place. Content Drive announces "this is running" four different ways today, the worst of which replaces the entire listing with skeleton rows for an action fired on a single row.
- **P2** Leaving does not lose the batch, carried by the pushed completion signal (C-006), so no jobs screen is required.
- **P2** Every outcome names what ran and what it ran on. The copy for the missing cases was written and never wired.
- **P3** One operation does not block another.
- **P4, optional** Stopping a run, deferred: a general task manager is the expected home for it.

Per-row in-flight marking and bulk reindex's reporting are documented as out of scope, with reasons.

### Review rounds

Two rounds so far, threaded on this PR rather than restated item by item here.

Round 2 (@fabrizzio-dotCMS) changed the shape of the work in three places:

- **Resumability** (backend FR-037) is either a new job-framework capability or a store this feature owns: job parameters are immutable after creation, progress is a single float, and the result is harvested only at the terminal state. It is now the first Planning Obligation, and it removed the alternative to Q6 rather than merely supporting it, since the abandoned-job sweep re-queues without consulting the retry policy.
- **The concurrent-collision window** is already closed by a unique index over the lower-cased full path per host, so FR-042 is now about catching that violation and mapping it to the collision reason, not building a lock for a race the storage layer already loses on the caller's behalf. FR-042a fixes collision as case-insensitive.
- **The total-size ceiling** splits into a fast refusal on the declared total and authoritative enforcement during the read (FR-013c), because content arriving in the same call is only measurable by reading it. That in turn requires the client to declare the total (frontend FR-038), or every over-ceiling batch is refused only after the author has already uploaded it.

Plus one correction spanning both documents: **C-006** summarised the completion signal and the durable record as carrying "the run's counts", while FR-014 to FR-016 record counts *and* the per-file results with a reason each. A plan trusting the summary would have shipped a counts-only notification, leaving an author who stepped away with "27 of 30 created" and no way to learn which three failed. Corrected in both specs, with FR-020 pinning what "the outcome" means there and the frontend's FR-023 / FR-023a covering the transient and durable surfaces alike.

### Proposed Changes

* Add `specs/37166-bulk-file-upload/spec.md`, the backend spec: the batch-upload contract, limits, outcome shape, and notification behavior.
* Add `specs/37166-bulk-file-upload-frontend/spec.md`, the frontend spec: consuming that contract, and unifying how Content Drive reports work in progress and its outcomes.
* Address two rounds of review on both specs. Round 1 clarified the per-file "permission denied" reason in FR-016 as distinct from the target-folder permission check, and aligned the `#37062` / `#37063` ticket references. Round 2 is summarised above.

### Checklist

- [x] Tests — not applicable; this PR is spec-only (no implementation code). Test strategy is defined per Spec-Kit's plan phase (`/speckit-plan`) once these specs are approved.
- [x] Translations — not applicable; no user-facing strings in this PR.
- [x] Security Implications Contemplated — permission enforcement (folder + per-file) and configurable limits are specified in the backend spec's FR-003, FR-004, FR-010–FR-013, FR-016; no security-relevant code changes in this PR itself.

### Additional Info

This is PR 1 of the Spec-Kit flow (spec only). Approval here unblocks `/speckit-plan` → `/speckit-tasks` → `/speckit-implement` for **both** halves. No code changes are included.

One item is deliberately left for planning: the concrete submission format (field names, endpoint, and the shape of the handle) is not pinned in either spec, which state the boundary at behavior altitude. It must be agreed between the two halves and recorded under `specs/*/contracts/`, since `plan.md` is gitignored in this repo and an agreement recorded there would not survive.

### Screenshots

Not applicable — this PR only adds specification documents, no UI or behavior changes.

This PR fixes: #37166


This PR fixes: #37166