### PR TITLE
ci(dotbot): override review model roster via DOTBOT_REVIEW_MODELS instead of adding to it

### DIFF
--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -45,12 +45,45 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      # DOTBOT_REVIEW_MODELS (repo VARIABLE), when set, OVERRIDES the review
+      # roster: we render .openrouter-review.yml from it and the action reads
+      # that as its primary + extras. This is a REPLACEMENT, not an addition —
+      # the action's `review_models` INPUT is additive (it would run the
+      # variable's models alongside the action's default primary). First
+      # entry = primary reviewer; the rest are the "fight" secondaries. When
+      # the variable is unset, nothing is rendered and the action's own
+      # defaults stand.
+      - name: Override review roster from DOTBOT_REVIEW_MODELS (when set)
+        if: ${{ vars.DOTBOT_REVIEW_MODELS != '' }}
+        env:
+          REVIEW_MODELS: ${{ vars.DOTBOT_REVIEW_MODELS }}
+        run: |
+          MODELS=()
+          IFS=',' read -ra PARTS <<< "$REVIEW_MODELS"
+          for p in "${PARTS[@]}"; do
+            p="${p//[[:space:]]/}"
+            [[ -n "${p}" ]] && MODELS+=("${p}")
+          done
+          if (( ${#MODELS[@]} == 0 )); then
+            echo "::warning::DOTBOT_REVIEW_MODELS set but parsed empty — using action defaults"
+            exit 0
+          fi
+          {
+            echo "review:"
+            echo "  model: ${MODELS[0]}"
+            if (( ${#MODELS[@]} > 1 )); then
+              echo "  models:"
+              for m in "${MODELS[@]:1}"; do echo "    - ${m}"; done
+            fi
+          } > .openrouter-review.yml
+          echo "Rendered .openrouter-review.yml from DOTBOT_REVIEW_MODELS:"
+          cat .openrouter-review.yml
       - name: dotbot autonomous review
-        uses: wezell/openrouter-code-review-action@34ee169dd9f35bf20a6b358b902c6c76e5df3a14
+        uses: dotcms/openrouter-code-review-action@a716ed1aaa24814e11ed684901b1f1525e8ee353
         with:
           mode: review
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          review_models: ${{ vars.DOTBOT_REVIEW_MODELS }}
+          github_approval_token: ${{ secrets.DOTBOT_GITHUB_USER_PAT }}
           reasoning_effort: medium
           web_search_mode: cached
           debug_level: 1

--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -83,7 +83,7 @@ jobs:
           echo "Rendered .openrouter-review.yml from DOTBOT_REVIEW_MODELS:"
           cat .openrouter-review.yml
       - name: dotbot autonomous review
-        uses: dotcms/openrouter-code-review-action
+        uses: dotcms/openrouter-code-review-action@latest # a716ed1aaa24814e11ed684901b1f1525e8ee353
         with:
           mode: review
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -58,6 +58,10 @@ jobs:
         env:
           REVIEW_MODELS: ${{ vars.DOTBOT_REVIEW_MODELS }}
         run: |
+          # Newlines to commas: `read` stops at the first newline, so models
+          # on later lines of a multi-line VARIABLE would otherwise be
+          # silently dropped without warning.
+          REVIEW_MODELS="${REVIEW_MODELS//$'\n'/,}"
           MODELS=()
           IFS=',' read -ra PARTS <<< "$REVIEW_MODELS"
           for p in "${PARTS[@]}"; do

--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -83,7 +83,7 @@ jobs:
           echo "Rendered .openrouter-review.yml from DOTBOT_REVIEW_MODELS:"
           cat .openrouter-review.yml
       - name: dotbot autonomous review
-        uses: dotcms/openrouter-code-review-action@latest # a716ed1aaa24814e11ed684901b1f1525e8ee353
+        uses: dotcms/openrouter-code-review-action@latest
         with:
           mode: review
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/dotbot-review.yml
+++ b/.github/workflows/dotbot-review.yml
@@ -83,7 +83,7 @@ jobs:
           echo "Rendered .openrouter-review.yml from DOTBOT_REVIEW_MODELS:"
           cat .openrouter-review.yml
       - name: dotbot autonomous review
-        uses: dotcms/openrouter-code-review-action@a716ed1aaa24814e11ed684901b1f1525e8ee353
+        uses: dotcms/openrouter-code-review-action
         with:
           mode: review
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary

Adopts the roster-override pattern from `dotCMS/ovh-k8s-cluster`'s `dotbot-review.yml` so `DOTBOT_REVIEW_MODELS` **replaces** the review roster instead of adding to it.

## Problem

Our workflow passed `review_models: ${{ vars.DOTBOT_REVIEW_MODELS }}` to the review action, but that input is **additive** — the VARIABLE's models ran *alongside* the action's default roster, growing the reviewer set instead of controlling it.

## Change

- New pre-step renders `.openrouter-review.yml` from `DOTBOT_REVIEW_MODELS` (when set): first entry = primary reviewer, rest = "fight" secondaries. The action reads it as its full roster — a replacement, not an addition.
- When the VARIABLE is unset or parses empty (with a `::warning::`), nothing is rendered and the action's own defaults stand.
- Dropped the additive `review_models:` input; switched to `dotcms/openrouter-code-review-action` (SHA-pinned) with `github_approval_token` as the ovh-k8s-cluster workflow does.

## Unchanged (deliberately)

The ovh-k8s-cluster reference lacks this repo's trigger gating — its `on:` block was **not** copied. This workflow still fires only when the `PR : dotbot review` label is on the PR, skips forks, only re-runs on changes to that specific label, and keeps the job-level concurrency.

Fixes #37348
