### PR TITLE
Fix: extract PR numbers using GitHub API

### DIFF
--- a/.github/scripts/gather-release-data/src/github.ts
+++ b/.github/scripts/gather-release-data/src/github.ts
@@ -138,17 +138,48 @@ export async function fetchCommitRange(
 }
 
 /**
- * Extract PR numbers from commit messages.
- * Looks for patterns like "(#12345)" at the end of the first line.
+ * Resolve PR numbers for a list of commits via the GitHub API.
  */
-export function extractPRNumbers(commits: CommitInfo[]): number[] {
+export async function extractPRNumbers(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commits: CommitInfo[]
+): Promise<number[]> {
   const prNumbers = new Set<number>();
-  for (const commit of commits) {
-    const match = commit.message.match(/\(#(\d+)\)\s*$/);
-    if (match) {
-      prNumbers.add(parseInt(match[1], 10));
+  const BATCH_SIZE = 15;
+
+  for (let i = 0; i < commits.length; i += BATCH_SIZE) {
+    const batch = commits.slice(i, i + BATCH_SIZE);
+
+    const promises = batch.map(async (commit) => {
+      try {
+        const { data } = await octokit.repos.listPullRequestsAssociatedWithCommit({
+          owner,
+          repo,
+          commit_sha: commit.sha,
+        });
+        return data.map((pr) => pr.number);
+      } catch (error: unknown) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        process.stderr.write(
+          `Warning: Could not fetch PRs for commit ${commit.sha}: ${errMsg}\n`
+        );
+        return [];
+      }
+    });
+
+    const batchResults = await Promise.all(promises);
+    for (const nums of batchResults) {
+      for (const n of nums) prNumbers.add(n);
+    }
+
+    // Brief pause between batches to avoid secondary rate limits
+    if (i + BATCH_SIZE < commits.length) {
+      await sleep(500);
     }
   }
+
   return Array.from(prNumbers);
 }
 

--- a/.github/scripts/gather-release-data/src/index.ts
+++ b/.github/scripts/gather-release-data/src/index.ts
@@ -127,10 +127,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Extract PR numbers from commit messages
-  const prNumbers = extractPRNumbers(commits);
+  // Resolve PR numbers for commits
+  const prNumbers = await extractPRNumbers(octokit, owner, repo, commits);
   process.stderr.write(
-    `Extracted ${prNumbers.length} PR numbers from ${commits.length} commits.\n`
+    `Resolved ${prNumbers.length} PR numbers from ${commits.length} commits.\n`
   );
 
   // Fetch PR details

--- a/.github/scripts/release-qa-status/src/github.ts
+++ b/.github/scripts/release-qa-status/src/github.ts
@@ -128,17 +128,47 @@ export async function fetchCommitRange(
 }
 
 /**
- * Extract PR numbers from squash-merge commit messages (the format dotCMS
- * uses on `main`). Merge-commit-merged PRs ("Merge pull request #N from …")
- * would be silently dropped if the merge policy ever changed — revisit this
- * regex if that happens.
+ * Resolve PR numbers for a list of commits via the GitHub API.
  */
-export function extractPRNumbers(commits: CommitInfo[]): number[] {
+export async function extractPRNumbers(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commits: CommitInfo[]
+): Promise<number[]> {
   const prNumbers = new Set<number>();
-  for (const commit of commits) {
-    const match = commit.message.match(/\(#(\d+)\)\s*$/);
-    if (match) prNumbers.add(parseInt(match[1], 10));
+  const BATCH_SIZE = 15;
+
+  for (let i = 0; i < commits.length; i += BATCH_SIZE) {
+    const batch = commits.slice(i, i + BATCH_SIZE);
+
+    const promises = batch.map(async (commit) => {
+      try {
+        const { data } = await octokit.repos.listPullRequestsAssociatedWithCommit({
+          owner,
+          repo,
+          commit_sha: commit.sha,
+        });
+        return data.map((pr) => pr.number);
+      } catch (error: unknown) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        process.stderr.write(
+          `Warning: Could not fetch PRs for commit ${commit.sha}: ${errMsg}\n`
+        );
+        return [];
+      }
+    });
+
+    const batchResults = await Promise.all(promises);
+    for (const nums of batchResults) {
+      for (const n of nums) prNumbers.add(n);
+    }
+
+    if (i + BATCH_SIZE < commits.length) {
+      await sleep(500);
+    }
   }
+
   return Array.from(prNumbers);
 }
 

--- a/.github/scripts/release-qa-status/src/index.ts
+++ b/.github/scripts/release-qa-status/src/index.ts
@@ -265,19 +265,13 @@ async function main(): Promise<void> {
     return;
   }
 
-  const prNumbers = extractPRNumbers(commits);
+  const prNumbers = await extractPRNumbers(octokit, owner, repo, commits);
   process.stderr.write(
-    `Extracted ${prNumbers.length} PR numbers from ${commits.length} commits.\n`
+    `Resolved ${prNumbers.length} PR numbers from ${commits.length} commits.\n`
   );
   if (commits.length > 0 && prNumbers.length === 0) {
-    // The extractPRNumbers regex only matches squash-merge commit subjects
-    // (`(#N)` at end). If `main` ever switches to merge commits the QA
-    // section would silently disappear from every release notification.
-    // Surface the situation explicitly so the cause is obvious.
     process.stderr.write(
-      `Warning: no PR numbers extracted from ${commits.length} commits. ` +
-        `Has the merge strategy on the source branch changed? ` +
-        `Expected squash-merge commit subjects ending in "(#N)".\n`
+      `Warning: no PR numbers resolved from ${commits.length} commits.\n`
     );
   }
 


### PR DESCRIPTION
Closes #37201. 

Replaces the regex extraction with direct GitHub API calls (`GET /repos/{owner}/{repo}/commits/{sha}/pulls`) to ensure PR numbers are fetched robustly, especially when merge strategies like non-squash commits are used.