### PR TITLE
fix(cicd): release notes never reach Claude — E2BIG on the prompt, then denied tool permissions

### DIFF
--- a/.github/scripts/gather-release-data/prompt-template.md
+++ b/.github/scripts/gather-release-data/prompt-template.md
@@ -52,7 +52,7 @@ If the `rollbackUnsafe` array is non-empty, add a `[!CAUTION]` block at the top 
 
 ## Output Format
 
-Write the release notes to the file `/tmp/release-notes.md` using the Write tool.
+Write the release notes to the file `./release-notes.md` using the Write tool.
 
 The file must contain **only** the Markdown content below. No preamble, no commentary, no trailing summary. This exact content is published to BOTH the GitHub release and the dev.dotcms.com changelog, so it must not contain GitHub-only or site-only syntax (no heading anchors, no release-title heading — both destinations render their own titles).
 
@@ -84,4 +84,4 @@ The file must contain **only** the Markdown content below. No preamble, no comme
 - Omit any section that has no items (do not emit an empty heading)
 - If the release contains only internal changes with no customer-facing impact, keep the intro line and add a single line: `This release contains internal maintenance only.` — an entry is still produced (the site convention)
 - Do NOT include any text outside the release notes content
-- Do NOT run any shell commands — only use the Write tool to create `/tmp/release-notes.md`
+- Do NOT run any shell commands — only use the Write tool to create `./release-notes.md`

--- a/.github/scripts/gather-release-data/src/github.ts
+++ b/.github/scripts/gather-release-data/src/github.ts
@@ -17,6 +17,9 @@ const ThrottledOctokit = Octokit.plugin(throttling);
 
 const MAX_RATE_LIMIT_RETRIES = 3;
 
+/** Per-PR body truncation, see fetchPRDetails. */
+export const BODY_CHAR_LIMIT = 1_000;
+
 export function onThrottle(kind: string) {
   return (
     retryAfter: number,
@@ -249,8 +252,12 @@ export async function fetchPRDetails(
 
         const linkedIssues = extractLinkedIssues(data.body || '');
 
-        // Safety cap at 50K chars to guard against extreme outliers
-        const body = (data.body || '').slice(0, 50_000);
+        // Bodies are ~90% of the payload and the changelog only needs the lede,
+        // so keep the first BODY_CHAR_LIMIT chars. Uncapped, a full release
+        // (50+ PRs, spec/design PRs running 10-18K each) pushes the assembled
+        // prompt past Linux MAX_ARG_STRLEN (128 KiB per argv/env entry) and any
+        // step that passes it through argv or GITHUB_ENV dies with E2BIG.
+        const body = (data.body || '').slice(0, BODY_CHAR_LIMIT);
 
         return {
           number: prNumber,

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -517,6 +517,7 @@ jobs:
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   # Changelog Site Publish - deliver the changelog entry to dev.dotcms.com/docs/changelogs.
   # Runs after release-notes, current-track GA only (reusing release-prepare's is_latest —

--- a/.github/workflows/cicd_comp_ai-release-notes-phase.yml
+++ b/.github/workflows/cicd_comp_ai-release-notes-phase.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: false
+      slack_channel_id:
+        description: 'Slack channel id for failure notices. Defaults to #dot-releases.'
+        required: false
+        type: string
+        default: 'CE1TBQU00'  # #dot-releases (public). Pass an override to post elsewhere.
     secrets:
       ANTHROPIC_API_KEY:
         required: true
@@ -30,6 +35,9 @@ on:
       CI_MACHINE_TOKEN:
         required: false
         description: 'GitHub token with release edit permissions (falls back to github.token)'
+      SLACK_BOT_TOKEN:
+        required: false
+        description: 'Slack bot token for failure notices. Omit to disable them.'
 
 jobs:
   generate-notes:
@@ -44,6 +52,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.release_tag }}
       PREVIOUS_TAG: ${{ inputs.previous_tag }}
       REPO: ${{ github.repository }}
+      HAVE_SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN != '' }}
     # Skip non-standard releases (CLI, LTS)
     if: >-
       !contains(inputs.release_tag, 'dotcms-cli-')
@@ -172,3 +181,19 @@ jobs:
 
           echo "## Release Notes Updated" >> "$GITHUB_STEP_SUMMARY"
           echo "Release [${RELEASE_TAG}](https://github.com/${REPO}/releases/tag/${RELEASE_TAG}) description updated." >> "$GITHUB_STEP_SUMMARY"
+
+      # allow_failure: true keeps a notes failure from blocking the release, which
+      # also hides it — four releases shipped with empty bodies before anyone
+      # noticed. This is the only signal that it broke. Success posts nothing.
+      - name: Notify Slack (release notes failed)
+        if: failure() && env.HAVE_SLACK_TOKEN == 'true'
+        uses: ./.github/actions/core-cicd/notification/notify-slack
+        with:
+          channel-id: ${{ inputs.slack_channel_id }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: >-
+            :rotating_light: *Release notes generation FAILED* for
+            `${{ inputs.release_tag }}` — the GitHub release is published but its
+            description is empty. The software release itself is unaffected.
+            Re-run via the AI Release Notes Backfill workflow. Run:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/cicd_comp_ai-release-notes-phase.yml
+++ b/.github/workflows/cicd_comp_ai-release-notes-phase.yml
@@ -86,12 +86,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
         run: |
+          # `bash -e` aborts the step the moment node exits non-zero, so the cat
+          # below never runs and the real error is lost. Trap it explicitly.
           if [ -n "$PREVIOUS_TAG" ]; then
-            node dist/index.js --repo "$REPO" --to-tag "$RELEASE_TAG" --from-tag "$PREVIOUS_TAG" \
-              > /tmp/release-data.json 2>/tmp/gather-stderr.log
+            set -- --from-tag "$PREVIOUS_TAG"
           else
-            node dist/index.js --repo "$REPO" --to-tag "$RELEASE_TAG" \
-              > /tmp/release-data.json 2>/tmp/gather-stderr.log
+            set --
+          fi
+          if ! node dist/index.js --repo "$REPO" --to-tag "$RELEASE_TAG" "$@" \
+              > /tmp/release-data.json 2>/tmp/gather-stderr.log; then
+            echo "::error::gather-release-data failed:"
+            cat /tmp/gather-stderr.log
+            exit 1
           fi
 
           # Log the resolved range for operator visibility
@@ -121,45 +127,48 @@ jobs:
       - name: Assemble prompt
         id: prompt
         run: |
-          # Build the full prompt: template + JSON data
-          cat .github/scripts/gather-release-data/prompt-template.md > /tmp/claude-prompt.md
-          printf '\n---\n\n## Release Data (JSON)\n\n```json\n' >> /tmp/claude-prompt.md
-          cat /tmp/release-data.json >> /tmp/claude-prompt.md
-          printf '\n```\n' >> /tmp/claude-prompt.md
+          # Build the full prompt: template + JSON data.
+          # Written into the workspace (not /tmp) so Claude's Read/Write stay
+          # inside its working directory.
+          cat .github/scripts/gather-release-data/prompt-template.md > release-prompt.md
+          printf '\n---\n\n## Release Data (JSON)\n\n```json\n' >> release-prompt.md
+          cat /tmp/release-data.json >> release-prompt.md
+          printf '\n```\n' >> release-prompt.md
+          echo "Prompt is $(wc -c < release-prompt.md) bytes."
 
-          # Pass prompt content via environment file to avoid shell escaping issues.
-          # Use a random delimiter to prevent PR body content from terminating the heredoc early.
-          DELIM="PROMPT_$(openssl rand -hex 16)"
-          {
-            echo "PROMPT_CONTENT<<${DELIM}"
-            cat /tmp/claude-prompt.md
-            echo "${DELIM}"
-          } >> "$GITHUB_ENV"
+          # NOT passed via GITHUB_ENV or argv: Linux caps a single env var /
+          # argv entry at MAX_ARG_STRLEN (128 KiB), and a full release's prompt
+          # exceeds that, killing every later step with E2BIG.
 
       - name: Generate release notes with Claude
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: ${{ env.PROMPT_CONTENT }}
-          claude_args: "--allowedTools Write --max-turns 3"
+          prompt: |
+            Read ./release-prompt.md (it is large — page through it until you
+            have read all of it), follow the instructions it contains, and write
+            the finished release notes to ./release-notes.md. Write no other files.
+          # Read is required for release-prompt.md; without it every tool call is
+          # denied and Claude exits "successfully" having written nothing.
+          claude_args: "--allowedTools Read,Write --max-turns 20"
 
       - name: Update release description
         env:
           GH_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
         run: |
-          if [ ! -f /tmp/release-notes.md ]; then
-            echo "Error: Claude did not generate /tmp/release-notes.md"
-            echo "Listing /tmp/ for debugging:"
-            ls -la /tmp/*.md 2>/dev/null || echo "No .md files in /tmp/"
+          if [ ! -f release-notes.md ]; then
+            echo "Error: Claude did not generate release-notes.md"
+            echo "Listing workspace .md files for debugging:"
+            ls -la ./*.md 2>/dev/null || echo "No .md files in the workspace"
             exit 1
           fi
 
-          echo "Generated release notes ($(wc -l < /tmp/release-notes.md) lines):"
-          cat /tmp/release-notes.md
+          echo "Generated release notes ($(wc -l < release-notes.md) lines):"
+          cat release-notes.md
 
           gh release edit "$RELEASE_TAG" \
             --repo "$REPO" \
-            --notes-file /tmp/release-notes.md
+            --notes-file release-notes.md
 
           echo "## Release Notes Updated" >> "$GITHUB_STEP_SUMMARY"
           echo "Release [${RELEASE_TAG}](https://github.com/${REPO}/releases/tag/${RELEASE_TAG}) description updated." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes: #37201

## The problem

Release notes generation has been failing for every release since **v26.08.28-01**. Four releases shipped with **empty descriptions** and a green pipeline:

| Release | Notes job | Release body |
|---|---|---|
| v26.09.02-01 | ❌ | 0 chars |
| v26.08.31-02 | ❌ | 0 chars |
| v26.08.31-01 | ❌ | 0 chars |
| v26.08.28-01 | ❌ | 0 chars |

#37213 correctly replaced the `(#N)` squash-subject regex with the commits→PRs API. That made PR resolution *complete* for the first time — and complete is roughly twice as big. The payload crossed a limit nobody was watching.

## Three defects, none of them AI-side

```
                          253 KB assembled prompt
                                    │
   ┌────────────────────────────────┼────────────────────────────────┐
   │                                │                                │
[1] GITHUB_ENV              [2] claude_args              [3] gather step
 MAX_ARG_STRLEN =            no --allowedTools            `bash -e` aborts
 131072 bytes/entry          → Read denied                before `cat stderr`
   │                                │                                │
   ▼                                ▼                                ▼
 E2BIG in every            7 turns, 6 permission        failures surface as
 subsequent step           denials, exits "success"     a bare "exit code 1"
                           having written nothing
```

**1 — E2BIG was a Linux limit, not a context limit.** The prompt was passed through `GITHUB_ENV`. Linux caps a *single* env var or argv entry at `MAX_ARG_STRLEN` (128 KiB); a full release's prompt is 253 KB. Before #37213 the regex silently dropped about half the PRs, which kept it under the ceiling by accident.

**2 — The workaround dropped the tool allowlist.** Switching to "read the prompt from a file" without restoring `--allowedTools` meant `Read` was denied. From run [33705418470](https://github.com/dotCMS/core/actions/runs/33705418470): `num_turns: 7`, `permission_denials_count: 6`, `is_error: false`. It wasn't running out of turns — it was being denied and giving up politely, then the next step failed on a missing file.

**3 — The real error was unreachable.** `bash -e` kills the gather step the instant `node` exits non-zero, so the `cat /tmp/gather-stderr.log` two lines down never ran.

## The fix

- **Prompt goes to a file in the workspace**, never through `GITHUB_ENV` or argv.
- **`--allowedTools Read,Write`** restored, `--max-turns 20`. (Turns were never the constraint — the failing run used 7 and cost $0.22.)
- **Gather stderr is trapped** and re-emitted as `::error::` before the step exits.
- **PR bodies cap at 1 KB.** They were ~90% of the payload and the changelog only needs the lede.

Full release prompt: **253 KB → 71 KB**, verified end-to-end against `v26.09.02-01`.

## Keeping `allow_failure: true`, adding a smoke alarm

An empty release description should never block a software release, so the flag stays. But it's also why this went unnoticed for four releases — so on failure the phase now posts to **#dot-releases**, matching the pattern `changelog-site-publish` already uses. Success posts nothing. The notice is opt-in via `SLACK_BOT_TOKEN`, so the backfill workflow (where an operator is already staring at a red run) stays quiet.

## Testing

- 36 unit tests pass.
- `gather-release-data` run end-to-end against `v26.09.02-01` (485 commits → 51 PRs) and `v26.08.28-01` (228 commits → 29 PRs); both clean, no 404s.
- Assembled prompt measured at 71,128 bytes vs the 131,072-byte ceiling.
- Backfill verified against `v26.08.28-01` on this branch before merge.

## Not in this PR

Moving commit→PR resolution to GraphQL would collapse 485 REST calls into one query. That's a real win for speed and rate-limit headroom, but it fixes neither failure here, so it belongs in its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37201