### PR TITLE
perf(cicd): batch release-data lookups over GraphQL — ~1,076 requests to ~78, and fix `Closes: #N`

### DIFF
--- a/.github/scripts/gather-release-data/src/github.test.ts
+++ b/.github/scripts/gather-release-data/src/github.test.ts
@@ -1,33 +1,85 @@
-import { extractLinkedIssues } from './github';
+import { BODY_CHAR_LIMIT, fetchPRDetails } from './github';
+import type { Octokit } from '@octokit/rest';
 
-describe('extractLinkedIssues', () => {
-  it('extracts Closes #N patterns', () => {
-    expect(extractLinkedIssues('Closes #123')).toEqual([123]);
-    expect(extractLinkedIssues('closes #456')).toEqual([456]);
+describe('fetchPRDetails', () => {
+  function mockPR(over: Record<string, unknown> = {}) {
+    return {
+      number: 37196,
+      title: 'fix(edit-content): pick the asset picker per host',
+      body: 'Closes: #37132',
+      labels: { nodes: [{ name: 'Type : Defect' }] },
+      closingIssuesReferences: {
+        nodes: [{ number: 37132, repository: { nameWithOwner: 'dotCMS/core' } }],
+      },
+      ...over,
+    };
+  }
+
+  it('reads linked issues from closingIssuesReferences, not the body (#35763)', async () => {
+    // "Closes: #N" — the form CLAUDE.md mandates — never matched the old regex.
+    const graphql = jest.fn(async () => ({ repository: { pr37196: mockPR() } }));
+    const octokit = { graphql } as unknown as Octokit;
+
+    const details = await fetchPRDetails(octokit, 'dotCMS', 'core', [37196]);
+    expect(details.get(37196)?.linkedIssues).toEqual([37132]);
+    expect(details.get(37196)?.labels).toEqual(['Type : Defect']);
   });
 
-  it('extracts Fixes #N patterns', () => {
-    expect(extractLinkedIssues('Fixes #789')).toEqual([789]);
+  it('drops cross-repo refs — the changelog links this repo only', async () => {
+    const graphql = jest.fn(async () => ({
+      repository: {
+        pr37196: mockPR({
+          closingIssuesReferences: {
+            nodes: [
+              { number: 37132, repository: { nameWithOwner: 'dotCMS/core' } },
+              { number: 673, repository: { nameWithOwner: 'dotCMS/private-issues' } },
+            ],
+          },
+        }),
+      },
+    }));
+    const octokit = { graphql } as unknown as Octokit;
+
+    const details = await fetchPRDetails(octokit, 'dotCMS', 'core', [37196]);
+    expect(details.get(37196)?.linkedIssues).toEqual([37132]);
   });
 
-  it('extracts Resolves #N patterns', () => {
-    expect(extractLinkedIssues('Resolves #101')).toEqual([101]);
+  it('truncates bodies to keep the assembled prompt under MAX_ARG_STRLEN', async () => {
+    const graphql = jest.fn(async () => ({
+      repository: { pr37196: mockPR({ body: 'x'.repeat(50_000) }) },
+    }));
+    const octokit = { graphql } as unknown as Octokit;
+
+    const details = await fetchPRDetails(octokit, 'dotCMS', 'core', [37196]);
+    expect(details.get(37196)?.body).toHaveLength(BODY_CHAR_LIMIT);
   });
 
-  it('extracts multiple linked issues', () => {
-    const issues = extractLinkedIssues('Fixes #100 and Closes #200');
-    expect(issues).toEqual(expect.arrayContaining([100, 200]));
-    expect(issues).toHaveLength(2);
+  it('warns about PRs the query could not resolve, and keeps the rest', async () => {
+    const warn = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const graphql = jest.fn(async () => ({
+      repository: { pr37196: mockPR(), pr99999: null },
+    }));
+    const octokit = { graphql } as unknown as Octokit;
+
+    const details = await fetchPRDetails(octokit, 'dotCMS', 'core', [37196, 99999]);
+    expect([...details.keys()]).toEqual([37196]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('#99999'));
+    warn.mockRestore();
   });
 
-  it('extracts full URL patterns', () => {
-    const issues = extractLinkedIssues(
-      'Closes https://github.com/dotCMS/core/issues/12345'
-    );
-    expect(issues).toEqual([12345]);
-  });
+  it('handles a PR with no body and no labels', async () => {
+    const graphql = jest.fn(async () => ({
+      repository: {
+        pr37196: mockPR({
+          body: null,
+          labels: null,
+          closingIssuesReferences: { nodes: [] },
+        }),
+      },
+    }));
+    const octokit = { graphql } as unknown as Octokit;
 
-  it('returns empty array for no links', () => {
-    expect(extractLinkedIssues('Just a normal description')).toEqual([]);
+    const details = await fetchPRDetails(octokit, 'dotCMS', 'core', [37196]);
+    expect(details.get(37196)).toMatchObject({ body: '', labels: [], linkedIssues: [] });
   });
 });

--- a/.github/scripts/gather-release-data/src/github.ts
+++ b/.github/scripts/gather-release-data/src/github.ts
@@ -13,10 +13,36 @@ import { PRDetails } from './types';
 /** Per-PR body truncation, see fetchPRDetails. */
 export const BODY_CHAR_LIMIT = 1_000;
 
+/** 20 PRs/query — bodies dominate the response, so keep batches smaller. */
+const PR_BATCH = 20;
+
+interface PRDetailsResponse {
+  repository: Record<
+    string,
+    {
+      number: number;
+      title: string;
+      body: string | null;
+      labels: { nodes: { name: string }[] } | null;
+      closingIssuesReferences: {
+        nodes: { number: number; repository: { nameWithOwner: string } }[];
+      };
+    } | null
+  >;
+}
+
 /**
- * Fetch PR details with rate-limit awareness.
- * Processes PRs in batches to avoid hitting secondary rate limits.
- * Throws if any PR fetch fails so the workflow step fails visibly.
+ * Fetch title, labels, body and linked issues for a list of PRs.
+ *
+ * `closingIssuesReferences` replaces the old body regex, which required
+ * whitespace directly after the keyword and so missed `Closes: #N` — the form
+ * CLAUDE.md mandates for every dotCMS PR. On v26.09.02-01 that cost 23 of 51
+ * PRs their issue cross-link. GraphQL reads the same relationship GitHub
+ * itself renders, so the colon form, `Closes owner/repo#N`, and issues linked
+ * only through the Development sidebar all resolve.
+ *
+ * Cross-repo refs are dropped: the changelog links issues in this repo only.
+ * (release-qa-status keeps them — it reports on them separately.)
  */
 export async function fetchPRDetails(
   octokit: Octokit,
@@ -25,93 +51,63 @@ export async function fetchPRDetails(
   prNumbers: number[]
 ): Promise<Map<number, PRDetails>> {
   const results = new Map<number, PRDetails>();
-  const fetchErrors: number[] = [];
-  const BATCH_SIZE = 15;
+  const missing: number[] = [];
+  const ownerRepoLower = `${owner}/${repo}`.toLowerCase();
 
-  for (let i = 0; i < prNumbers.length; i += BATCH_SIZE) {
-    const batch = prNumbers.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < prNumbers.length; i += PR_BATCH) {
+    const batch = prNumbers
+      .slice(i, i + PR_BATCH)
+      .filter((n) => Number.isInteger(n) && n > 0);
+    if (batch.length === 0) continue;
 
-    const promises = batch.map(async (prNumber) => {
-      try {
-        const { data } = await octokit.pulls.get({
-          owner,
-          repo,
-          pull_number: prNumber,
-        });
+    const aliases = batch
+      .map(
+        (n) =>
+          `  pr${n}: pullRequest(number: ${n}) {\n` +
+          `    number title body\n` +
+          `    labels(first: 50) { nodes { name } }\n` +
+          `    closingIssuesReferences(first: 50, userLinkedOnly: false) {\n` +
+          `      nodes { number repository { nameWithOwner } }\n` +
+          `    }\n` +
+          `  }`
+      )
+      .join('\n');
 
-        const labels = data.labels.map((l) => l.name || '');
+    // Re-thrown for the same reason as resolvePRNumbers: a dropped batch would
+    // quietly shrink the changelog rather than fail the step.
+    const data = await octokit.graphql<PRDetailsResponse>(
+      `query($owner: String!, $repo: String!) {\n` +
+        `  repository(owner: $owner, name: $repo) {\n` +
+        aliases +
+        `\n  }\n}`,
+      { owner, repo }
+    );
 
-        const linkedIssues = extractLinkedIssues(data.body || '');
-
-        // Bodies are ~90% of the payload and the changelog only needs the lede,
-        // so keep the first BODY_CHAR_LIMIT chars. Uncapped, a full release
-        // (50+ PRs, spec/design PRs running 10-18K each) pushes the assembled
-        // prompt past Linux MAX_ARG_STRLEN (128 KiB per argv/env entry) and any
-        // step that passes it through argv or GITHUB_ENV dies with E2BIG.
-        const body = (data.body || '').slice(0, BODY_CHAR_LIMIT);
-
-        return {
-          number: prNumber,
-          title: data.title,
-          labels,
-          body,
-          linkedIssues,
-        } as PRDetails;
-      } catch (error: unknown) {
-        const errMsg =
-          error instanceof Error ? error.message : String(error);
-        process.stderr.write(
-          `Error: Could not fetch PR #${prNumber}: ${errMsg}\n`
-        );
-        fetchErrors.push(prNumber);
-        return null;
+    for (const n of batch) {
+      const pr = data.repository[`pr${n}`];
+      if (!pr) {
+        missing.push(n);
+        continue;
       }
-    });
-
-    const batchResults = await Promise.all(promises);
-    for (const result of batchResults) {
-      if (result) {
-        results.set(result.number, result);
-      }
-    }
-
-    // Brief pause between batches to avoid secondary rate limits
-    if (i + BATCH_SIZE < prNumbers.length) {
-      await sleep(500);
+      results.set(n, {
+        number: n,
+        title: pr.title,
+        labels: (pr.labels?.nodes ?? []).map((l) => l.name),
+        // See BODY_CHAR_LIMIT.
+        body: (pr.body ?? '').slice(0, BODY_CHAR_LIMIT),
+        linkedIssues: pr.closingIssuesReferences.nodes
+          .filter((r) => r.repository.nameWithOwner.toLowerCase() === ownerRepoLower)
+          .map((r) => r.number),
+      });
     }
   }
 
-  if (fetchErrors.length > 0) {
+  if (missing.length > 0) {
     process.stderr.write(
-      `Warning: Could not fetch ${fetchErrors.length} PR(s): ${fetchErrors.map((n) => `#${n}`).join(', ')}. ` +
-        `These PRs will be missing from the release notes.\n`
+      `Warning: ${missing.length} PR(s) not found in ${owner}/${repo}: ` +
+        `${missing.map((n) => `#${n}`).join(', ')}. These will be missing from the release notes.\n`
     );
   }
 
   return results;
-}
-
-/**
- * Extract linked issue numbers from PR body text.
- * Looks for "Closes #N", "Fixes #N", "Resolves #N" patterns.
- */
-export function extractLinkedIssues(body: string): number[] {
-  const issues = new Set<number>();
-  const patterns = [
-    /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi,
-    /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/gi,
-  ];
-
-  for (const pattern of patterns) {
-    let match;
-    while ((match = pattern.exec(body)) !== null) {
-      issues.add(parseInt(match[1], 10));
-    }
-  }
-
-  return Array.from(issues);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/.github/scripts/shared/github.test.ts
+++ b/.github/scripts/shared/github.test.ts
@@ -18,79 +18,86 @@ describe('parseRepo', () => {
 });
 
 describe('resolvePRNumbers', () => {
-  it('resolves merge-commit and branch-commit dedup, and ignores direct pushes (#37201)', async () => {
-    // aaa: feature-branch commit whose subject ended in the issue "(#37132)"
-    // bbb: the two-parent merge commit for the same PR
-    // ccc: a direct push, unassociated with any PR
-    const bySha: Record<string, Array<{ number: number; merged_at: string | null }>> = {
-      aaa: [{ number: 37196, merged_at: '2026-08-25T00:00:00Z' }],
-      bbb: [{ number: 37196, merged_at: '2026-08-25T00:00:00Z' }],
-      ccc: [],
-    };
-    const listPRs = jest.fn(async ({ commit_sha }: { commit_sha: string }) => ({
-      data: bySha[commit_sha] ?? [],
-    }));
-    const octokit = {
-      repos: { listPullRequestsAssociatedWithCommit: listPRs },
-    } as unknown as Octokit;
+  /** Stand-in for octokit.graphql that serves a sha -> associated PRs map. */
+  function mockGraphql(
+    bySha: Record<string, Array<{ number: number; mergedAt: string | null }>>
+  ) {
+    return jest.fn(async (query: string) => {
+      const repository: Record<string, unknown> = {};
+      for (const [sha, nodes] of Object.entries(bySha)) {
+        // Only answer for shas the query actually asked about, so the test
+        // fails if alias construction drops or mangles a commit.
+        if (query.includes(`c${sha}: object(oid: "${sha}")`)) {
+          repository[`c${sha}`] = { associatedPullRequests: { nodes } };
+        }
+      }
+      return { repository };
+    });
+  }
 
-    const commits: CommitInfo[] = [{ sha: 'aaa' }, { sha: 'bbb' }, { sha: 'ccc' }];
+  const AAA = 'a'.repeat(40); // feature-branch commit, subject ended in "(#37132)"
+  const BBB = 'b'.repeat(40); // the two-parent merge commit for the same PR
+  const CCC = 'c'.repeat(40); // a direct push, unassociated with any PR
 
-    const prNumbers = await resolvePRNumbers(octokit, 'dotCMS', 'core', commits);
+  it('dedupes merge and branch commits, and ignores direct pushes (#37201)', async () => {
+    const graphql = mockGraphql({
+      [AAA]: [{ number: 37196, mergedAt: '2026-08-25T00:00:00Z' }],
+      [BBB]: [{ number: 37196, mergedAt: '2026-08-25T00:00:00Z' }],
+      [CCC]: [],
+    });
+    const octokit = { graphql } as unknown as Octokit;
 
-    expect(prNumbers).toEqual([37196]);
-    expect(listPRs).toHaveBeenCalledTimes(3);
+    const commits: CommitInfo[] = [{ sha: AAA }, { sha: BBB }, { sha: CCC }];
+    expect(await resolvePRNumbers(octokit, 'dotCMS', 'core', commits)).toEqual([37196]);
+    // The point of the migration: three commits, one round-trip.
+    expect(graphql).toHaveBeenCalledTimes(1);
   });
 
   it('filters out unmerged PRs', async () => {
-    const bySha: Record<string, Array<{ number: number; merged_at: string | null }>> = {
-      abc: [
-        { number: 1, merged_at: null },
-        { number: 2, merged_at: '2026-08-25T00:00:00Z' },
+    const graphql = mockGraphql({
+      [AAA]: [
+        { number: 1, mergedAt: null },
+        { number: 2, mergedAt: '2026-08-25T00:00:00Z' },
       ],
-    };
-    const listPRs = jest.fn(async ({ commit_sha }: { commit_sha: string }) => ({
-      data: bySha[commit_sha] ?? [],
-    }));
-    const octokit = {
-      repos: { listPullRequestsAssociatedWithCommit: listPRs },
-    } as unknown as Octokit;
-
-    const prNumbers = await resolvePRNumbers(octokit, 'dotCMS', 'core', [{ sha: 'abc' }]);
-
-    expect(prNumbers).toEqual([2]);
+    });
+    const octokit = { graphql } as unknown as Octokit;
+    expect(await resolvePRNumbers(octokit, 'dotCMS', 'core', [{ sha: AAA }])).toEqual([2]);
   });
 
-  // The per-commit catch is the "one bad sha can't abort the whole range" guarantee.
-  // It degrades silently, so this is the only thing that fails if it stops working.
-  it('does not abort the batch when one commit fails to resolve', async () => {
-    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
-
-    const bySha: Record<string, Array<{ number: number; merged_at: string | null }>> = {
-      good: [{ number: 42, merged_at: '2026-08-25T00:00:00Z' }],
-    };
-    const listPRs = jest.fn(async ({ commit_sha }: { commit_sha: string }) => ({
-      data: bySha[commit_sha] ?? [],
+  it('batches large ranges instead of one request per commit', async () => {
+    const commits: CommitInfo[] = Array.from({ length: 120 }, (_, i) => ({
+      sha: i.toString(16).padStart(40, '0'),
     }));
-    listPRs.mockImplementationOnce(() => Promise.reject(new Error('boom')));
-    const octokit = {
-      repos: { listPullRequestsAssociatedWithCommit: listPRs },
-    } as unknown as Octokit;
+    const graphql = jest.fn(async () => ({ repository: {} }));
+    const octokit = { graphql } as unknown as Octokit;
 
-    const prNumbers = await resolvePRNumbers(octokit, 'dotCMS', 'core', [
-      { sha: 'bad' },
-      { sha: 'good' },
+    await resolvePRNumbers(octokit, 'dotCMS', 'core', commits);
+    // 120 commits at COMMIT_BATCH=50 -> 3 queries, not 120.
+    expect(graphql).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips anything that is not a real oid rather than interpolating it', async () => {
+    const graphql = jest.fn(async () => ({ repository: {} }));
+    const octokit = { graphql } as unknown as Octokit;
+
+    await resolvePRNumbers(octokit, 'dotCMS', 'core', [
+      { sha: '") { __typename } evil: object(oid: "' },
+      { sha: 'abc' },
     ]);
+    expect(graphql).not.toHaveBeenCalled();
+  });
 
-    expect(prNumbers).toEqual([42]);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad'));
+  it('propagates GraphQL failures instead of silently dropping the batch', async () => {
+    const graphql = jest.fn(async () => {
+      throw new Error('502 Bad Gateway');
+    });
+    const octokit = { graphql } as unknown as Octokit;
 
-    stderrSpy.mockRestore();
+    await expect(
+      resolvePRNumbers(octokit, 'dotCMS', 'core', [{ sha: AAA }])
+    ).rejects.toThrow('502 Bad Gateway');
   });
 });
-
-// Bounds the throttling plugin's retries so an exhausted quota can't park a
-// release job indefinitely.
 
 describe('findPreviousTag', () => {
   const documented = (...tags: string[]) =>

--- a/.github/scripts/shared/github.test.ts
+++ b/.github/scripts/shared/github.test.ts
@@ -1,5 +1,6 @@
 import {
   findPreviousTag,
+  listStandardReleaseTags,
   onThrottle,
   parseRepo,
   resolvePRNumbers,
@@ -96,6 +97,50 @@ describe('resolvePRNumbers', () => {
     await expect(
       resolvePRNumbers(octokit, 'dotCMS', 'core', [{ sha: AAA }])
     ).rejects.toThrow('502 Bad Gateway');
+  });
+});
+
+describe('listStandardReleaseTags', () => {
+  /** Stand-in for octokit.paginate.iterator over repos.listReleases. */
+  function mockOctokit(data: { tag_name: string; draft: boolean; body: string | null }[]) {
+    return {
+      repos: { listReleases: {} },
+      paginate: { iterator: () => [{ data }][Symbol.iterator]() },
+    } as unknown as Octokit;
+  }
+
+  it('skips drafts, which listReleases returns first regardless of date (#37138)', async () => {
+    // Live state on dotCMS/core: 6 drafts match STANDARD_RELEASE_PATTERN and
+    // one of them duplicates a published tag, so an unfiltered list both
+    // mis-orders the walk-back and makes findIndex ambiguous.
+    const tags = await listStandardReleaseTags(
+      mockOctokit([
+        { tag_name: 'v26.04.11-02', draft: true, body: null },
+        { tag_name: 'v26.08.19-04', draft: false, body: 'notes' },
+        { tag_name: 'v26.04.11-02', draft: false, body: 'notes' },
+      ]),
+      'dotCMS',
+      'core'
+    );
+
+    expect(tags).toEqual([
+      { tag: 'v26.08.19-04', hasNotes: true },
+      { tag: 'v26.04.11-02', hasNotes: true },
+    ]);
+  });
+
+  it('ignores non-standard tags and reports an empty body as undocumented', async () => {
+    const tags = await listStandardReleaseTags(
+      mockOctokit([
+        { tag_name: 'dotcms-cli-1.2.3', draft: false, body: 'notes' },
+        { tag_name: 'v26.08.19-04_lts_01', draft: false, body: 'notes' },
+        { tag_name: 'v26.08.19-03', draft: false, body: '   ' },
+      ]),
+      'dotCMS',
+      'core'
+    );
+
+    expect(tags).toEqual([{ tag: 'v26.08.19-03', hasNotes: false }]);
   });
 });
 

--- a/.github/scripts/shared/github.ts
+++ b/.github/scripts/shared/github.ts
@@ -181,10 +181,28 @@ export async function fetchCommitRange(
 }
 
 /**
- * Resolve merged PRs per commit via GET /repos/{owner}/{repo}/commits/{sha}/pulls.
- * Commit subjects ending in "(#N)" are often an ISSUE number under merge commits,
- * and pulls.get 404s on those; the API also maps a PR's branch commits and its
- * merge commit to the same PR (Set dedupes) and returns [] for direct pushes.
+ * GraphQL aliases must be static field names, so batch size is bounded by
+ * query size rather than a page limit. 50 commits/query keeps each request
+ * well inside GitHub's node budget while cutting a 485-commit release from
+ * 485 round-trips to 10 — twice over, since both scripts resolve the same
+ * range in the same pipeline run.
+ */
+const COMMIT_BATCH = 50;
+
+interface CommitPRsResponse {
+  repository: Record<
+    string,
+    { associatedPullRequests: { nodes: { number: number; mergedAt: string | null }[] } } | null
+  >;
+}
+
+/**
+ * Resolve merged PRs for a set of commits via GraphQL `associatedPullRequests`.
+ *
+ * Same source of truth as GET /commits/{sha}/pulls, batched. A PR's branch
+ * commits and its merge commit both map to that PR (the Set dedupes), and a
+ * direct push maps to nothing. Unmerged PRs are filtered out: for commits not
+ * reachable from the default branch the association also includes open PRs.
  */
 export async function resolvePRNumbers(
   octokit: Octokit,
@@ -193,44 +211,45 @@ export async function resolvePRNumbers(
   commits: CommitInfo[]
 ): Promise<number[]> {
   const prNumbers = new Set<number>();
-  const BATCH_SIZE = 15;
 
-  for (let i = 0; i < commits.length; i += BATCH_SIZE) {
-    const batch = commits.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < commits.length; i += COMMIT_BATCH) {
+    const batch = commits
+      .slice(i, i + COMMIT_BATCH)
+      // Aliases are interpolated, not parameterised, so only accept real oids.
+      .filter((c) => /^[0-9a-f]{40}$/i.test(c.sha));
+    if (batch.length === 0) continue;
 
-    const promises = batch.map(async (commit) => {
-      try {
-        const { data } = await octokit.repos.listPullRequestsAssociatedWithCommit({
-          owner,
-          repo,
-          commit_sha: commit.sha,
-          // A default-branch commit resolves to the one merged PR that introduced
-          // it, so page 1 always suffices; this just clears the default 30.
-          per_page: 100,
-        });
-        // Only merged PRs: for commits not reachable from the default branch the
-        // endpoint also returns open PRs.
-        return data.filter((pr) => pr.merged_at).map((pr) => pr.number);
-      } catch (error: unknown) {
-        const errMsg = error instanceof Error ? error.message : String(error);
-        process.stderr.write(
-          `Warning: could not resolve PR for commit ${commit.sha}: ${errMsg}\n`
-        );
-        return [];
+    const aliases = batch
+      .map(
+        (c) =>
+          `  c${c.sha}: object(oid: "${c.sha}") {\n` +
+          `    ... on Commit {\n` +
+          `      associatedPullRequests(first: 5) { nodes { number mergedAt } }\n` +
+          `    }\n` +
+          `  }`
+      )
+      .join('\n');
+
+    // Re-thrown, not warned-and-skipped: an errored batch is indistinguishable
+    // from a batch of commits with no PRs, and swallowing it would silently
+    // drop up to 50 commits' worth of PRs — the exact failure mode #37201
+    // existed to eliminate.
+    const data = await octokit.graphql<CommitPRsResponse>(
+      `query($owner: String!, $repo: String!) {\n` +
+        `  repository(owner: $owner, name: $repo) {\n` +
+        aliases +
+        `\n  }\n}`,
+      { owner, repo }
+    );
+
+    for (const c of batch) {
+      const node = data.repository[`c${c.sha}`];
+      if (!node) continue; // commit not found in this repo (e.g. a fork's oid)
+      for (const pr of node.associatedPullRequests.nodes) {
+        if (pr.mergedAt) prNumbers.add(pr.number);
       }
-    });
-
-    const batchResults = await Promise.all(promises);
-    for (const numbers of batchResults) {
-      for (const n of numbers) prNumbers.add(n);
     }
-
-    if (i + BATCH_SIZE < commits.length) await sleep(500);
   }
 
   return Array.from(prNumbers);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Closes: #35763

> [!NOTE]
> **Draft, and stacked on #37387** (the transport extraction), which is itself now based on `main` since #37361 merged. Base retargets automatically as the stack lands. Not for review until #37387 is in.

## Why this is stacked

Because #37387 puts the transport in one place, this migration is written **once** and both release scripts get it. Before the extraction, the same change would have had to be applied twice — which is precisely the pattern that produced #37201 and #37138.

## The perf half

Commit→PR resolution was one REST call per commit. Under merge commits a release carries 5-10x more commits than PRs, so the loop scaled with the wrong number — and **both scripts resolve the same range in the same pipeline run**:

```
                    before                                    after
   ┌──────────────────────────────────┐        ┌──────────────────────────────┐
   │ gather-release-data              │        │ gather-release-data          │
   │   compare API              2     │        │   compare API            2   │  REST, unchanged
   │   /commits/{sha}/pulls   485     │        │   associatedPRs         10   │  50 commits/query
   │   /pulls/{n}              51     │  ───►  │   pullRequest            3   │  20 PRs/query
   │ release-qa-status                │        │ release-qa-status            │
   │   compare API              2     │        │   compare API            2   │
   │   /commits/{sha}/pulls   485     │        │   associatedPRs         10   │  shared code path
   │   /pulls/{n}              51     │        │   /pulls/{n}            51   │  needs author/url
   ├──────────────────────────────────┤        ├──────────────────────────────┤
   │ ~1,076 requests                  │        │ ~78 requests                 │
   │ + 35 × sleep(500) ≈ 17s          │        │ no sleeps on the shared path │
   └──────────────────────────────────┘        └──────────────────────────────┘
```

Those `sleep(500)` calls were added in #37213 to stay under the secondary rate limit. On the batched path they are unnecessary.

## The correctness half — the reason this is worth doing now

`gather-release-data` extracted linked issues with a body regex requiring whitespace **directly** after the keyword:

```js
/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi
```

| PR body | Old regex | GraphQL |
|---|:--:|:--:|
| `Closes #123` | ✅ | ✅ |
| `Closes: #123` | ❌ | ✅ |
| `Fixes: #123` | ❌ | ✅ |
| `closes dotCMS/core#123` | ❌ | ✅ |
| `Resolves: https://github.com/dotCMS/core/issues/123` | ❌ | ✅ |
| linked only via the Development sidebar | ❌ | ✅ |

`Closes: #NNN` — with the colon — is the form CLAUDE.md mandates for every dotCMS PR, because the `link-issue` merge gate requires it. **The house style was the one form that didn't match.**

`closingIssuesReferences` reads the relationship GitHub itself renders, so the regex is deleted rather than patched. (`release-qa-status` already used this API — it was ahead on linked issues and behind on commit→PR resolution, which is what interleaved drift looks like.)

## Verification

Both scripts run over `v26.08.24-01...v26.09.02-01` (485 commits, 51 PRs):

| | REST | GraphQL |
|---|---|---|
| PRs resolved | 51 | **51 — identical set** |
| Titles / labels / categories | — | **identical** |
| PRs with a linked issue | 25 / 51 | **48 / 51** |
| Issue refs total | 27 | **50** |
| Requests (both scripts) | ~1,076 | **~78** |

`release-qa-status`'s markdown report is unchanged apart from one issue label GitHub's own release automation edited between the two runs (`Next Release` → `Release : 26.09.03-01`).

The PR set, titles, labels and categories match exactly — for those fields this is a pure transport swap. The only behavioural change is linked issues, and it is a strict improvement. The three PRs still without a link genuinely close nothing.

**Don't read this as a speed PR.** Wall clock only moved 51s → 38s locally, where network latency dominates and CI runners are faster. The value is ~78 requests instead of ~1,076 inside the release pipeline, and the linked-issue fix.

## Tests

76 across the three packages. The GraphQL transport tests live in `shared/` and now cover both scripts at once: merge/branch commit dedup, unmerged-PR filtering, batch arithmetic (120 commits → 3 queries, not 120), oid validation rejecting an alias-injection attempt, and error propagation instead of silent batch loss. `gather-release-data` keeps its own tests for cross-repo ref filtering, body truncation and null body/labels.

Also re-adds draft-filtering coverage for `listStandardReleaseTags` (#37138), which #37140 shipped untested — now one test covers both scripts.

## Deliberately unchanged

- **Compare API stays REST** — no clean GraphQL equivalent for a merge-base range with pagination.
- **`listStandardReleaseTags` stays REST**, so `@octokit/plugin-throttling` stays with it. It still paginates the full release list, which is dozens of requests given the CLI and LTS tag volume.
- **`release-qa-status`'s `fetchPRDetails` stays REST.** It needs `author` / `authorType` / `url` for the Slack digest and is only ~7-51 calls; batching it is a separate change with its own review surface.
- **Errors are re-thrown, not warned-and-skipped.** An errored batch is indistinguishable from a batch with no PRs, and swallowing it would quietly shrink the changelog — the exact failure mode #37201 existed to kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
