### PR TITLE
docs(block-editor): add issue-resolution spec for #37340

### DIFF
--- a/specs/37340-emoji-text-node/spec.md
+++ b/specs/37340-emoji-text-node/spec.md
@@ -87,7 +87,9 @@ Decisions taken during `/speckit-clarify`. Earlier decisions from the specify se
   (3) `:name:`. Every renderer also emits a warning, in the JS SDKs via `console.warn` and in
   Java via `Logger.warn` (Constitution Principle II), with the message
   `[dotCMS Block Editor]: Emoji <name> is not supported`. Warned once per distinct name per
-  render pass so a page with repeats does not flood the console or the log.
+  render scope so a page with repeats does not flood the console or the log. The scope is
+  defined per surface (one render call in the JS SDKs; one `StoryBlockRenderHelper` instance —
+  i.e. one Story Block field render — in Java), so no request-scoped state is required.
 - Q: The two linked text nodes in the reported data are not adjacent — an unmarked `emoji` node
   sits between them. Should coalescing absorb it? → A: **Option A, narrowed to `emoji` nodes
   only.** A run of `text(link) + unmarked node + text(link)` collapses into a single `<a>` only
@@ -390,6 +392,16 @@ function.
   - The generated map is a **new drift surface**: if it falls behind the extension's `emojis`
     list, renderers resolve a `name` the editor can produce to nothing. The CI equality check in
     AC-012 is what prevents that, and is why generation is required over a hand-written table.
+  - **The cross-build handoff is the riskiest unproven mechanic in this change, and the plan
+    must prove it rather than assume it.** The map is generated from `@tiptap/extension-emoji`,
+    a `core-web` npm dependency, but consumed by `StoryBlockRenderHelper` on the Java
+    classpath. The `openapi.yaml` precedent is **not** a like-for-like comparison: that artifact
+    is generated *inside* the Maven build, whereas this one originates in the frontend
+    toolchain and must cross into Java resources. The plan must answer, concretely: which build
+    generates it, where the artifact is committed, how Java loads it, and how the CI diff-check
+    runs against a JS-produced file without requiring the frontend toolchain in the Java build.
+    If that handoff proves awkward, generating the table inside the Maven build from a
+    committed source of truth is the fallback to evaluate.
   - The map adds weight to three **published** npm packages (`@dotcms/react`, `@dotcms/vue`,
     `@dotcms/angular`). It must be tree-shakeable and must not land in `@dotcms/types`.
   - **Gap B is a consumer-visible output change** in those same published packages: content a
@@ -454,7 +466,14 @@ function.
   node's `text` when it carries one and otherwise the literal `:name:` — **never** empty
   output — and emits `[dotCMS Block Editor]: Emoji <name> is not supported` as a warning
   (`console.warn` in the JS SDKs, `Logger.warn` in Java). The warning fires once per distinct
-  unresolved name per render pass, not once per occurrence.
+  unresolved name per **render scope**, not once per occurrence. The render scope is defined
+  per surface, because "render pass" has no common meaning across them:
+  - **JS SDKs** — one render call of the block-editor renderer component.
+  - **Java / VTL** — one `StoryBlockRenderHelper` instance, i.e. one Story Block **field**
+    render including its nested blocks. `GenericRenderableImpl` creates at most one helper per
+    `toHtml` call and shares it across the recursion, so this scope needs no request-scoped
+    state. A page rendering N Story Block fields may therefore warn up to N times per distinct
+    name — bounded, and preferable to threading request state through the render path.
 
 **Renderers — Gap B (link run coalescing)**
 
@@ -506,7 +525,12 @@ function.
   rendered, never re-saved.
 - **Unit (JUnit)** for `StoryBlockRenderHelper` — the Gap B grouping and the map lookup, in
   `dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/content/util/`, alongside the
-  existing `StoryBlockAPIImplToMapTest`. Covers AC-014, AC-017 and the no-op path.
+  existing `StoryBlockAPIImplToMapTest`. Covers **AC-014 through AC-017** — including
+  **AC-015** (an unmarked `emoji` node is absorbed into the run) and **AC-016** (a non-`emoji`
+  unmarked atom breaks it), the two behaviors this Java grouping exists to implement — plus the
+  no-op path where nothing coalesces and the input is returned unchanged. AC-018 (nested marks
+  inside the anchor) is asserted at the VTL end-to-end layer instead, since it depends on macro
+  rendering rather than on grouping.
   `./mvnw test -pl :dotcms-core -Dtest=StoryBlockRenderHelperTest`
 - **Generated map and unresolved-name fallback** — AC-012 and AC-013. A CI step regenerates the map and fails on any diff against the
   committed artifact, plus a unit test asserting VTL and the SDKs agree on a sample of names.

--- a/specs/37340-emoji-text-node/spec.md
+++ b/specs/37340-emoji-text-node/spec.md
@@ -55,6 +55,47 @@ are the visible symptom of a defect that spans a large class of characters (meas
 - **How often**: every time an affected character is typed. Links still resolve and navigate,
   which is why this is Medium rather than High.
 
+## Clarifications
+
+Decisions taken during `/speckit-clarify`. Earlier decisions from the specify session are in
+[Resolved Decisions](#resolved-decisions).
+
+### Session 2026-09-03
+
+- Q: How do renderers resolve an `emoji` node's `name` attribute to a character, given no
+  shortcode table exists in Java or in any SDK? → A: **Option A — a generated shared map.**
+  Generate the `name` → character table at build time from `@tiptap/extension-emoji`'s own
+  `emojis` list, so it cannot drift from the editor. Expose it to the JS SDKs as a small runtime
+  module (**not** `@dotcms/types`, which is types-only) and to VTL through the existing
+  `StoryBlockRenderHelper`.
+- Q: Where does Gap B (adjacent-link coalescing) live for the VTL path — the Velocity macro,
+  Java, or the shared read path? → A: **Option A — pre-group in Java.**
+  `StoryBlockRenderHelper` merges adjacent same-link text nodes before the macro renders. The
+  `.vm`/`.vtl` edits stay additive, the mark-attribute equality logic becomes JUnit-testable
+  instead of interpreted per request, and no API contract changes. The four JS SDK renderers
+  still implement Gap B themselves.
+- Q: How do the three published SDK packages ship a change that alters rendered HTML for
+  content consumers already have? → A: **Option A — coordinated minor bump, independent
+  version numbers.** `@dotcms/react`, `@dotcms/vue` and `@dotcms/angular` are released
+  together, each with a `### Fixed` entry for Gap B that explicitly warns rendered HTML changes
+  for existing content (snapshot diffs expected), and an `### Added` entry for Gap A. Not a
+  major bump — the prior output is a WCAG 2.2 Level A failure, so the fix must be on by
+  default rather than opt-in.
+- Q: What does a renderer output for an `emoji` node whose `name` does not resolve? → A:
+  **Render the node's `text` if present, else the literal `:name:` — never nothing — and warn.**
+  Resolution precedence is: (1) the generated map, (2) the node's own `text` if it carries one,
+  (3) `:name:`. Every renderer also emits a warning, in the JS SDKs via `console.warn` and in
+  Java via `Logger.warn` (Constitution Principle II), with the message
+  `[dotCMS Block Editor]: Emoji <name> is not supported`. Warned once per distinct name per
+  render pass so a page with repeats does not flood the console or the log.
+- Q: The two linked text nodes in the reported data are not adjacent — an unmarked `emoji` node
+  sits between them. Should coalescing absorb it? → A: **Option A, narrowed to `emoji` nodes
+  only.** A run of `text(link) + unmarked node + text(link)` collapses into a single `<a>` only
+  when the intervening node is an **`emoji`** node carrying no marks and both `link` marks are
+  identical. Any other unmarked inline atom (e.g. `hardBreak`) is **not** absorbed and still
+  breaks the run. This confines the inference to the exact node type this defect produces,
+  rather than silently swallowing arbitrary nodes into links.
+
 ## Reproduction *(mandatory)*
 
 **Environment**: `main` (verified against commit `69073e17f1`), `@tiptap/extension-emoji@3.22.2`,
@@ -176,10 +217,27 @@ editor in jsdom):
     returns **zero** hits in any SDK.
   - `core-web/libs/sdk/types` — the shared `internal.ts` enum of Story Block node types has no
     `emoji` member; all three JS SDKs dispatch from it.
+  - **Release surface**: `package.json` + `CHANGELOG.md` for `@dotcms/react` (1.2.6),
+    `@dotcms/vue` (1.5.5) and `@dotcms/angular` (1.1.1). There is no changesets tooling in
+    `core-web` — versions are hand-bumped and changelogs hand-written (`## vX.Y.Z` with
+    `### Fixed` / `### Added`), so the release artifacts are part of the change, not a
+    follow-up.
   - `dotCMS/src/main/webapp/WEB-INF/velocity/` (`VM_global_library.vm`, `static/storyblock/render.vtl`)
     — **legacy Velocity macro surface**. Not `com.dotmarketing.*` Java, but legacy in style and
     the highest-risk edit in this change: the macro is shared by all Story Block rendering.
-  - No Java package under `com.dotcms.*` or `com.dotmarketing.*` is expected to change.
+  - `com.dotcms.rendering.velocity.viewtools.content.util.StoryBlockRenderHelper` — **modern**
+    `com.dotcms.*`. Carries **both** server-side responsibilities: Velocity cannot resolve a
+    shortcode to a character on its own, so the generated map is read here, and it also
+    pre-groups adjacent same-link text nodes so the macro never has to look ahead at siblings. This helper is already exposed in the Velocity context as
+    `$dotStoryBlockRenderHelper` and already invoked as `.render($element)` from `render.vtl`,
+    so the resolution extends an established extension point rather than adding a new Velocity
+    tool. **Legacy Impact is therefore lower than a Velocity-only fix would suggest**: the Java
+    edit lands in a modern package, and the `.vm`/`.vtl` edits stay additive.
+  - A **generated** `name` → character map, produced at build time from
+    `@tiptap/extension-emoji`'s `emojis` list and consumed by both the JS SDKs and the Java
+    helper. CI must verify the committed artifact matches what the build produces — the same
+    guarantee the repo already applies to `openapi.yaml`.
+  - No `com.dotmarketing.*` Java package is expected to change.
 - **Related known decisions**:
   - #37175 established that `link`, `emoji`, and `youtube` are registered **regardless of a
     field's Allowed Blocks**, so that stored content authored with them still parses. That
@@ -216,8 +274,10 @@ this bug makes visible, and both must be addressed for already-stored content:
 
 - **Gap A** — no renderer has an `emoji` branch, so the character is dropped (VTL) or renders
   as an unknown block (React, Vue, and both Angular renderers).
-- **Gap B** — no renderer coalesces adjacent text nodes that share an identical `link` mark, so
-  each emits its own `<a>`. All five renderer implementations use the same recursive
+- **Gap B** — no renderer coalesces text nodes that share an identical `link` mark, so
+  each emits its own `<a>`. In the reported data the two linked text nodes are not even
+  adjacent — the unmarked `emoji` node sits between them — so plain adjacency merging is not
+  sufficient on its own. All five renderer implementations use the same recursive
   "outermost mark wraps the rest" pattern and none looks at its siblings, which is precisely
   why none of them coalesce. This is latent for any stored JSON with adjacent same-link text
   nodes and predates the new editor.
@@ -252,9 +312,32 @@ function.
   renderers** (React, Vue, Angular standard, Angular semantic), plus the `emoji` member in the
   shared `libs/sdk/types` node-type enum, so already-stored `emoji` nodes render their character
   as inline text and never as a block-level element inside a `<p>`.
-- **Gap B** — coalesce adjacent text nodes sharing an identical `link` mark into a single `<a>`
-  in VTL and in all four JS SDK renderers, comparing full mark attributes so links differing in
-  `href`, `target`, `rel`, `title`, or `aria-label` stay separate.
+- **The `name` → character map that Gap A depends on**, generated at build time from
+  `@tiptap/extension-emoji`'s `emojis` list so it cannot drift from the editor. Consumed by the
+  JS SDKs via a small runtime module and by VTL via `StoryBlockRenderHelper`. A CI check
+  verifies the committed artifact matches the generated one.
+- **A defined, identical fallback in all five renderers** when a `name` does not resolve —
+  reachable because no Story Block schema validation was found in `dotCMS/src/main/java`, so
+  arbitrary node JSON can arrive through the Contentlet REST API. Precedence: map → the node's
+  own `text` → `:name:`. Never empty, plus a warning (see Clarifications).
+- **Gap B** — collapse a run of text nodes sharing an identical `link` mark into a single `<a>`,
+  comparing full mark attributes so links differing in `href`, `target`, `rel`, `title`, or
+  `aria-label` stay separate. A run continues across an intervening **`emoji` node that carries
+  no marks**, which is absorbed into the anchor; any other unmarked inline atom breaks the run.
+  Two stored shapes must both resolve to one anchor:
+  - **Shape 1** — emoji typed *into* linked text: `text(link) + emoji(no marks) + text(link)`.
+    The reported case; needs the absorption rule.
+  - **Shape 2** — link applied *over* an existing emoji node: the `emoji` node carries the
+    `link` mark and already renders as one anchor today.
+
+  Implemented per surface:
+  - **VTL** — the grouping happens in `StoryBlockRenderHelper` (Java), *before* the macro
+    renders. The `.vm`/`.vtl` change stays additive; no sibling lookahead in Velocity.
+  - **JS SDKs** — each of the four renderers implements the grouping itself, against the same
+    shared fixture so all surfaces agree.
+- **Release artifacts for the three published SDK packages**: a coordinated minor version bump
+  (independent numbers) plus `CHANGELOG.md` entries — `### Added` for Gap A, `### Fixed` for
+  Gap B with an explicit warning that rendered HTML changes for existing content.
 - Regression coverage at each layer, per Constitution Principle V.
 
 **Explicitly out of scope / non-goals**:
@@ -280,10 +363,13 @@ function.
 ## Regression Risk *(mandatory)*
 
 - **Blast radius**:
-  - **Highest risk is the VTL macro.** `VM_global_library.vm` renders *every* Story Block field
-    on *every* VTL-rendered page, for all customers, flag or no flag. Gap B changes how text
-    runs are grouped there. A defect introduced in coalescing affects far more content than
-    this bug does.
+  - **Highest risk is the VTL path.** `VM_global_library.vm` renders *every* Story Block field
+    on *every* VTL-rendered page, for all customers, flag or no flag. A defect in coalescing
+    affects far more content than this bug does.
+    **Mitigated by the Q2 decision**: the grouping logic moves into `StoryBlockRenderHelper`
+    (Java), so it is JUnit-testable in isolation and the interpreted macro edit stays additive.
+    The residual risk is that the helper now sits on the render path for every Story Block —
+    it must be allocation-cheap and must return the input unchanged when nothing coalesces.
   - The React, Vue, and both Angular SDK text renderers carry the same coalescing risk for
     headless consumers — five implementations of the same logic, which must stay behaviourally
     identical or the same content renders differently per framework.
@@ -300,7 +386,17 @@ function.
     literal text.
   - No REST contract, DB schema, or ES mapping changes. Not rollback-unsafe in the
     [documented categories](../../docs/core/ROLLBACK_UNSAFE_CATEGORIES.md) **unless** a data
-    migration is chosen.
+    migration is chosen — and render-only was decided, so none is.
+  - The generated map is a **new drift surface**: if it falls behind the extension's `emojis`
+    list, renderers resolve a `name` the editor can produce to nothing. The CI equality check in
+    AC-012 is what prevents that, and is why generation is required over a hand-written table.
+  - The map adds weight to three **published** npm packages (`@dotcms/react`, `@dotcms/vue`,
+    `@dotcms/angular`). It must be tree-shakeable and must not land in `@dotcms/types`.
+  - **Gap B is a consumer-visible output change** in those same published packages: content a
+    consumer already has starts rendering one `<a>` where it rendered two. Downstream snapshot
+    tests will diff, and CSS relying on adjacent-anchor selectors may shift. Shipped as a minor
+    bump with an explicit changelog warning rather than opt-in, because the prior output is a
+    WCAG 2.2 Level A failure and must not stay on by default.
   - Renderer coalescing must not merge across differing mark attributes, and must keep other
     marks (e.g. `bold`) nested correctly inside the single `<a>`.
   - This change **contradicts an acceptance criterion in issue #37340**, which requires
@@ -312,7 +408,7 @@ function.
     rendering, which is why it is in scope rather than optional.
   - **Decided: render-only.** Stored `emoji` nodes are NOT normalized — no data migration and
     no heal-on-load. Gap A and Gap B make existing content render correctly without a re-save,
-    which satisfies AC-015 on its own and keeps this change out of Java, the DB, and
+    which satisfies AC-019 on its own and keeps this change out of Java, the DB, and
     rollback-relevant territory. Accepted consequence: old `emoji` nodes persist indefinitely,
     so the legacy-editor drop path and the `<img>` fallback stay live for that content.
 
@@ -351,23 +447,43 @@ function.
   input instead of falling through to their unknown-block component.
 - **AC-011**: No renderer emits a block-level element (e.g. `<div>`) inside a `<p>` for an
   `emoji` node, in UVE or on the live site.
+- **AC-012**: The `name` → character map is generated from `@tiptap/extension-emoji`'s `emojis`
+  list, and a CI check fails if the committed artifact does not match what the build produces.
+  VTL and all four JS SDK renderers resolve a given `name` to the **same** character.
+- **AC-013**: For an `emoji` node whose `name` does not resolve, every renderer outputs the
+  node's `text` when it carries one and otherwise the literal `:name:` — **never** empty
+  output — and emits `[dotCMS Block Editor]: Emoji <name> is not supported` as a warning
+  (`console.warn` in the JS SDKs, `Logger.warn` in Java). The warning fires once per distinct
+  unresolved name per render pass, not once per occurrence.
 
-**Renderers — Gap B (adjacent-link coalescing)**
+**Renderers — Gap B (link run coalescing)**
 
-- **AC-012**: Given stored JSON with adjacent text nodes sharing an identical `link` mark, VTL
+- **AC-014**: Given stored JSON with adjacent text nodes sharing an identical `link` mark, VTL
   and all four JS SDK renderers each emit exactly **one** `<a>`.
-- **AC-013**: Given adjacent text nodes whose `link` marks differ in any of `href`, `target`,
+- **AC-015**: **Shape 1** — given `text(link) + emoji(no marks) + text(link)` with identical
+  `link` marks, every renderer emits exactly **one** `<a>` containing the emoji character
+  inline. This is the reported customer payload.
+- **AC-016**: An intervening unmarked inline atom that is **not** an `emoji` node (e.g.
+  `hardBreak`) is **not** absorbed: the run breaks and two `<a>` elements are emitted.
+- **AC-017**: Given adjacent text nodes whose `link` marks differ in any of `href`, `target`,
   `rel`, `title`, or `aria-label`, each renderer emits **two** `<a>` elements.
-- **AC-014**: A `bold` (or other) mark inside a coalesced link still nests correctly within the
+- **AC-018**: A `bold` (or other) mark inside a coalesced link still nests correctly within the
   single `<a>`.
-- **AC-015**: Content already saved with the split renders as a single link **without requiring
+- **AC-019**: Content already saved with the split renders as a single link **without requiring
   a re-save**.
 
 **Accessibility verification**
 
-- **AC-016**: Tabbing through the rendered link produces exactly **one** focus stop.
-- **AC-017**: The NVDA Elements List / VoiceOver rotor shows **one** entry carrying the
+- **AC-020**: Tabbing through the rendered link produces exactly **one** focus stop.
+- **AC-021**: The NVDA Elements List / VoiceOver rotor shows **one** entry carrying the
   complete accessible name, including the symbol.
+
+**Release**
+
+- **AC-022**: `@dotcms/react`, `@dotcms/vue` and `@dotcms/angular` each carry a minor version
+  bump and a `CHANGELOG.md` entry for this release: `### Added` for `emoji` node support,
+  `### Fixed` for link run coalescing, the latter stating explicitly that rendered HTML
+  changes for existing content.
 
 **Verification method**:
 
@@ -376,18 +492,27 @@ function.
   the class, not three literals, is covered. Use real `NgZone` in service tests; a mocked one
   breaks the change-detection scheduler.
   `pnpm nx test new-block-editor`
-- **Unit (Jest)** for the React, Vue, and Angular SDK renderers — AC-010 through AC-014. The
+- **Unit (Jest)** for the React, Vue, and Angular SDK renderers — AC-010 through AC-018. The
   Angular SDK needs both of its renderers covered.
   `pnpm nx test sdk-react` / `pnpm nx test sdk-vue` / `pnpm nx test sdk-angular`
-- **VTL renderer** — AC-009, AC-011 through AC-014. Exercised via a Postman collection
+- **VTL renderer end-to-end** — AC-009, AC-011 through AC-018, on top of the JUnit coverage
+  above. Exercised via a Postman collection
   rendering a fixture contentlet whose Story Block field holds both an `emoji` node and
   adjacent same-link text nodes.
   `./mvnw verify -pl :dotcms-postman -Dpostman.test.skip=false -Dpostman.collections=<collection>`
 - **Regression fixture** — a stored-JSON fixture reproducing the exact three-node payload from
   the Actual Behavior section, shared across the renderer test suites so all five renderer
-  implementations assert against identical input. This fixture is what proves **AC-015**: it is only ever
+  implementations assert against identical input. This fixture is what proves **AC-019**: it is only ever
   rendered, never re-saved.
-- **Manual accessibility pass** — AC-016 and AC-017, with NVDA and with VoiceOver. Not
+- **Unit (JUnit)** for `StoryBlockRenderHelper` — the Gap B grouping and the map lookup, in
+  `dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/content/util/`, alongside the
+  existing `StoryBlockAPIImplToMapTest`. Covers AC-014, AC-017 and the no-op path.
+  `./mvnw test -pl :dotcms-core -Dtest=StoryBlockRenderHelperTest`
+- **Generated map and unresolved-name fallback** — AC-012 and AC-013. A CI step regenerates the map and fails on any diff against the
+  committed artifact, plus a unit test asserting VTL and the SDKs agree on a sample of names.
+- **Release artifacts** — AC-022. Reviewed on the PR: three `package.json` bumps and three
+  `CHANGELOG.md` entries. No automated gate exists, so this is a review checklist item.
+- **Manual accessibility pass** — AC-020 and AC-021, with NVDA and with VoiceOver. Not
   automatable; must be recorded in the post-merge QA plan.
 
 Per Constitution Principle V, these tests are written, developer-approved, and confirmed
@@ -420,7 +545,7 @@ spec carries no `[NEEDS CLARIFICATION]` markers.
 
 | # | Question | Decision | Rationale / consequence |
 | --- | --- | --- | --- |
-| 1 | Existing stored `emoji` nodes — render-only, heal-on-edit, or migrate? | **Render-only** | Gap A + Gap B satisfy AC-015 without a re-save. No Java, no DB, not rollback-relevant. Accepted trade-off: old nodes persist, so the legacy-editor drop path and the `<img>` fallback stay live for that content. |
+| 1 | Existing stored `emoji` nodes — render-only, heal-on-edit, or migrate? | **Render-only** | Gap A + Gap B satisfy AC-019 without a re-save. No Java, no DB, not rollback-relevant. Accepted trade-off: old nodes persist, so the legacy-editor drop path and the `<img>` fallback stay live for that content. |
 | 2 | `enableEmoticons` (`:)`) — keep as text, or drop? | **Insert literal character** | Preserves a shortcut authors already use, while removing the node creation that strips marks. `:)` now yields `🙂` inside the text node. Covered by AC-006. |
 | 3 | Does AC-002's character sample need to be exhaustive? | **Representative sample** | All 3 reported symbols, ~20 further text-presentation characters, plus pictographic and multi-codepoint cases (ZWJ sequence, flag). Fast, readable, and stable across extension upgrades. |
 

--- a/specs/37340-emoji-text-node/spec.md
+++ b/specs/37340-emoji-text-node/spec.md
@@ -1,0 +1,433 @@
+# Issue Resolution Specification: Block Editor emoji conversion splits marked text and drops characters
+
+**Feature Branch**: `37340-emoji-text-node`
+
+**Created**: 2026-09-03
+
+**Status**: Draft
+
+**Type**: Issue / Bug Resolution
+
+**Related GitHub Issue**: [#37340](https://github.com/dotCMS/core/issues/37340) — *AC amendment required, see Assumptions*
+
+**Input**: User description: "Giving you the context of the ticket and my two doubts; let's start the specify fix. Keep in mind that we want to preserve the node registration for compatibility, and we need to fix the whole class. I think the best approach is that if an emoji is added inside a paragraph, it should be part of that node instead of a standalone emoji node."
+
+<!--
+  This is the dotCMS ISSUE-RESOLUTION spec (used by /speckit-specify-fix). Unlike the
+  feature spec, it is framed around a defect: what is wrong, how to reproduce it, and how
+  we will know it is fixed. It still flows into /speckit-plan, where the Legacy Impact and
+  ADR Alignment gates apply. Keep this technology-light — root-cause and fix details are
+  refined in the plan.
+-->
+
+## Problem Statement *(mandatory)*
+
+When a content author types or pastes any character that Unicode classifies as an emoji into
+Block Editor text, the editor silently replaces that character with a standalone `emoji`
+node. The replacement node is created **bare** — it carries none of the formatting that
+surrounded it.
+
+Two consequences follow, both persisted into the stored Story Block JSON:
+
+1. **Marked text is torn in two.** A single linked phrase becomes `text(link)` +
+   `emoji(no marks)` + `text(link)`. The rendered output is two `<a>` elements where the
+   author created one.
+2. **The character is lost on published pages.** The stored node holds only a shortcode
+   (`{"type":"emoji","attrs":{"name":"copyright"}}`) — no literal character. Consumers with
+   no `emoji` branch drop it entirely: the VTL renderer emits nothing, and **all three JS SDKs
+   (React, Vue, Angular)** fall through to their unknown-block component.
+
+The customer reported this for `©`, `®`, and `™`. Those three are not a special case — they
+are the visible symptom of a defect that spans a large class of characters (measured below).
+
+**Severity / Impact**: Medium.
+
+- **Who**: any author using the new Block Editor (`FEATURE_FLAG_NEW_BLOCK_EDITOR`), plus every
+  downstream consumer of the content they authored.
+- **Accessibility** — the reported symptom. One logical link yields two keyboard tab stops and
+  two entries in the NVDA Elements List / VoiceOver rotor, with the announcement fragmented
+  ("link dotCMS Copyright", then "link All rights reserved"). Maps to WCAG 2.2 Level A
+  failures: 1.3.1 Info and Relationships, 2.4.4 Link Purpose (In Context), 4.1.2 Name, Role,
+  Value. Closest documented technique is H2 (combining adjacent links to the same resource).
+- **Content loss** — on VTL-rendered pages the character disappears from published output.
+  Legal symbols (`©`, `®`, `™`) vanishing from a footer is a customer-visible defect
+  independent of accessibility.
+- **How often**: every time an affected character is typed. Links still resolve and navigate,
+  which is why this is Medium rather than High.
+
+## Reproduction *(mandatory)*
+
+**Environment**: `main` (verified against commit `69073e17f1`), `@tiptap/extension-emoji@3.22.2`,
+`emoji-regex@10.6.0`. Requires `FEATURE_FLAG_NEW_BLOCK_EDITOR` enabled. Not browser-specific —
+the defect is in the stored document, so it reproduces in any browser and in any renderer.
+
+**Steps to Reproduce**:
+
+1. Enable `FEATURE_FLAG_NEW_BLOCK_EDITOR`.
+2. Edit a contentlet with a Story Block (Block Editor) field.
+3. Type `dotCMS Copyright All rights reserved` in a paragraph.
+4. Select the whole line and apply a link to `https://dotcms.com`.
+5. Place the cursor between `Copyright ` and `All`, then type or paste `©`.
+6. Observe the underline break — the single link is now two links. Save the contentlet.
+7. Inspect the stored field JSON.
+8. Render the content through VTL and through the React/Vue SDK on a page.
+9. Tab through the rendered link.
+
+**Expected Behavior**:
+
+- Step 6: the link stays visually and structurally intact.
+- Step 7: one `text` node carrying one `link` mark, with `©` inside its text.
+- Step 8: `<p><a href="https://dotcms.com">dotCMS Copyright © All rights reserved</a></p>`.
+- Step 9: exactly one focus stop; one screen-reader entry with the complete accessible name.
+
+**Actual Behavior**:
+
+- Step 7 — three nodes, the middle one unmarked:
+
+  ```json
+  [
+    { "type": "text", "marks": [{ "type": "link", "attrs": { "href": "https://dotcms.com" } }],
+      "text": "dotCMS Copyright " },
+    { "type": "emoji", "attrs": { "name": "copyright" } },
+    { "type": "text", "marks": [{ "type": "link", "attrs": { "href": "https://dotcms.com" } }],
+      "text": "All rights reserved" }
+  ]
+  ```
+
+- Step 8 — two anchors, and under VTL the `©` is absent entirely:
+
+  ```html
+  <p>
+    <a href="https://dotcms.com">dotCMS Copyright </a>
+    <span data-name="copyright" data-type="emoji">©</span>
+    <a href="https://dotcms.com">All rights reserved</a>
+  </p>
+  ```
+
+- Step 9 — two tab stops, two rotor entries, fragmented announcement.
+
+**Reproducibility**: Always, for any character in the affected class.
+
+**Measured scope of the affected class** (script run against the shipped extension: each entry
+in the extension's `emojis` list tested against `emoji-regex@10.6.0` followed by the same
+`emojiToShortcode` lookup the conversion performs):
+
+| Measure | Count |
+| --- | --- |
+| Entries in the extension's `emojis` list | 1949 |
+| Entries that convert to an `emoji` node when typed | **1907** |
+| …of those, **text-presentation** (no `Emoji_Presentation` property — render as typography, not as pictures) | **219** |
+| …of those, pictographic | 1688 |
+
+The 219 text-presentation characters are the ones authors type as ordinary punctuation and
+have no reason to expect to become emoji. They include, beyond the three reported:
+
+```
+‼ ⁉ ✔ ✖ ✂ ✏ ✒ ⚠ ℹ ♻ ▪ ▫ ◼ ◻ ↔ ↕ ↖ ↗ ↘ ↙ ↩ ↪ ⤴ ⤵ ⬅ ⬆ ⬇ ➡
+♀ ♂ ⚧ ✝ ✡ ☪ ☯ ☮ ⚖ ⚙ ☎ ✉ 〰 〽 ✳ ✴ ❇ ⚛ ♾ ⚕ ⚜ ㊗ ㊙ Ⓜ ☑ ▶ ◀ ⏸ ⏹
+```
+
+A `✔` inside a linked list item splits that link exactly as `©` does.
+
+**Additional verified findings that shape the fix** (each reproduced against a real TipTap
+editor in jsdom):
+
+- **Applying a link over an *existing* `emoji` node already works.** The link mark is applied,
+  one `<a>` is produced, and the mark survives a save/reload round-trip. `allowsMarkType(link)`
+  reports `false` for the node, but ProseMirror does not enforce that for atoms in these code
+  paths. **No schema change is needed for mark inheritance.**
+- **The split is therefore an ordering defect, not a schema limitation.** The conversion runs
+  after the mark is applied and rebuilds the node without marks, destroying the mark that was
+  already there.
+- **Narrowing the extension's `emojis` option is not a viable fix.** That option also feeds
+  rendering, so removing an entry makes already-stored nodes of that name render as a literal
+  shortcode. Verified:
+
+  ```text
+  full list      → "dotCMS © 2026"
+  filtered list  → "dotCMS :copyright: 2026"
+  ```
+
+- **The image fallback is broader than the issue records.** 1908 of 1949 entries carry a
+  `fallbackImage` pointing at `cdn.jsdelivr.net`. The render path takes it whenever
+  `isEmojiSupported()` returns false, even with `forceFallbackImages: false`, producing
+  `<img alt="copyright emoji">` and a third-party request from the editor. The 26
+  `regional_indicator_*` entries have no `version`, so their support check is
+  unconditionally false and they always render as an image.
+
+## Scope of Investigation *(mandatory)*
+
+<!--
+  Keep to WHAT is affected, not the code-level fix (that is the plan's job). But DO name the
+  product area, since dotCMS mixes modern and legacy surfaces — this drives Legacy Impact in
+  the plan.
+-->
+
+- **Affected area**: content editing (new Block Editor authoring) and page rendering (Story
+  Block renderers — VTL and the JS SDKs). No REST contract, DB schema, or Elasticsearch
+  mapping is involved unless a data migration is chosen (see Regression Risk).
+- **Suspected surface**: predominantly modern and frontend.
+  - `core-web/libs/new-block-editor` — Angular, modern. Where the conversion is registered.
+  - `core-web/libs/sdk/react`, `core-web/libs/sdk/vue`, `core-web/libs/sdk/angular` — modern.
+    **The Angular SDK ships two independent Block Editor renderers** (`dotcms-block-editor-renderer`
+    and the semantic/native successor `dotcms-block-editor-renderer-semantic`), each with its own
+    node dispatch and its own recursive mark renderer. Neither is mentioned in #37340; both carry
+    Gap A and Gap B identically. Verified: `grep` for an `emoji` node type across `libs/sdk/`
+    returns **zero** hits in any SDK.
+  - `core-web/libs/sdk/types` — the shared `internal.ts` enum of Story Block node types has no
+    `emoji` member; all three JS SDKs dispatch from it.
+  - `dotCMS/src/main/webapp/WEB-INF/velocity/` (`VM_global_library.vm`, `static/storyblock/render.vtl`)
+    — **legacy Velocity macro surface**. Not `com.dotmarketing.*` Java, but legacy in style and
+    the highest-risk edit in this change: the macro is shared by all Story Block rendering.
+  - No Java package under `com.dotcms.*` or `com.dotmarketing.*` is expected to change.
+- **Related known decisions**:
+  - #37175 established that `link`, `emoji`, and `youtube` are registered **regardless of a
+    field's Allowed Blocks**, so that stored content authored with them still parses. That
+    decision is binding here and is why registration is preserved.
+  - #37145 established that dropping a registration TipTap needs to parse stored content is a
+    data-loss path — removing the `Highlight` mark caused TipTap to abort the whole document.
+  - `core-web/libs/new-block-editor/CLAUDE.md` documents the same legacy-compat reasoning for
+    the `AIContent` node: the registration exists solely so old content parses, and removing
+    it "would silently drop those blocks on load".
+  - The plan formally consults `dotCMS/platform-adrs`.
+
+**Observation for planning** (not a defect): the extension's `addStorage` runs a canvas-based
+`isEmojiSupported()` probe once per distinct emoji version at editor construction. This cost
+remains as long as the node is registered, and is worth measuring but is not in scope to fix.
+
+## Root-Cause Hypothesis
+
+The `emoji` extension's `appendTransaction` hook runs on **every** document change. It scans
+changed text nodes with `emoji-regex`, and for each match found in its `emojis` list it
+replaces the matched range with a new inline `emoji` node.
+
+Two properties of that replacement produce the defect:
+
+1. **It is indiscriminate.** The gate is "is this character in the Unicode emoji set", which
+   is true for 1907 of 1949 catalogued characters — including 219 that render as typography
+   and that authors type as ordinary text. There is no notion of author intent.
+2. **It discards formatting.** The replacement creates the node with no marks. The hook does
+   set stored marks afterwards, but stored marks only affect what the author types *next* —
+   they are never applied to the node just created. So any mark the replaced text carried is
+   lost at that position, splitting the surrounding run.
+
+The two renderer gaps identified in the issue are **independent pre-existing defects** that
+this bug makes visible, and both must be addressed for already-stored content:
+
+- **Gap A** — no renderer has an `emoji` branch, so the character is dropped (VTL) or renders
+  as an unknown block (React, Vue, and both Angular renderers).
+- **Gap B** — no renderer coalesces adjacent text nodes that share an identical `link` mark, so
+  each emits its own `<a>`. All five renderer implementations use the same recursive
+  "outermost mark wraps the rest" pattern and none looks at its siblings, which is precisely
+  why none of them coalesce. This is latent for any stored JSON with adjacent same-link text
+  nodes and predates the new editor.
+
+## Fix Scope & Non-Goals *(mandatory)*
+
+**Chosen approach** (developer decision, per user input): *an emoji typed or pasted into
+paragraph text stays part of that text node.* Suppress the automatic
+character-to-node conversion entirely, while keeping the `emoji` node **registered** so that
+content already saved with `emoji` nodes continues to parse and render.
+
+This approach was selected over a per-character allowlist because it fixes the entire class in
+one change, requires no list to maintain across extension upgrades, and eliminates the marks
+problem structurally — text nodes carry marks natively, so there is no node left to strip
+them. It is also consistent with how insertion already works: the emoji picker calls
+`insertContent(emoji.native)` with a raw character, so the picker needs no `emoji` node to
+function.
+
+**In scope**:
+
+- Suppress automatic conversion of typed or pasted characters into `emoji` nodes, for the
+  whole affected class — all 1907 convertible characters, not only `©`/`®`/`™`.
+- Keep the `emoji` node registered, with its `emojis` option **unfiltered**, so already-stored
+  `emoji` nodes still parse and still resolve their character.
+- Keep emoji insertion working end to end: the toolbar picker inserts the literal character
+  into the text node, and it inherits the surrounding marks like any other typed character.
+- Redirect the `:)`-style emoticon input rule (`enableEmoticons`, gated on `has('emoji')`) to
+  insert the literal character into the text node instead of creating an `emoji` node. The
+  shortcut is preserved for authors who use it; only its output changes.
+- Preserve behavior parity whether or not `emoji` appears in a field's Allowed Blocks.
+- **Gap A** — add an `emoji` branch to the VTL Story Block renderer and to **all four JS SDK
+  renderers** (React, Vue, Angular standard, Angular semantic), plus the `emoji` member in the
+  shared `libs/sdk/types` node-type enum, so already-stored `emoji` nodes render their character
+  as inline text and never as a block-level element inside a `<p>`.
+- **Gap B** — coalesce adjacent text nodes sharing an identical `link` mark into a single `<a>`
+  in VTL and in all four JS SDK renderers, comparing full mark attributes so links differing in
+  `href`, `target`, `rel`, `title`, or `aria-label` stay separate.
+- Regression coverage at each layer, per Constitution Principle V.
+
+**Explicitly out of scope / non-goals**:
+
+- **The legacy Block Editor** (`core-web/libs/block-editor`). It never registered the emoji
+  extension, so it cannot create this split.
+- **Removing the `emoji` node registration.** Explicitly preserved for backward compatibility.
+- **Shortcode authoring as a feature.** The `:` suggestion trigger is already inert by design;
+  this change does not add or restore `:rocket:` shortcode entry.
+- **A report of affected contentlets.** #37340 asks for a query identifying content already
+  carrying the split. It is read-only and useful, but explicitly deferred out of this change —
+  track it separately.
+- **Reworking the extension's image-fallback path** beyond what Gap A requires. The
+  `cdn.jsdelivr.net` dependency and the `<img alt="… emoji">` accessible name are recorded
+  here as findings and should be tracked separately.
+- **The `isEmojiSupported()` startup cost.** Measured and noted, not fixed here.
+- **Any wholesale rewrite of the VTL Story Block macro.** Gap A and Gap B are additive edits;
+  progressive enhancement only, per Constitution Principle I.
+- **Emoji-only-link accessible naming.** A link whose entire text is one emoji gets its
+  accessible name from that character and may fail WCAG 2.4.4. The link popover already
+  supports `aria-label` for this. Authoring guidance, not a code defect.
+
+## Regression Risk *(mandatory)*
+
+- **Blast radius**:
+  - **Highest risk is the VTL macro.** `VM_global_library.vm` renders *every* Story Block field
+    on *every* VTL-rendered page, for all customers, flag or no flag. Gap B changes how text
+    runs are grouped there. A defect introduced in coalescing affects far more content than
+    this bug does.
+  - The React, Vue, and both Angular SDK text renderers carry the same coalescing risk for
+    headless consumers — five implementations of the same logic, which must stay behaviourally
+    identical or the same content renders differently per framework.
+  - Within the editor, suppressing conversion touches the shared `appendTransaction` path, so
+    every Block Editor keystroke is on that path.
+  - **Cross-editor exposure**: content authored in the new editor and then opened in the
+    **legacy** editor is a pre-existing loss path — the legacy editor has no `emoji`
+    registration, and by the mechanism documented for `AIContent` the node would be dropped on
+    load. This change reduces future exposure by not creating new nodes, but does not fix
+    existing ones. **The plan should confirm this behavior empirically.**
+- **Backward compatibility**:
+  - Stored `emoji` nodes MUST keep working. The node stays registered and `emojis` stays
+    unfiltered — the verified failure mode of filtering it is rendering `:copyright:` as
+    literal text.
+  - No REST contract, DB schema, or ES mapping changes. Not rollback-unsafe in the
+    [documented categories](../../docs/core/ROLLBACK_UNSAFE_CATEGORIES.md) **unless** a data
+    migration is chosen.
+  - Renderer coalescing must not merge across differing mark attributes, and must keep other
+    marks (e.g. `bold`) nested correctly inside the single `<a>`.
+  - This change **contradicts an acceptance criterion in issue #37340**, which requires
+    pictographic emoji to keep producing `emoji` nodes. See Assumptions.
+- **Data considerations**:
+  - Content already saved with the split needs to render as one link **without a re-save**.
+    Gap B coalescing achieves this at render time and is the preferred path.
+  - Existing `emoji` nodes remain in stored content indefinitely. Gap A is what keeps them
+    rendering, which is why it is in scope rather than optional.
+  - **Decided: render-only.** Stored `emoji` nodes are NOT normalized — no data migration and
+    no heal-on-load. Gap A and Gap B make existing content render correctly without a re-save,
+    which satisfies AC-015 on its own and keeps this change out of Java, the DB, and
+    rollback-relevant territory. Accepted consequence: old `emoji` nodes persist indefinitely,
+    so the legacy-editor drop path and the `<img>` fallback stay live for that content.
+
+## Acceptance & Verification *(mandatory)*
+
+<!-- Measurable, so the fix is provably done. -->
+
+**Editor — root cause**
+
+- **AC-001**: The reproduction steps above no longer produce the actual behavior; they produce
+  the expected behavior. Specifically, step 7 yields exactly one `text` node carrying one
+  `link` mark whose text contains `©`.
+- **AC-002**: Typing or pasting any character in the affected class into paragraph text stores
+  a plain `text` node and creates **no** `emoji` node. Verified against a **representative
+  sample** (decided — not exhaustive): all three reported symbols, ~20 further
+  text-presentation characters, and a handful of pictographic and multi-codepoint cases
+  including a ZWJ sequence and a flag.
+- **AC-003**: AC-002 holds at the **start** and at the **end** of linked text, not only in the
+  middle.
+- **AC-004**: AC-002 holds when the character arrives by **paste** — plain-text paste, HTML
+  paste, and `&copy;` HTML-entity paste.
+- **AC-005**: Inserting an emoji from the toolbar picker inserts the literal character into the
+  surrounding text node, and inside a link yields a **single** `<a>` in the editor DOM.
+- **AC-006**: Typing a `:)`-style emoticon inserts the literal character into the surrounding
+  text node and creates **no** `emoji` node. Inside linked text it leaves the link as a single
+  `text` node with one `link` mark.
+- **AC-007**: Behavior is identical whether or not `emoji` is in the field's Allowed Blocks.
+- **AC-008**: The character renders as text; no `<img alt="… emoji">` is emitted for
+  newly authored content.
+
+**Renderers — Gap A (existing `emoji` nodes)**
+
+- **AC-009**: Given stored JSON containing an `emoji` node, the VTL renderer outputs the
+  character. It is no longer silently dropped.
+- **AC-010**: The React, Vue, and both Angular SDK renderers render the character for the same
+  input instead of falling through to their unknown-block component.
+- **AC-011**: No renderer emits a block-level element (e.g. `<div>`) inside a `<p>` for an
+  `emoji` node, in UVE or on the live site.
+
+**Renderers — Gap B (adjacent-link coalescing)**
+
+- **AC-012**: Given stored JSON with adjacent text nodes sharing an identical `link` mark, VTL
+  and all four JS SDK renderers each emit exactly **one** `<a>`.
+- **AC-013**: Given adjacent text nodes whose `link` marks differ in any of `href`, `target`,
+  `rel`, `title`, or `aria-label`, each renderer emits **two** `<a>` elements.
+- **AC-014**: A `bold` (or other) mark inside a coalesced link still nests correctly within the
+  single `<a>`.
+- **AC-015**: Content already saved with the split renders as a single link **without requiring
+  a re-save**.
+
+**Accessibility verification**
+
+- **AC-016**: Tabbing through the rendered link produces exactly **one** focus stop.
+- **AC-017**: The NVDA Elements List / VoiceOver rotor shows **one** entry carrying the
+  complete accessible name, including the symbol.
+
+**Verification method**:
+
+- **Unit (Jest/Spectator)** in `core-web/libs/new-block-editor` — drives a real TipTap editor
+  and asserts document shape for AC-001 through AC-008. Parameterize over a character sample so
+  the class, not three literals, is covered. Use real `NgZone` in service tests; a mocked one
+  breaks the change-detection scheduler.
+  `pnpm nx test new-block-editor`
+- **Unit (Jest)** for the React, Vue, and Angular SDK renderers — AC-010 through AC-014. The
+  Angular SDK needs both of its renderers covered.
+  `pnpm nx test sdk-react` / `pnpm nx test sdk-vue` / `pnpm nx test sdk-angular`
+- **VTL renderer** — AC-009, AC-011 through AC-014. Exercised via a Postman collection
+  rendering a fixture contentlet whose Story Block field holds both an `emoji` node and
+  adjacent same-link text nodes.
+  `./mvnw verify -pl :dotcms-postman -Dpostman.test.skip=false -Dpostman.collections=<collection>`
+- **Regression fixture** — a stored-JSON fixture reproducing the exact three-node payload from
+  the Actual Behavior section, shared across the renderer test suites so all five renderer
+  implementations assert against identical input. This fixture is what proves **AC-015**: it is only ever
+  rendered, never re-saved.
+- **Manual accessibility pass** — AC-016 and AC-017, with NVDA and with VoiceOver. Not
+  automatable; must be recorded in the post-merge QA plan.
+
+Per Constitution Principle V, these tests are written, developer-approved, and confirmed
+failing (Red) before any implementation.
+
+## Assumptions
+
+- **This spec's approach supersedes an acceptance criterion in issue #37340.** That issue
+  requires "Genuine pictographic emoji inserted via the emoji picker still work and still
+  produce `emoji` nodes — no regression." The approach chosen here deliberately stops producing
+  `emoji` nodes for **all** newly authored content, pictographic included. The user's stated
+  direction is explicit and takes precedence. **Action: amend the AC on #37340 before this spec
+  is approved**, so the issue and the spec do not disagree in the record.
+- Emoji rendered as a literal character in a text node is acceptable product behavior. This is
+  already what the picker produces (`insertContent(emoji.native)`), and what the legacy Block
+  Editor has always produced.
+- Losing shortcode round-tripping (`:rocket:`) for new content is acceptable. The `:`
+  suggestion trigger is already inert by design in this editor.
+- The customer on helpdesk ticket 39197 authored the affected content in the **new** Block
+  Editor. Only the new editor registers the emoji extension, so only it can create this split.
+  **This remains unconfirmed** and is the triage precondition recorded on #37340 — if they were
+  on the legacy editor, this diagnosis does not explain their data.
+- All measurements in this spec were taken against `@tiptap/extension-emoji@3.22.2` and
+  `emoji-regex@10.6.0`. The counts are version-specific; the defect class is not.
+
+## Resolved Decisions
+
+All three open questions were decided by the developer on 2026-09-03. None remain open; the
+spec carries no `[NEEDS CLARIFICATION]` markers.
+
+| # | Question | Decision | Rationale / consequence |
+| --- | --- | --- | --- |
+| 1 | Existing stored `emoji` nodes — render-only, heal-on-edit, or migrate? | **Render-only** | Gap A + Gap B satisfy AC-015 without a re-save. No Java, no DB, not rollback-relevant. Accepted trade-off: old nodes persist, so the legacy-editor drop path and the `<img>` fallback stay live for that content. |
+| 2 | `enableEmoticons` (`:)`) — keep as text, or drop? | **Insert literal character** | Preserves a shortcut authors already use, while removing the node creation that strips marks. `:)` now yields `🙂` inside the text node. Covered by AC-006. |
+| 3 | Does AC-002's character sample need to be exhaustive? | **Representative sample** | All 3 reported symbols, ~20 further text-presentation characters, plus pictographic and multi-codepoint cases (ZWJ sequence, flag). Fast, readable, and stable across extension upgrades. |
+
+**Still to confirm outside this spec** — not a clarification, an action:
+
+- Amend the acceptance criterion on issue [#37340](https://github.com/dotCMS/core/issues/37340)
+  that requires pictographic emoji to keep producing `emoji` nodes. This spec deliberately stops
+  producing them for all newly authored content. See Assumptions.
+- Confirm from helpdesk ticket 39197 that the customer authored the affected content in the
+  **new** Block Editor. This is the triage precondition already recorded on #37340.


### PR DESCRIPTION
## What this PR is

**PR 1 of 2** — the spec only, per [Spec-Kit Quick Start §3](../blob/main/docs/core/SPEC_KIT_QUICK_START.md). No code.

Fixes #37340 (spec; the implementation lands in PR 2).

Spec: `specs/37340-emoji-text-node/spec.md`

---

## What you're approving

**The problem.** The Block Editor's emoji extension replaces any Unicode-emoji character in text with a standalone `emoji` node. The node is created bare, so it carries none of the surrounding formatting. Two persisted consequences: a single linked phrase is torn into two `<a>` elements (WCAG 2.2 Level A failures — 1.3.1, 2.4.4, 4.1.2), and the character itself is dropped from VTL-rendered pages because the stored node holds only a shortcode, no literal character.

**The approach** — an emoji typed or pasted into paragraph text stays part of that text node. The automatic character-to-node conversion is suppressed; the `emoji` node stays **registered** so content already saved with `emoji` nodes still parses and renders.

Chosen over a per-character allowlist because it closes the whole class in one change, needs no list maintained across extension upgrades, and removes the marks problem structurally — text nodes carry marks natively, so there is no bare node left to strip them. It also matches how insertion already works: the emoji picker calls `insertContent(emoji.native)` with a raw character, so it never needed the node.

---

## Four findings that changed the scope

Each was verified against a real TipTap editor in jsdom, not inferred from the code.

| Finding | Consequence for the fix |
| --- | --- |
| The defect spans **219 text-presentation characters**, not the 3 reported. 1907 of 1949 catalogued entries convert on typing. | `✔` in a linked list item splits that link exactly as `©` does. The fix targets the class. |
| **Mark inheritance needs no schema change.** Applying a link over an existing `emoji` node already yields one `<a>`, and the mark survives a round-trip. | The split is an *ordering* defect: the conversion rebuilds the node without marks after the mark is applied. Simpler fix than #37340 assumes. |
| **Narrowing the extension's `emojis` option is not viable.** That option also feeds rendering. | Filtering it makes already-stored nodes render as literal `:copyright:`. Verified. The option must stay unfiltered. |
| **The Angular SDK ships two Block Editor renderers** that #37340 never mentions. | Gap A and Gap B live in **five** renderer implementations, not three. `grep` for an `emoji` node type across `libs/sdk/` returns zero hits. |

---

## Decisions recorded in the spec

- **Legacy data: render-only.** No data migration, no heal-on-load. Renderer coalescing satisfies AC-015 without a re-save, keeping this out of Java, the DB, and rollback-relevant territory. Accepted trade-off: old `emoji` nodes persist.
- **`:)` emoticons insert the literal character** rather than creating a node. AC-006.
- **AC-002 uses a representative character sample**, not all 1907 — stable across extension upgrades.

---

## Biggest risk, flagged for planning

`VM_global_library.vm` renders **every** Story Block field on **every** VTL-rendered page, for all customers, feature flag or not. Gap B changes how text runs are grouped there. A defect introduced in coalescing would affect far more content than this bug does. Five parallel Gap B implementations must also stay behaviourally identical, or the same content renders differently per framework — which is why the spec requires one shared fixture driving all five test suites.

---

## Two things to settle before/with approval

1. **An AC on #37340 contradicts this spec.** The issue requires pictographic emoji to keep producing `emoji` nodes; this spec deliberately stops producing them for all newly authored content. The issue AC needs amending so the record doesn't self-contradict.
2. **Triage precondition still unconfirmed** — that the customer on helpdesk ticket 39197 authored the content in the **new** Block Editor. Only the new editor registers the extension, so only it can create this split.

---

## Not in this PR

`plan.md`, `tasks.md`, and `checklists/` are process artifacts and are gitignored. `/speckit-plan` runs only after this PR is **approved** — approval is the gate, not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37340