### PR TITLE
fix(cicd): publish the site changelog from the release-notes backfill

### DIFF
--- a/.github/workflows/cicd_ai-release-notes-backfill.yml
+++ b/.github/workflows/cicd_ai-release-notes-backfill.yml
@@ -9,6 +9,10 @@
 # - Re-generate notes for a specific release (clear existing notes first)
 # - Test the release notes pipeline in isolation
 #
+# The regenerated GitHub release body is then republished to the dev.dotcms.com
+# changelog (#37388). Without that leg, a release whose notes generation failed
+# publishes an empty site entry that no later backfill can ever repair.
+#
 
 name: 'AI Release Notes (Backfill)'
 run-name: "Release Notes: ${{ inputs.release_tag }}"
@@ -39,4 +43,71 @@ jobs:
       previous_tag: ${{ inputs.previous_tag }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+
+  # The release pipeline reads docker_tags off its deployment phase; a backfill has no
+  # deployment, so recover them from Docker Hub. Also recovers the original availability
+  # date — the phase otherwise defaults to today and would relabel an old entry.
+  resolve-site-inputs:
+    name: Resolve Site Inputs
+    needs: release-notes
+    # Same exclusion as the notes phase: the site changelog is current-track GA only.
+    if: >-
+      !contains(inputs.release_tag, 'dotcms-cli-')
+      && !contains(inputs.release_tag, '_lts_')
+      && startsWith(inputs.release_tag, 'v')
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    outputs:
+      release_version: ${{ steps.resolve.outputs.release_version }}
+      docker_tags: ${{ steps.resolve.outputs.docker_tags }}
+      released_date: ${{ steps.resolve.outputs.released_date }}
+    steps:
+      - name: Resolve version, image and availability date
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          version="${RELEASE_TAG#v}"
+
+          # Select on a 7-hex sha suffix, NOT a bare "_": <version>_tainted tags exist
+          # (26.08.28-01, 26.08.31-01) and a looser match picks them over the real image.
+          sha_tag=$(curl -sS --fail \
+            "https://hub.docker.com/v2/repositories/dotcms/dotcms/tags/?page_size=100&name=${version}" \
+            | jq -r --arg v "${version}" \
+                '.results[].name | select(startswith($v + "_")) | select(test("_[0-9a-f]{7}$"))' \
+            | head -1)
+          if [ -z "${sha_tag}" ]; then
+            echo "::error::No sha-tagged dotcms/dotcms image found for ${version}. The site changelog records the deployed image, so publishing without it would be wrong."
+            exit 1
+          fi
+
+          # published_at, not today: publisher.py writes released_date through verbatim on
+          # the update path, so today's date would silently relabel an old entry.
+          released_date=$(gh api "repos/${REPO}/releases/tags/${RELEASE_TAG}" --jq .published_at | cut -dT -f1)
+
+          {
+            echo "release_version=${version}"
+            echo "docker_tags=dotcms/dotcms:${sha_tag} dotcms/dotcms:${version}"
+            echo "released_date=${released_date}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved ${version}: image dotcms/dotcms:${sha_tag}, available ${released_date}."
+
+  # Not allow_failure: the release pipeline tolerates a changelog hiccup because it must
+  # never fail a software release (FR-008). A backfill has no release to protect, and a
+  # silent failure here is the exact condition #37388 exists to end.
+  changelog-site-publish:
+    name: Changelog Site Publish
+    needs: [ release-notes, resolve-site-inputs ]
+    uses: ./.github/workflows/cicd_comp_changelog-site-publish-phase.yml
+    with:
+      release_tag: ${{ inputs.release_tag }}
+      release_version: ${{ needs.resolve-site-inputs.outputs.release_version }}
+      docker_tags: ${{ needs.resolve-site-inputs.outputs.docker_tags }}
+      released_date: ${{ needs.resolve-site-inputs.outputs.released_date }}
+    secrets:
+      DOTCMS_DEVSITE_RELEASENOTES_TOKEN: ${{ secrets.DOTCMS_DEVSITE_RELEASENOTES_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}

--- a/.github/workflows/cicd_ai-release-notes-backfill.yml
+++ b/.github/workflows/cicd_ai-release-notes-backfill.yml
@@ -51,9 +51,13 @@ jobs:
   resolve-site-inputs:
     name: Resolve Site Inputs
     needs: release-notes
-    # Same exclusion as the notes phase: the site changelog is current-track GA only.
+    # success() is explicit, not decorative: a job carrying a custom `if` must state its
+    # own status gate, and publishing the site off a failed notes regeneration is the
+    # exact thing this must not do. Second clause is the notes phase's own exclusion —
+    # the site changelog is current-track GA only.
     if: >-
-      !contains(inputs.release_tag, 'dotcms-cli-')
+      success()
+      && !contains(inputs.release_tag, 'dotcms-cli-')
       && !contains(inputs.release_tag, '_lts_')
       && startsWith(inputs.release_tag, 'v')
     runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}

--- a/.github/workflows/cicd_comp_changelog-site-publish-phase.yml
+++ b/.github/workflows/cicd_comp_changelog-site-publish-phase.yml
@@ -33,6 +33,11 @@ on:
         description: 'Space-separated docker image tags produced by the deployment phase'
         required: true
         type: string
+      released_date:
+        description: 'Availability date (yyyy-MM-dd). Defaults to today. A backfill MUST pass the original release date — the update path writes this through verbatim, so today would relabel an old entry.'
+        required: false
+        type: string
+        default: ''
       allow_failure:
         description: 'If true, job failures are non-blocking (used by release pipeline). Defaults to false.'
         required: false
@@ -113,6 +118,7 @@ jobs:
           # passed here — override is a manual operator re-run only.
           DOTCMS_DEVSITE_RELEASENOTES_ACCOUNT: ${{ vars.DOTCMS_DEVSITE_RELEASENOTES_ACCOUNT }}
           DOCKER_TAGS: ${{ inputs.docker_tags }}
+          RELEASED_DATE: ${{ inputs.released_date }}
         run: |
           # Pick the sha-tagged dotcms/dotcms image (version_sha form, e.g.
           # dotcms/dotcms:26.07.10-01_84b0486). The `_` in the glob excludes the floating
@@ -135,7 +141,7 @@ jobs:
             --version "$RELEASE_VERSION" \
             --notes-file /tmp/site-release-notes.md \
             --docker-image "$DOCKER_IMAGE" \
-            --released-date "$(date -u +%F)" \
+            --released-date "${RELEASED_DATE:-$(date -u +%F)}" \
             --apply 2>&1)
           RC=$?
           set -e


### PR DESCRIPTION
Closes: #37388

## Problem

Four entries on the [public changelog](https://dev.dotcms.com/docs/reference/releases/product-versions/changelogs) render with a title, date and docker tag but **no notes** — `26.08.28-01`, `26.08.31-01`, `26.08.31-02`, `26.09.02-01`. Their GitHub release bodies are fine (2.2k–6.8k chars). The site never got them.

```mermaid
flowchart TD
    subgraph before["before"]
        R1[Release run] --> N1["Generate notes<br/>❌ failed"]
        N1 --> E1["GitHub release body:<br/>empty"]
        E1 --> P1["Site publish<br/>✅ 'succeeded'<br/>published empty"]
        B1[Backfill] --> F1["GitHub release body:<br/>repaired"]
        F1 -.->|no path| P1
    end
    subgraph after["after"]
        B2[Backfill] --> F2["GitHub release body:<br/>repaired"]
        F2 --> RS[Resolve site inputs]
        RS --> P2["Site publish<br/>entry repaired"]
    end
    style P1 fill:#ffdddd,stroke:#cc0000
    style P2 fill:#ddffdd,stroke:#00aa00
```

`cicd_ai-release-notes-backfill.yml` had exactly one job — `Generate Notes`. It wrote the GitHub release body and stopped, so once an entry was published empty nothing could ever repair it.

(The reason they published empty in the first place is a separate defect: the phase's `[ ! -s ]` guard doesn't fire because `--jq .body` writes a bare newline for an empty body — 1 byte, not 0. Tracked separately, deliberately not fixed here.)

## Change

A `resolve-site-inputs` job recovers the two things a backfill can't inherit from a deployment phase, then hands off to the existing publish phase. Net +78 / −1 across two files, no new tooling.

**Docker image** — selected on a 7-hex sha suffix, not a bare `_`:

```jq
.results[].name | select(startswith($v + "_")) | select(test("_[0-9a-f]{7}$"))
```

`26.08.28-01_tainted` and `26.08.31-01_tainted` both exist and a looser match prefers them. Verified the selector reproduces exactly what each original run passed:

| Version | Resolved | Original run's `docker_tags` |
|---|---|---|
| 26.08.28-01 | `26.08.28-01_d5ab3fd` | `dotcms/dotcms:26.08.28-01_d5ab3fd ...` ✅ |
| 26.08.31-01 | `26.08.31-01_a6d1271` | `dotcms/dotcms:26.08.31-01_a6d1271 ...` ✅ |
| 26.08.31-02 | `26.08.31-02_b1a33f2` | `dotcms/dotcms:26.08.31-02_b1a33f2 ...` ✅ |
| 26.09.02-01 | `26.09.02-01_2460a36` | `dotcms/dotcms:26.09.02-01_2460a36 ...` ✅ |

Negative case checked too — `_tainted` is not selected.

**Availability date** — from the release's `published_at`. `publisher.py:154` writes `released_date` through verbatim on the update path, so the phase's `$(date -u +%F)` default would have relabelled `26.08.28-01` as "Available: Sep 3, 2026". The phase gains an optional `released_date` input; omitted, it still defaults to today, so **the release pipeline is behaviourally unchanged**.

## Deliberate choices

- **No `allow_failure`.** The release pipeline sets it so a changelog hiccup can never fail a software release (FR-008). A backfill has no release to protect, and a silent failure is the exact condition this PR ends.
- **CLI / LTS excluded**, matching the notes phase's own gate.
- **Hard fail when no sha-tagged image is found** rather than falling back to the bare `:<version>` tag — the site entry records the deployed image, and a backfill has no deployment to vouch for a guess.

## Repairing the existing four

Not done by this PR. Once merged, dispatching the backfill for each of the four tags repairs them; the publisher upserts, so it updates the existing entries in place rather than duplicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37388