### PR TITLE
fix(image-editor): provide MessageService in the editor so it renders in every host

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
@@ -29,6 +29,10 @@ import { DotMessagePipe } from '@dotcms/ui';
 
 import { DotEditContentDialogComponent } from './dot-create-content-dialog.component';
 
+import {
+    AngularImageEditorLauncher,
+    IMAGE_EDITOR_LAUNCHER
+} from '../../fields/shared/image-editor-launcher';
 import { DotEditContentService } from '../../services/dot-edit-content.service';
 import { OverlayEditContentHost } from '../../services/host/overlay-edit-content-host';
 
@@ -114,6 +118,28 @@ describe('DotEditContentDialogComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    /**
+     * This host is an Angular Edit Content host like the shell and the side panel, so it must
+     * provide the same launcher pair. `DotFileFieldComponent` injects `IMAGE_EDITOR_LAUNCHER` as
+     * `{ optional: true }`, so a missing provider is legal at the type level and degrades in
+     * silence: the Image/File field falls back to the legacy Dojo editor with a clean console.
+     * Only an explicit assertion catches that, which is why these exist (#37398).
+     */
+    describe('image editor host capability', () => {
+        it('should provide IMAGE_EDITOR_LAUNCHER so fields use the new editor, not legacy Dojo', () => {
+            const launcher = spectator.inject(IMAGE_EDITOR_LAUNCHER, true);
+
+            expect(launcher).toBeDefined();
+            expect(launcher).toBeInstanceOf(AngularImageEditorLauncher);
+        });
+
+        it('should provide the DialogService the launcher opens the editor through', () => {
+            // The launcher injects `DialogService`; without one it cannot be constructed, so the
+            // token resolving above is necessary but not sufficient on its own.
+            expect(spectator.inject(DialogService, true)).toBeTruthy();
+        });
     });
 
     it('should set loaded state for new content', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.ts
@@ -11,12 +11,16 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ButtonModule } from 'primeng/button';
-import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { DotCMSContentlet, ComponentStatus } from '@dotcms/dotcms-models';
 import { pushFormBridge, popFormBridge } from '@dotcms/edit-content-bridge';
 import { ASSET_PICKER_LAUNCHER, AngularAssetPickerLauncher, DotMessagePipe } from '@dotcms/ui';
 
+import {
+    AngularImageEditorLauncher,
+    IMAGE_EDITOR_LAUNCHER
+} from '../../fields/shared/image-editor-launcher';
 import { EditContentDialogData } from '../../models/dot-edit-content-dialog.interface';
 import { EDIT_CONTENT_HOST } from '../../services/host/edit-content-host.model';
 import { OverlayEditContentHost } from '../../services/host/overlay-edit-content-host';
@@ -59,8 +63,15 @@ import { DotEditContentLayoutComponent } from '../dot-edit-content-layout/dot-ed
         // field — so the new AssetPicker belongs here as much as in the shell and the side
         // panel. Without it the three asset-selection entry points would silently fall back to
         // the legacy picker in both of those flows. The launcher borrows the caller's
-        // `DialogService`, so unlike `IMAGE_EDITOR_LAUNCHER` it needs no provider of its own.
-        { provide: ASSET_PICKER_LAUNCHER, useClass: AngularAssetPickerLauncher }
+        // `DialogService`, so it needs no provider of its own — but the image editor launcher
+        // below does, which is why `DialogService` is provided here as well.
+        { provide: ASSET_PICKER_LAUNCHER, useClass: AngularAssetPickerLauncher },
+        // Same host-capability reasoning for the image editor, and the same pair the shell and the
+        // side panel provide. Without them the file field's `inject(IMAGE_EDITOR_LAUNCHER,
+        // { optional: true })` resolved to `undefined` and Image/File fields opened the legacy Dojo
+        // editor instead of the new one — no error, just the wrong editor (#37398).
+        DialogService,
+        { provide: IMAGE_EDITOR_LAUNCHER, useClass: AngularImageEditorLauncher }
     ],
     templateUrl: './dot-edit-content-dialog.component.html',
     styleUrls: ['./dot-edit-content-dialog.component.scss'],

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-side-panel/dot-edit-content-side-panel.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-side-panel/dot-edit-content-side-panel.component.spec.ts
@@ -4,6 +4,7 @@ import { Subject } from 'rxjs';
 
 import { ButtonModule } from 'primeng/button';
 import { Drawer, DrawerModule } from 'primeng/drawer';
+import { DialogService } from 'primeng/dynamicdialog';
 import { ZIndexUtils } from 'primeng/utils';
 
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
@@ -11,6 +12,10 @@ import { DotMessagePipe } from '@dotcms/ui';
 
 import { DotEditContentSidePanelComponent } from './dot-edit-content-side-panel.component';
 
+import {
+    AngularImageEditorLauncher,
+    IMAGE_EDITOR_LAUNCHER
+} from '../../fields/shared/image-editor-launcher';
 import { EditContentDialogData } from '../../models/dot-edit-content-dialog.interface';
 import { DotSidePanelNavController } from '../../services/dot-side-panel-nav.service';
 import { OverlayEditContentHost } from '../../services/host/overlay-edit-content-host';
@@ -524,5 +529,70 @@ describe('DotEditContentSidePanelComponent — persisted expanded preference', (
             ariaLabel: 'edit.content.side-panel.expand',
             width: '80%'
         });
+    });
+});
+
+/**
+ * Regression lock for #37398, as its own top-level suite on purpose.
+ *
+ * The suites above override this component with `set: { providers: [...] }`, which REPLACES the
+ * component's own `providers` — so `IMAGE_EDITOR_LAUNCHER` would be absent there for a reason that
+ * has nothing to do with the component. This factory overrides only `imports` (stubbing the heavy
+ * layout), leaving the real provider list intact, so the assertion is about the component rather
+ * than about the test setup.
+ *
+ * `DotFileFieldComponent` injects the token as `{ optional: true }`, so a host losing this provider
+ * does not fail loudly — Image/File fields quietly open the legacy Dojo editor instead of the new
+ * one. This turns that into a test failure rather than a user-visible downgrade.
+ */
+describe('DotEditContentSidePanelComponent — image editor host capability', () => {
+    let spectator: Spectator<DotEditContentSidePanelComponent>;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentSidePanelComponent,
+        overrideComponents: [
+            [
+                DotEditContentSidePanelComponent,
+                {
+                    remove: { imports: [DotEditContentLayoutComponent, DotMessagePipe] },
+                    add: {
+                        imports: [
+                            MockComponent(DotEditContentLayoutComponent),
+                            MockPipe(DotMessagePipe, (key: string) => key)
+                        ]
+                    }
+                }
+            ]
+        ]
+    });
+
+    beforeEach(() => {
+        spectator = createComponent({
+            providers: [
+                { provide: OverlayEditContentHost, useValue: { saved$: new Subject() } },
+                // Same stub the suites above use: keep the real controller — and the GlobalStore
+                // and HTTP services behind it — out of a test that is only about providers.
+                {
+                    provide: DotSidePanelNavController,
+                    useValue: {
+                        acquire: jest.fn(),
+                        release: jest.fn(),
+                        isTop: jest.fn().mockReturnValue(true)
+                    }
+                }
+            ],
+            detectChanges: false
+        });
+    });
+
+    it('should provide IMAGE_EDITOR_LAUNCHER so fields use the new editor, not legacy Dojo', () => {
+        const launcher = spectator.inject(IMAGE_EDITOR_LAUNCHER, true);
+
+        expect(launcher).toBeDefined();
+        expect(launcher).toBeInstanceOf(AngularImageEditorLauncher);
+    });
+
+    it('should provide the DialogService the launcher opens the editor through', () => {
+        expect(spectator.inject(DialogService, true)).toBeTruthy();
     });
 });

--- a/core-web/libs/edit-content/src/lib/edit-content.shell.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/edit-content.shell.component.spec.ts
@@ -1,8 +1,13 @@
 import { createComponentFactory, Spectator } from '@openng/spectator/jest';
 
+import { DialogService } from 'primeng/dynamicdialog';
 import { Toast } from 'primeng/toast';
 
 import { EditContentShellComponent } from './edit-content.shell.component';
+import {
+    AngularImageEditorLauncher,
+    IMAGE_EDITOR_LAUNCHER
+} from './fields/shared/image-editor-launcher';
 
 describe('EditContentShellComponent', () => {
     let spectator: Spectator<EditContentShellComponent>;
@@ -14,5 +19,22 @@ describe('EditContentShellComponent', () => {
 
     it('should have p-toast component', () => {
         expect(spectator.query(Toast)).toBeTruthy();
+    });
+
+    /**
+     * Regression lock for #37398. `DotFileFieldComponent` injects `IMAGE_EDITOR_LAUNCHER` as
+     * `{ optional: true }`, so a host losing this provider does not fail loudly — Image/File
+     * fields just quietly open the legacy Dojo editor instead of the new one. Asserting it per
+     * host means such a regression breaks a test rather than reaching users.
+     */
+    it('should provide IMAGE_EDITOR_LAUNCHER so fields use the new editor, not legacy Dojo', () => {
+        const launcher = spectator.inject(IMAGE_EDITOR_LAUNCHER, true);
+
+        expect(launcher).toBeDefined();
+        expect(launcher).toBeInstanceOf(AngularImageEditorLauncher);
+    });
+
+    it('should provide the DialogService the launcher opens the editor through', () => {
+        expect(spectator.inject(DialogService, true)).toBeTruthy();
     });
 });

--- a/core-web/libs/image-editor/src/lib/components/dot-image-editor-address-bar/dot-image-editor-address-bar.component.spec.ts
+++ b/core-web/libs/image-editor/src/lib/components/dot-image-editor-address-bar/dot-image-editor-address-bar.component.spec.ts
@@ -37,10 +37,17 @@ describe('DotImageEditorAddressBarComponent', () => {
 
     const createComponent = createComponentFactory({
         component: DotImageEditorAddressBarComponent,
-        providers: [{ provide: DotMessageService, useValue: messageServiceMock }],
+        // `MessageService` sits in the ANCESTOR injector, not in `componentProviders`, because
+        // that mirrors the real topology after #37398: `DotImageEditorComponent` provides it for
+        // the whole editor subtree and this component resolves it by walking up. Scoping the mock
+        // to the address bar itself would let the component pass even if nothing above it provided
+        // one — which is exactly how the NG0201 crash stayed invisible to this suite.
+        providers: [
+            { provide: DotMessageService, useValue: messageServiceMock },
+            mockProvider(MessageService)
+        ],
         componentProviders: [
             Dispatcher,
-            mockProvider(MessageService),
             mockProvider(ImageEditorStore, {
                 previewUrl,
                 zoom,
@@ -83,7 +90,7 @@ describe('DotImageEditorAddressBarComponent', () => {
     });
 
     it('should copy the full (absolute) preview URL to the clipboard and toast success', async () => {
-        const messageService = spectator.inject(MessageService, true);
+        const messageService = spectator.inject(MessageService);
         spectator.click(button('image-editor-copy-url-btn'));
 
         expect(writeText).toHaveBeenCalledWith(document.location.origin + PREVIEW_URL);
@@ -98,7 +105,7 @@ describe('DotImageEditorAddressBarComponent', () => {
 
     it('should toast an error when copying to the clipboard fails', async () => {
         writeText.mockRejectedValueOnce(new Error('clipboard denied'));
-        const messageService = spectator.inject(MessageService, true);
+        const messageService = spectator.inject(MessageService);
 
         spectator.click(button('image-editor-copy-url-btn'));
         await spectator.fixture.whenStable();

--- a/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.html
+++ b/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.html
@@ -37,3 +37,8 @@
 </dot-dialog>
 
 <p-confirmDialog [style]="{ width: '500px' }" />
+
+<!-- The editor's own toast outlet, fed by the `MessageService` this component provides. Rendered
+     here rather than borrowed from the host so the copy-URL toasts appear in every host — same
+     arrangement as `DotAssetPickerComponent`. -->
+<dot-toast position="top-center" />

--- a/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.spec.ts
+++ b/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.spec.ts
@@ -13,6 +13,7 @@ import { signal } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { Confirmation, ConfirmationService, ConfirmEventType, MessageService } from 'primeng/api';
+import { Dialog } from 'primeng/dialog';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { DotMessageService, DotPropertiesService } from '@dotcms/data-access';
@@ -20,6 +21,7 @@ import { DotCMSTempFile } from '@dotcms/dotcms-models';
 
 import { DotImageEditorComponent } from './dot-image-editor.component';
 
+import { DIALOG_SIZE_TRANSITION, MAXIMIZED_DIALOG_CLASS } from '../../image-editor.constants';
 import { AssetMeta, ImageEditorOpenParams } from '../../models/image-editor.models';
 import { DotImageEditorService } from '../../services/dot-image-editor.service';
 import {
@@ -351,6 +353,120 @@ function describeWith(label: string, data: ImageEditorOpenParams): void {
 
 describeWith('inode', { inode: 'i1', variable: 'fileAsset', fieldName: 'fileAsset' });
 describeWith('tempId', { tempId: 'temp_x', variable: 'fileAsset', fieldName: 'fileAsset' });
+
+describe('DotImageEditorComponent — full screen', () => {
+    let spectator: Spectator<DotImageEditorComponent>;
+    const isFullscreen = signal(false);
+    const container = document.createElement('div');
+    const dialog: {
+        maximized: boolean | undefined;
+        maximize: jest.Mock;
+        container: () => HTMLElement;
+    } = {
+        maximized: undefined,
+        maximize: jest.fn(() => (dialog.maximized = !dialog.maximized)),
+        container: () => container
+    };
+
+    const data: ImageEditorOpenParams = {
+        inode: 'i1',
+        variable: 'fileAsset',
+        fieldName: 'fileAsset'
+    };
+
+    const createComponent = createComponentFactory({
+        component: DotImageEditorComponent,
+        providers: [
+            provideNoopAnimations(),
+            Dispatcher,
+            mockProvider(DotMessageService, { get: jest.fn((key: string) => key) }),
+            mockProvider(DynamicDialogRef, { close: jest.fn() }),
+            { provide: DynamicDialogConfig, useValue: { data } }
+        ],
+        componentProviders: [
+            ConfirmationService,
+            MessageService,
+            mockProvider(ImageEditorStore, {
+                isDirty: signal(false),
+                canUndo: signal(false),
+                canRedo: signal(false),
+                isFullscreen,
+                saveStatus: signal('idle'),
+                saveError: signal(null)
+            }),
+            { provide: Dialog, useValue: dialog }
+        ],
+        overrideComponents: [
+            [
+                DotImageEditorComponent,
+                {
+                    remove: {
+                        imports: [
+                            DotImageEditorFullscreenToggleComponent,
+                            DotImageEditorCanvasComponent,
+                            DotImageEditorPanelsComponent,
+                            DotImageEditorFooterComponent
+                        ]
+                    },
+                    add: {
+                        imports: [
+                            MockComponent(DotImageEditorFullscreenToggleComponent),
+                            MockComponent(DotImageEditorCanvasComponent),
+                            MockComponent(DotImageEditorPanelsComponent),
+                            MockComponent(DotImageEditorFooterComponent)
+                        ]
+                    }
+                }
+            ]
+        ]
+    });
+
+    beforeEach(() => {
+        isFullscreen.set(false);
+        container.className = '';
+        container.style.cssText = 'width: 1040px';
+        dialog.maximized = undefined;
+        dialog.maximize.mockClear();
+
+        spectator = createComponent();
+    });
+
+    it('should open windowed, not full screen', () => {
+        expect(container.classList.contains(MAXIMIZED_DIALOG_CLASS)).toBe(false);
+        expect(dialog.maximize).not.toHaveBeenCalled();
+        expect(dialog.maximized).toBeFalsy();
+    });
+
+    it('should maximize the dialog when the flag flips', () => {
+        isFullscreen.set(true);
+        spectator.detectChanges();
+
+        expect(container.classList.contains(MAXIMIZED_DIALOG_CLASS)).toBe(true);
+    });
+
+    it("should keep PrimeNG's own maximized flag in step", () => {
+        isFullscreen.set(true);
+        spectator.detectChanges();
+
+        expect(dialog.maximized).toBe(true);
+        expect(dialog.maximize).toHaveBeenCalledTimes(1);
+    });
+
+    it('should hand the windowed size back on exit', () => {
+        isFullscreen.set(true);
+        spectator.detectChanges();
+        isFullscreen.set(false);
+        spectator.detectChanges();
+
+        expect(container.classList.contains(MAXIMIZED_DIALOG_CLASS)).toBe(false);
+        expect(dialog.maximized).toBe(false);
+        expect(container.style.width).toBe('1040px');
+    });
+
+    it('should animate the resize by default', () => {
+        expect(container.style.transition).toBe(DIALOG_SIZE_TRANSITION);
+    });
+});
 
 /**
  * Host-independence of the editor's messaging.

--- a/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.spec.ts
+++ b/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.spec.ts
@@ -7,19 +7,21 @@ import {
     SpyObject
 } from '@openng/spectator/jest';
 import { MockComponent } from 'ng-mocks';
+import { of } from 'rxjs';
 
 import { signal } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
-import { Confirmation, ConfirmationService, ConfirmEventType } from 'primeng/api';
+import { Confirmation, ConfirmationService, ConfirmEventType, MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
-import { DotMessageService } from '@dotcms/data-access';
+import { DotMessageService, DotPropertiesService } from '@dotcms/data-access';
 import { DotCMSTempFile } from '@dotcms/dotcms-models';
 
 import { DotImageEditorComponent } from './dot-image-editor.component';
 
-import { ImageEditorOpenParams } from '../../models/image-editor.models';
+import { AssetMeta, ImageEditorOpenParams } from '../../models/image-editor.models';
+import { DotImageEditorService } from '../../services/dot-image-editor.service';
 import {
     imageEditorHistoryEvents,
     imageEditorLifecycleEvents
@@ -56,10 +58,13 @@ function describeWith(label: string, data: ImageEditorOpenParams): void {
             ],
             // `componentProviders` overrides the component's own `providers`, so
             // re-supply the real ConfirmationService (the template's
-            // `<p-confirmDialog />` subscribes to it; we spy on `confirm`) while
-            // mocking only the store.
+            // `<p-confirmDialog />` subscribes to it; we spy on `confirm`) and the
+            // MessageService backing the template's `<dot-toast />` — while mocking
+            // only the store. Host-independence of that provider is covered by the
+            // un-mocked suite at the bottom of this file, not here.
             componentProviders: [
                 ConfirmationService,
+                MessageService,
                 mockProvider(ImageEditorStore, {
                     isDirty,
                     canUndo,
@@ -346,3 +351,80 @@ function describeWith(label: string, data: ImageEditorOpenParams): void {
 
 describeWith('inode', { inode: 'i1', variable: 'fileAsset', fieldName: 'fileAsset' });
 describeWith('tempId', { tempId: 'temp_x', variable: 'fileAsset', fieldName: 'fileAsset' });
+
+/**
+ * Host-independence of the editor's messaging.
+ *
+ * Unlike the suites above, this one mounts the **real** child tree: no `overrideComponents`, no
+ * `MockComponent`, and no `componentProviders` (which would replace the component's own
+ * `providers` — including the very `MessageService` under test). That is deliberate and load
+ * bearing. `DotImageEditorAddressBarComponent`, nested inside the canvas, injects PrimeNG's
+ * `MessageService` non-optionally; every other spec in this library replaces one of the components
+ * on that path with a mock, so `inject(MessageService)` never actually runs unprovided and the
+ * suite stayed green while the editor was completely broken in two of its three hosts (#37398).
+ *
+ * No `MessageService` is provided here on purpose: the editor must supply its own, so it renders in
+ * any host rather than relying on an ancestor injector happening to have one.
+ */
+describe('DotImageEditorComponent (no ambient MessageService)', () => {
+    let spectator: Spectator<DotImageEditorComponent>;
+
+    const data: ImageEditorOpenParams = {
+        inode: 'i1',
+        variable: 'fileAsset',
+        fieldName: 'fileAsset'
+    };
+
+    const assetMeta: AssetMeta = {
+        naturalWidth: 800,
+        naturalHeight: 600,
+        originalBytes: 2048
+    };
+
+    const createComponent = createComponentFactory({
+        component: DotImageEditorComponent,
+        providers: [
+            provideNoopAnimations(),
+            Dispatcher,
+            mockProvider(DotMessageService, { get: jest.fn((key: string) => key) }),
+            mockProvider(DynamicDialogRef, { close: jest.fn() }),
+            { provide: DynamicDialogConfig, useValue: { data } },
+            // Stub the boundaries the real tree reaches — HTTP and server config — so the mount
+            // needs no backend. Everything else resolves from the library itself.
+            mockProvider(DotImageEditorService, {
+                loadAssetMeta: jest.fn(() => of(assetMeta)),
+                loadPreviewImage: jest.fn(() => of('blob:preview')),
+                getFileSize: jest.fn(() => of(null)),
+                triggerDownload: jest.fn(),
+                saveEditedImage: jest.fn()
+            }),
+            mockProvider(DotPropertiesService, { getKey: jest.fn(() => of('false')) })
+        ]
+    });
+
+    beforeEach(() => {
+        spectator = createComponent();
+    });
+
+    it('should instantiate and render without an ambient MessageService', () => {
+        expect(spectator.component).toBeTruthy();
+        expect(spectator.query(byTestId('image-editor-root'))).toExist();
+    });
+
+    it('should render the real address bar, which is what injects MessageService', () => {
+        expect(spectator.query('dot-image-editor-address-bar')).toExist();
+    });
+
+    it('should provide its own MessageService rather than resolving one from the host', () => {
+        // Resolved through the component injector. Nothing in this factory's `providers`
+        // supplies one, so a successful resolution can only have come from the component's own
+        // `providers` — which is the property the host chain must no longer be asked for.
+        expect(spectator.inject(MessageService, true)).toBeTruthy();
+        // And confirm the premise: it is genuinely absent from the ambient/module injector.
+        expect(() => spectator.inject(MessageService)).toThrow();
+    });
+
+    it('should render exactly one toast outlet inside the dialog', () => {
+        expect(spectator.queryAll(byTestId('dot-toast'))).toHaveLength(1);
+    });
+});

--- a/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.ts
+++ b/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.ts
@@ -1,7 +1,7 @@
 import { Events, injectDispatch } from '@ngrx/signals/events';
 
 import { DOCUMENT } from '@angular/common';
-import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, Renderer2 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ConfirmationService, ConfirmEventType, MessageService } from 'primeng/api';
@@ -20,7 +20,7 @@ import {
 } from '@dotcms/ui';
 
 import { imageEditorModalScaleFade } from '../../animations/image-editor.animations';
-import { DIALOG_SIZE_TRANSITION, FULLSCREEN_DIALOG_STYLE } from '../../image-editor.constants';
+import { DIALOG_SIZE_TRANSITION, MAXIMIZED_DIALOG_CLASS } from '../../image-editor.constants';
 import { ImageEditorOpenParams } from '../../models/image-editor.models';
 import {
     imageEditorHistoryEvents,
@@ -91,13 +91,11 @@ export class DotImageEditorComponent {
     readonly #historyDispatch = injectDispatch(imageEditorHistoryEvents);
     readonly #events = inject(Events);
     readonly #document = inject(DOCUMENT);
+    readonly #renderer = inject(Renderer2);
     // The PrimeNG dialog hosting this editor: injectable because the dialog content
     // is declared inside `<p-dialog>` in DynamicDialog's template, so we sit in the
     // Dialog's element injector. Its `container()` signal is the `.p-dialog` element.
     readonly #dialog = inject(Dialog, { optional: true });
-
-    /** Windowed inline dialog styles saved on entering full-screen, restored on exit. */
-    #windowedStyle: Record<string, string> | null = null;
 
     /** True while the discard-confirm prompt is showing, so a repeated Esc can't re-open it. */
     #discardPromptOpen = false;
@@ -118,31 +116,42 @@ export class DotImageEditorComponent {
     }
 
     /**
-     * Expands the host dialog to the viewport (or restores it). `DialogService`
-     * sets the dialog width/height as inline styles, so we override those inline
-     * styles directly — a stylesheet rule can't win against inline without
-     * `!important` — and restore the saved values on exit.
+     * Expands the host dialog to the viewport, or restores it.
+     *
+     * Full-screen is PrimeNG's own maximized state, so there is nothing to save and restore: the
+     * theme sizes {@link MAXIMIZED_DIALOG_CLASS} with `!important`, which is what beats the
+     * width/height `DialogService` writes inline. Dropping the class hands the windowed size back.
+     *
+     * `maximize()` keeps PrimeNG's `maximized` flag in step, so its own class computation agrees with
+     * us; the class is applied here as well because the `Dialog` is `OnPush` and a toggle coming from
+     * its projected content never marks it dirty.
      */
     #applyFullscreen(on: boolean): void {
-        const dialog = this.#dialog?.container() as HTMLElement | undefined;
+        const container = this.#dialog?.container() as HTMLElement | undefined;
 
-        if (!dialog) {
+        if (!this.#dialog || !container) {
             return;
         }
 
-        // Set the size transition (idempotent) before any toggle, honouring
-        // reduced-motion. It lands on the first (windowed) effect run, so the
-        // first real toggle already animates.
-        dialog.style.transition = this.#prefersReducedMotion() ? '' : DIALOG_SIZE_TRANSITION;
+        // Set the size transition (idempotent) before any toggle, honouring reduced-motion. It
+        // lands on the first (windowed) effect run, so the first real toggle already animates.
+        this.#renderer.setStyle(
+            container,
+            'transition',
+            this.#prefersReducedMotion() ? '' : DIALOG_SIZE_TRANSITION
+        );
+
+        // `Boolean(...)`: PrimeNG leaves `maximized` UNSET until its own button is clicked, and
+        // `undefined !== false` would fire `maximize()` on the effect's first (windowed) run —
+        // flipping the flag to `true` and opening the editor full screen.
+        if (Boolean(this.#dialog.maximized) !== on) {
+            this.#dialog.maximize();
+        }
 
         if (on) {
-            this.#windowedStyle ??= Object.fromEntries(
-                Object.keys(FULLSCREEN_DIALOG_STYLE).map((prop) => [prop, dialog.style[prop]])
-            );
-            Object.assign(dialog.style, FULLSCREEN_DIALOG_STYLE);
-        } else if (this.#windowedStyle) {
-            Object.assign(dialog.style, this.#windowedStyle);
-            this.#windowedStyle = null;
+            this.#renderer.addClass(container, MAXIMIZED_DIALOG_CLASS);
+        } else {
+            this.#renderer.removeClass(container, MAXIMIZED_DIALOG_CLASS);
         }
     }
 

--- a/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.ts
+++ b/core-web/libs/image-editor/src/lib/components/dot-image-editor/dot-image-editor.component.ts
@@ -4,7 +4,7 @@ import { DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-import { ConfirmationService, ConfirmEventType } from 'primeng/api';
+import { ConfirmationService, ConfirmEventType, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { Dialog } from 'primeng/dialog';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -15,7 +15,8 @@ import {
     DotDialogContentComponent,
     DotDialogFooterComponent,
     DotDialogHeaderComponent,
-    DotMessagePipe
+    DotMessagePipe,
+    DotToastComponent
 } from '@dotcms/ui';
 
 import { imageEditorModalScaleFade } from '../../animations/image-editor.animations';
@@ -51,13 +52,22 @@ import { DotImageEditorPanelsComponent } from '../dot-image-editor-panels/dot-im
         DotImageEditorFullscreenToggleComponent,
         DotImageEditorCanvasComponent,
         DotImageEditorPanelsComponent,
-        DotImageEditorFooterComponent
+        DotImageEditorFooterComponent,
+        DotToastComponent
     ],
     providers: [
         ImageEditorStore,
         // Scoped here so the template's `<p-confirmDialog />` and the discard
         // guard share one instance; the lib has no global confirm dialog.
-        ConfirmationService
+        ConfirmationService,
+        // Scoped here — not left to the host — so the editor renders in every host rather than
+        // only the ones that happen to provide one. `DialogService` opens this dialog from the
+        // host's injector, so the address bar's `inject(MessageService)` used to walk up into the
+        // host chain: the full-screen shell had one, the UVE side panel and the centered dialog
+        // did not, and the injection threw NG0201 mid-construction — a blank white dialog (#37398).
+        // Mirrors `DotAssetPickerComponent`, and the contract `DotToastComponent` documents:
+        // the outlet's owner provides the stream. The template renders that outlet below.
+        MessageService
     ],
     templateUrl: './dot-image-editor.component.html',
     styleUrl: './dot-image-editor.component.scss',

--- a/core-web/libs/image-editor/src/lib/image-editor.constants.ts
+++ b/core-web/libs/image-editor/src/lib/image-editor.constants.ts
@@ -81,7 +81,7 @@ export const IMAGE_EDITOR_PANEL_STATE_KEY = 'DOT_IMAGE_EDITOR_PANEL_STATE';
 export const LIBVIPS_CONFIG_KEY = 'IMAGE_API_USE_LIBVIPS';
 
 /**
- * Full-screen dialog styling now lives in `@dotcms/ui`, shared with the AssetPicker.
+ * Full-screen dialog sizing now lives in `@dotcms/ui`, shared with the AssetPicker.
  * Re-exported here so existing imports keep resolving from this module.
  */
-export { DIALOG_SIZE_TRANSITION, FULLSCREEN_DIALOG_STYLE } from '@dotcms/ui';
+export { DIALOG_SIZE_TRANSITION, MAXIMIZED_DIALOG_CLASS } from '@dotcms/ui';

--- a/core-web/libs/image-editor/tsconfig.spec.json
+++ b/core-web/libs/image-editor/tsconfig.spec.json
@@ -2,10 +2,10 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "../../dist/out-tsc",
-        "module": "commonjs",
+        "module": "preserve",
         "target": "es2016",
         "types": ["jest", "node"],
-        "moduleResolution": "node10",
+        "moduleResolution": "bundler",
         "isolatedModules": true
     },
     "files": ["src/test-setup.ts"],

--- a/core-web/libs/ui/src/lib/dialog/fullscreen-dialog.ts
+++ b/core-web/libs/ui/src/lib/dialog/fullscreen-dialog.ts
@@ -18,8 +18,7 @@ export const MAXIMIZED_DIALOG_CLASS = 'p-dialog-maximized';
  * rule can't beat inline without `!important`.
  *
  * @deprecated Prefer {@link MAXIMIZED_DIALOG_CLASS}: PrimeNG's theme already declares the same sizing
- * with `!important`, so the class needs no save/restore of the windowed values. Still used by the
- * image editor.
+ * with `!important`, so the class needs no save/restore of the windowed values.
  */
 export const FULLSCREEN_DIALOG_STYLE: Record<string, string> = {
     width: '100vw',

--- a/specs/37398-image-editor-message-service/contracts/image-editor-host-contract.md
+++ b/specs/37398-image-editor-message-service/contracts/image-editor-host-contract.md
@@ -1,0 +1,112 @@
+# Contract: What a host must provide to embed `@dotcms/image-editor`
+
+**Feature**: `37398-image-editor-message-service` · **Plan**: [../plan.md](../plan.md) · **Date**: 2026-09-04
+
+`@dotcms/image-editor` exposes no REST endpoint, CLI, or public HTTP surface. The one contract it
+*does* have is a **dependency-injection contract** with its embedding host: the set of tokens a host
+must supply for `DotImageEditorComponent` to instantiate. That contract was implicit and undocumented,
+which is why two of three hosts violated it without anyone noticing. This document states it
+explicitly, before and after the fix, so a future host has something to conform to and a reviewer has
+something to check against.
+
+## Consumer-facing surface (unchanged)
+
+```ts
+// @dotcms/image-editor — public API, NOT modified by this fix
+export class DotImageEditorComponent { /* opened via DialogService, never used as <dot-image-editor> */ }
+export interface DotImageEditorLauncher {
+    isAvailable(): boolean;
+    open(params: ImageEditorOpenParams): Observable<DotCMSTempFile | null>;
+}
+export interface ImageEditorOpenParams {
+    inode?: string;
+    tempId?: string;
+    variable: string;
+    fieldName: string;
+}
+```
+
+No signature, input, output, or exported type changes. A host that compiles today compiles after.
+
+## The host DI contract
+
+### Before (implicit, violated)
+
+| Token | Required? | Enforced how? | Failure when missing |
+|---|---|---|---|
+| `DialogService` (PrimeNG) | **yes** | `AngularImageEditorLauncher` injects it | Launcher cannot be constructed |
+| `MessageService` (PrimeNG) | **yes, undocumented** | nothing — resolved by injector walk at construction time | `NG0201` thrown mid-construction → **blank dialog, editor unusable** |
+
+The second row is the whole defect. It was a requirement in fact but not in any type, docstring, or
+test, so it could only be discovered by running each host by hand.
+
+### After (explicit, satisfiable)
+
+| Token | Required? | Provided by | Notes |
+|---|---|---|---|
+| `DialogService` (PrimeNG) | **yes** | the host | Unchanged. The launcher opens the editor through the host's instance, which is what makes the dialog's injector chain the host's chain. |
+| `MessageService` (PrimeNG) | **no** | `DotImageEditorComponent` itself | Now terminates inside the library. A host may still provide one for its *own* messages — the editor's component-scoped instance shadows it for the editor subtree. |
+
+**Post-fix invariant**: `DialogService` is the *only* token a host must provide to embed the image
+editor. Anything else the editor needs, the editor provides.
+
+### Conformance
+
+A conforming host:
+
+1. Provides `DialogService` in its component `providers`.
+2. Provides `{ provide: IMAGE_EDITOR_LAUNCHER, useClass: AngularImageEditorLauncher }` if its
+   Image/File/Binary fields should use the new editor rather than falling back to legacy Dojo.
+3. Provides **nothing** on the editor's behalf beyond that.
+
+Verified by the AC-012 assertions — one per host spec, checking `IMAGE_EDITOR_LAUNCHER` resolves to
+an `AngularImageEditorLauncher` and is not `undefined`. Non-conformance on point 2 is *silent* by
+design (`inject(IMAGE_EDITOR_LAUNCHER, { optional: true })` in `DotFileFieldComponent`), which is
+exactly why it needs a test rather than trust.
+
+## The launcher token contract (`IMAGE_EDITOR_LAUNCHER`)
+
+```ts
+// libs/edit-content/src/lib/fields/shared/image-editor-launcher/image-editor-launcher.token.ts
+export const IMAGE_EDITOR_LAUNCHER = new InjectionToken<DotImageEditorLauncher>('IMAGE_EDITOR_LAUNCHER');
+```
+
+| Consumer | Injection | Behavior when unprovided |
+|---|---|---|
+| `DotFileFieldComponent` (`dot-file-field.component.ts:131`) | `inject(IMAGE_EDITOR_LAUNCHER, { optional: true })` | Falls back to the legacy Dojo image editor |
+
+The optionality is **intentional and preserved**: the field also renders outside the new Edit
+Content (inside the `dotcms-binary-field` web component in the legacy JSP editor), where no Angular
+launcher exists and the Dojo fallback is the correct behavior. This fix does not make the token
+required; it makes the three Angular hosts provide it, so the fallback fires only where it should.
+
+## Toast contract
+
+Established by `DotToastComponent`'s own docstring
+(`libs/ui/src/lib/components/dot-toast/dot-toast.component.ts`) and implemented by
+`DotAssetPickerComponent`:
+
+> *"The `MessageService` stays with the consumer: provide it on the host so each outlet — a portlet
+> shell, a dialog — keeps its own message stream instead of sharing one globally."*
+
+| Element | Value |
+|---|---|
+| Provider scope | The component that owns the outlet — here `DotImageEditorComponent` |
+| Outlet | `<dot-toast position="top-center" />`, one per provider |
+| Precedent | `dot-asset-picker.component.ts:97` (provider) + `dot-asset-picker.component.html:129` (outlet) |
+| Anti-pattern | A root/application-wide `MessageService` shared by unrelated features |
+
+The image editor previously satisfied neither half — no provider, no outlet — and depended on some
+ancestor happening to satisfy both. That is the pattern violation this fix corrects.
+
+## Non-contracts
+
+Explicitly *not* part of any contract, so no consumer can depend on them:
+
+- The **position or styling** of the editor's toast. `top-center` mirrors the asset picker; a
+  reviewer may change it without breaking a consumer.
+- **Which `MessageService` instance** an editor toast reaches. After this fix it is always the
+  editor's own; nothing outside the editor may observe those messages.
+- The **`z-index`/stacking mechanism** that puts the toast above the dialog. Currently PrimeNG's
+  default tiering, unaided. See [research.md R2](../research.md) for the fallback if that proves
+  insufficient — swapping it is an implementation detail, not a contract change.

--- a/specs/37398-image-editor-message-service/data-model.md
+++ b/specs/37398-image-editor-message-service/data-model.md
@@ -1,0 +1,105 @@
+# Phase 1: Data Model — DI provider topology
+
+**Feature**: `37398-image-editor-message-service` · **Plan**: [plan.md](./plan.md) · **Date**: 2026-09-04
+
+This fix introduces **no domain entities, no persisted state, and no API payloads**. Nothing is
+stored, migrated, or serialized differently. The "model" that matters here is the *injector
+topology* — which token is provided at which level — because that topology is precisely what is
+broken. It is documented in entity-like form so the change is reviewable and so the tasks phase has
+an unambiguous target state.
+
+## Entities
+
+**None.** No new interface, model, or type is added. `ImageEditorOpenParams`, `DotCMSTempFile` and
+the `ImageEditorStore` state shape are all untouched.
+
+## Injector topology
+
+### Token inventory
+
+Every token the `@dotcms/image-editor` component tree injects, and where it resolves from:
+
+| Token | Resolves from | Level | Status |
+|---|---|---|---|
+| `MessageService` (PrimeNG) | *nothing in the library* | ambient host — **absent in 2 of 3 hosts** | ❌ **the defect** |
+| `ImageEditorStore` | `DotImageEditorComponent.providers` | component | ✅ safe |
+| `ConfirmationService` (PrimeNG) | `DotImageEditorComponent.providers` | component | ✅ safe |
+| `DotImageEditorService` | `@Injectable({ providedIn: 'root' })` | root | ✅ safe |
+| `DotPropertiesService` | `@Injectable({ providedIn: 'root' })` | root | ✅ safe |
+| `DotMessageService` | `@Injectable({ providedIn: 'root' })` | root | ✅ safe |
+| `Dispatcher`, `Events` (`@ngrx/signals/events`) | root / store-scoped | root | ✅ safe |
+| `DynamicDialogConfig`, `DynamicDialogRef` | PrimeNG `DialogService` on open | dialog | ✅ safe — the host must provide `DialogService`, which is the documented host requirement |
+| `Dialog` (PrimeNG) | `inject(Dialog, { optional: true })` | dialog, optional | ✅ safe by construction |
+| `DOCUMENT`, `NgZone`, `DestroyRef`, `ElementRef`, `HttpClient` | Angular platform | platform/root | ✅ safe |
+
+Derived from an audit of every `inject()` call in `core-web/libs/image-editor/src` (excluding
+specs). `MessageService` is the sole outlier: the only token the library requires, does not provide,
+and cannot obtain from a root-provided service. This table *is* the evidence for AC-004.
+
+### State transition: before → after
+
+```text
+BEFORE (defective)
+
+  Host component injector
+  ├─ DialogService ................. provided by host (all 3 hosts must)
+  ├─ MessageService ................ provided by the SHELL ONLY  ◄── the gap
+  └─ DynamicDialog (opened via the host's DialogService)
+     └─ DotImageEditorComponent
+        ├─ providers: ImageEditorStore, ConfirmationService
+        └─ …canvas
+           └─ DotImageEditorAddressBarComponent
+              └─ inject(MessageService) ─── walks UP the host chain
+                                            ├─ shell host   → found    → renders
+                                            └─ other hosts  → NOT FOUND → NG0201, blank dialog
+
+AFTER (self-sufficient)
+
+  Host component injector
+  ├─ DialogService ................. provided by host (unchanged requirement)
+  └─ DynamicDialog
+     └─ DotImageEditorComponent
+        ├─ providers: ImageEditorStore, ConfirmationService, MessageService  ◄── the fix
+        ├─ template: <dot-toast position="top-center" />                     ◄── the outlet
+        └─ …canvas
+           └─ DotImageEditorAddressBarComponent
+              └─ inject(MessageService) ─── resolves at the EDITOR, never reaching the host
+                                            → found in every host → renders everywhere
+```
+
+The resolution now terminates inside the library, so host composition can no longer affect it. The
+`inject(MessageService)` call site in `dot-image-editor-address-bar.component.ts:37` is **not
+modified** — only what it resolves against changes.
+
+### Validation rules
+
+Rules the target state must satisfy, each traceable to an acceptance criterion:
+
+| Rule | AC |
+|---|---|
+| `MessageService` appears in `DotImageEditorComponent.providers` | AC-001 |
+| Exactly **one** `dot-toast` outlet exists inside the editor dialog | AC-001 |
+| `DotImageEditorComponent` instantiates when no ancestor injector provides `MessageService` | AC-010 |
+| `MessageService` is **not** added to any host's `providers` for the editor's benefit | AC-003 |
+| `edit-content.shell.component.ts` keeps its own `MessageService` + `<p-toast />` | AC-003, AC-007 |
+| No token in the inventory above is both library-required and unprovided | AC-004 |
+
+## Host provider matrix
+
+The second, quieter half of the fix. `IMAGE_EDITOR_LAUNCHER` is injected `{ optional: true }` by
+`DotFileFieldComponent`, so a missing provider is legal at the type level and degrades silently.
+
+| Host | `DialogService` | `IMAGE_EDITOR_LAUNCHER` | `ASSET_PICKER_LAUNCHER` | `MessageService` (own use) |
+|---|---|---|---|---|
+| `EditContentShellComponent` (full-screen route) | ✅ keep | ✅ keep | ✅ keep | ✅ **keep** — for the shell's own messages, not the editor's |
+| `DotEditContentSidePanelComponent` (UVE, Content Drive, Query Tool) | ✅ keep | ✅ keep | ✅ keep | ➖ not needed |
+| `DotEditContentDialogComponent` (UVE, side-panel flag off) | ➕ **add** | ➕ **add** | ✅ keep | ➖ not needed |
+
+`MessageService` is deliberately absent from the "add" column everywhere: after this change no host
+provides it *for the editor*. That is the invariant AC-003 protects, and the reason the fix does not
+regress the moment a fourth host appears.
+
+**Consequence to review, not a defect**: a component-scoped `MessageService` shadows the shell's
+ambient one for the editor's subtree, so in the full-screen route editor toasts move from the
+shell's `<p-toast />` to the editor's own outlet. Intended; called out because it is the only
+visible change on an otherwise-unaffected host.

--- a/specs/37398-image-editor-message-service/spec.md
+++ b/specs/37398-image-editor-message-service/spec.md
@@ -1,0 +1,244 @@
+# Issue Resolution Specification: New image editor opens blank inside UVE — NG0201: No provider found for MessageService
+
+**Feature Branch**: `37398-image-editor-message-service`
+
+**Created**: 2026-09-04
+
+**Status**: Draft
+
+**Type**: Issue / Bug Resolution
+
+**Related GitHub Issue**: [#37398](https://github.com/dotCMS/core/issues/37398) (epic: [#36702](https://github.com/dotCMS/core/issues/36702))
+
+**Input**: User description: "https://github.com/dotCMS/core/issues/37398"
+
+## Problem Statement *(mandatory)*
+
+Opening **Edit image** on an Image/File field from inside **UVE** renders an empty white dialog.
+The new image editor never paints, and the browser console throws:
+
+```
+ERROR ɵNotFound: NG0201: No provider found for `MessageService`.
+Source: Standalone[_DotImageEditorComponent].
+```
+
+The same field works from the full-screen Edit Content route, so the failure is specific to the
+new Edit Content experience when it is hosted by UVE. Because it is a dependency-injection
+failure and not a rendering one, it is not browser- or OS-specific (reported on Chrome / macOS).
+
+A second, quieter symptom shares the same root: with the side-panel feature flag **off**, UVE
+opens the centered `DotEditContentDialogComponent`, which provides neither `DialogService` nor
+`IMAGE_EDITOR_LAUNCHER`. There the Image/File field's optional launcher injection resolves to
+`undefined` and the field silently falls back to the **legacy Dojo image editor** — no error, just
+the wrong editor.
+
+**Severity / Impact**: **High — major functionality broken.** It hits anyone editing an Image or
+File field without leaving the page editor, which is the primary flow the new Edit Content
+experience was built for. Inside UVE the image editor is completely unusable; the only workaround
+is to abandon UVE and open the content full-screen.
+
+## Reproduction *(mandatory)*
+
+**Environment**: Latest `main`; dotCMS admin UI (Angular `core-web`); new Edit Content experience
+enabled with the side-panel flag **on**; Chrome on macOS (not browser-specific).
+
+**Steps to Reproduce**:
+
+1. Open a page in **UVE** with the new Edit Content experience enabled and the side-panel flag on.
+2. Click a contentlet that has an **Image** field, so the Edit Content side panel opens.
+3. Hover the image and click the **pencil / Edit image** action.
+4. Observe the dialog and the browser console.
+
+**Expected Behavior**: The "Edit image" modal renders completely — address bar, canvas, and the
+Adjust / Transform / File info panels, plus the footer — exactly as it does from the full-screen
+Edit Content route.
+
+**Actual Behavior**: The dialog opens **completely blank** — no toolbar, no canvas, no panels — and
+the console logs `NG0201: No provider found for MessageService. Source:
+Standalone[_DotImageEditorComponent]`.
+
+**Reproducibility**: **Always**, in every host that lacks an ambient `MessageService`. Confirmed
+deterministic (a construction-time injection failure, not a race).
+
+Secondary path, also always reproducible: turn the side-panel flag **off**, open the same field
+from UVE, and the **legacy Dojo** editor opens instead of the new one, with a clean console.
+
+## Scope of Investigation *(mandatory)*
+
+- **Affected area**: Frontend only — the new Angular Edit Content experience: the
+  `@dotcms/image-editor` library and the three Angular Edit Content hosts that can open it
+  (full-screen route, side panel, centered dialog). No backend or REST surface is involved.
+- **Suspected surface**: Modern Angular/TypeScript under `core-web/libs/` — no `com.dotcms.*` or
+  `com.dotmarketing.*` Java code is touched. The legacy Dojo image editor is only relevant as the
+  fallback the secondary path incorrectly reaches; it is not modified.
+- **Related known decisions**: The library already establishes the intended pattern next door —
+  `DotAssetPickerComponent` self-provides `MessageService` and renders its own `<dot-toast />`
+  outlet, which is why it works in every host. The provider-scoping comments in
+  `edit-content.shell.component.ts` and `dot-edit-content-side-panel.component.ts` document a
+  deliberate decision to scope the new editor/picker launchers per host rather than globally; the
+  fix must preserve that scoping. The plan formally consults `dotCMS/platform-adrs`.
+
+Confirmed in the codebase during scoping:
+
+| Host | Where | `DialogService` | `IMAGE_EDITOR_LAUNCHER` | `MessageService` | Result |
+|---|---|---|---|---|---|
+| Full-screen route | `libs/edit-content/src/lib/edit-content.shell.component.ts` `providers` | yes | yes | yes | Editor works |
+| Side panel (UVE, Content Drive, Query Tool) | `libs/edit-content/src/lib/components/dot-edit-content-side-panel/dot-edit-content-side-panel.component.ts:81-103` | yes | yes | **no** | **Opens blank — NG0201** |
+| Centered dialog (UVE, side-panel flag off) | `libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.ts` `providers` | **no** | **no** | **no** | Editor never opens; silently falls back to legacy Dojo |
+
+## Root-Cause Hypothesis
+
+`DotImageEditorAddressBarComponent` injects PrimeNG's `MessageService` non-optionally, to surface
+the copy-URL toast:
+
+```ts
+// libs/image-editor/src/lib/components/dot-image-editor-address-bar/dot-image-editor-address-bar.component.ts:37
+readonly #messageService = inject(MessageService);
+```
+
+Nothing in `@dotcms/image-editor` provides that token — the library implicitly relies on its host
+having one. `AngularImageEditorLauncher` opens the editor through the `DialogService` provided on
+the host component, so the dialog's injector chain is the host's chain. In the side panel that
+chain has no `MessageService`, so the address bar's `inject()` throws while the component tree is
+being constructed, `DotImageEditorComponent` fails to instantiate, and the dialog paints as an
+empty white box.
+
+Two supporting findings, both verified:
+
+- An audit of every `inject()` in `libs/image-editor/src` (excluding specs) shows `MessageService`
+  is the **only** host-dependent token the library does not either provide itself or obtain from a
+  root-provided service. `DotImageEditorService`, `DotPropertiesService` and `DotMessageService`
+  are `providedIn: 'root'`; `ImageEditorStore` and `ConfirmationService` are declared in
+  `DotImageEditorComponent`'s own `providers`; `Dialog` is injected `{ optional: true }`.
+- The existing Jest specs do not catch this because they replace the child components with
+  `MockComponent(...)` via `overrideComponents` — `dot-image-editor.component.spec.ts` mocks the
+  canvas, and `dot-image-editor-canvas.component.spec.ts` mocks the address bar — so the real
+  `inject(MessageService)` never executes in any test.
+
+For the secondary path, the cause is simply that `DotEditContentDialogComponent` was never given
+the two providers the shell and the side panel have, so the field's
+`inject(IMAGE_EDITOR_LAUNCHER, { optional: true })` legitimately resolves to `undefined`.
+
+## Fix Scope & Non-Goals *(mandatory)*
+
+**In scope**:
+
+- Make `@dotcms/image-editor` self-sufficient for messaging: `DotImageEditorComponent` declares
+  `MessageService` in its own `providers` and renders its own toast outlet, following the
+  `DotAssetPickerComponent` precedent, so no host is required to supply either.
+- Ensure the copy-URL success and error toasts render inside the editor dialog and are visible
+  above it, in every host.
+- Provide `DialogService` and `IMAGE_EDITOR_LAUNCHER` on `DotEditContentDialogComponent` the way
+  the shell and the side panel provide them, so the centered-dialog host opens the new editor
+  instead of silently downgrading to legacy Dojo.
+- Audit the library's remaining `inject()` sites once, so a future host cannot hit the same class
+  of failure.
+- Add regression coverage that exercises the real child component tree (not mocks) with no ambient
+  `MessageService`, plus coverage asserting `IMAGE_EDITOR_LAUNCHER` resolves in all three hosts.
+
+**Explicitly out of scope / non-goals**:
+
+- No changes to the legacy Dojo image editor, and no removal of the legacy fallback path itself.
+- No change to the full-screen shell's own `MessageService` / `<p-toast />`, which stays for the
+  shell's own messages.
+- No move of `MessageService` (or the launcher tokens) to a root/application-level provider — the
+  per-host scoping of `IMAGE_EDITOR_LAUNCHER` / `ASSET_PICKER_LAUNCHER` is deliberate and is
+  preserved.
+- No redesign of the image editor's toast/messaging UX, no new toast positions or styles beyond
+  what is needed to render inside the dialog.
+- No change to the side-panel feature flag, its default, or the choice of which host UVE opens.
+- No refactor of `ImageEditorStore`, the editor's features, or the asset picker.
+- No broader dependency-injection refactor of other `@dotcms/*` libraries, even if the same
+  implicit-host-provider pattern exists elsewhere.
+
+## Regression Risk *(mandatory)*
+
+- **Blast radius**: `@dotcms/image-editor` is consumed by all three Angular Edit Content hosts, so
+  the change is exercised by UVE, Content Drive, the Query Tool, the Relationship field's dialog,
+  and the full-screen route. Adding a component-scoped `MessageService` shadows any ambient one
+  for the editor's subtree: in the full-screen shell, editor toasts will now render through the
+  editor's own outlet rather than the shell's `<p-toast />`. That is the intended behavior, but it
+  is a visible change in where those specific toasts appear. A second toast outlet inside a
+  PrimeNG `DynamicDialog` also carries a stacking/`z-index` risk — the toast must be visible above
+  the dialog, not trapped behind its mask. Giving `DotEditContentDialogComponent` a `DialogService`
+  and the launcher token changes which editor that host opens for Image/File/Binary fields; that
+  path currently runs the legacy Dojo editor, so it moves from one working editor to another.
+- **Backward compatibility**: Frontend-only. No REST contract, `@Schema`, `openapi.yaml`, DB
+  schema, or Elasticsearch/OpenSearch mapping is touched, so nothing here falls into a
+  rollback-unsafe category. Saved image edits continue to flow through the existing temp-file
+  mechanism unchanged. The public surface of `@dotcms/image-editor` gains no new required input and
+  loses no existing one; hosts that already provide `MessageService` keep working without edits.
+- **Data considerations**: None. No stored content, field value, or serialized state is read or
+  written differently, so there is no existing bad data to migrate or repair.
+
+## Acceptance & Verification *(mandatory)*
+
+### The editor is self-sufficient
+
+- **AC-001**: `DotImageEditorComponent` declares `MessageService` in its own `providers` and
+  renders its own toast outlet (`<dot-toast />`), so the editor no longer depends on the host
+  providing either.
+- **AC-002**: The copy-URL success and error toasts raised by
+  `DotImageEditorAddressBarComponent` render **inside** the editor dialog and are visible above
+  it, in every host.
+- **AC-003**: No host is required to add `MessageService` for the editor to work. The full-screen
+  shell keeps its own `MessageService` / `<p-toast />` for its own messages, unchanged.
+- **AC-004**: No other `inject()` in `@dotcms/image-editor` resolves against a token the library
+  neither provides itself nor obtains from a root-provided service, so a second host cannot hit
+  the same class of failure.
+
+### Works in every Angular Edit Content host
+
+- **AC-005**: **Side panel** (UVE, Content Drive, Query Tool) — the reproduction above no longer
+  produces a blank dialog: the "Edit image" modal opens and renders fully (address bar, canvas,
+  Adjust / Transform / File info panels, footer).
+- **AC-006**: **Centered dialog** (`DotEditContentDialogComponent`, side-panel flag off) — the
+  modal opens the **new** editor, not the legacy Dojo one, because `DialogService` and
+  `IMAGE_EDITOR_LAUNCHER` are provided there the way the shell and the side panel provide them.
+- **AC-007**: **Full-screen route** — unchanged; no regression in opening, rendering, or closing
+  the editor.
+- **AC-008**: Save, Cancel, Download, and the unsaved-changes confirm dialog all work in each of
+  the three hosts.
+- **AC-009**: The browser console is free of `NG0201` in all three hosts.
+
+### Regression coverage
+
+- **AC-010**: `dot-image-editor.component.spec.ts` instantiates the component with **no ambient
+  `MessageService`** and asserts it renders. The test must exercise the real child tree along the
+  path that injects `MessageService` (today both `dot-image-editor.component.spec.ts` and
+  `dot-image-editor-canvas.component.spec.ts` replace those children with `MockComponent(...)`,
+  which is precisely why the defect is invisible in CI). The test fails on the current code and
+  passes after the fix.
+- **AC-011**: `dot-image-editor-address-bar.component.spec.ts` covers the copy-URL toast resolving
+  through the component-scoped `MessageService`.
+- **AC-012**: A spec asserts `IMAGE_EDITOR_LAUNCHER` resolves (is not `undefined`) in each of the
+  three hosts, so a host losing the provider fails a test instead of silently downgrading to the
+  legacy editor.
+- **AC-013**: The existing binary-field E2E that drives `image-editor-root`
+  (`apps/dotcms-ui-e2e/src/tests/edit-content/fields/file-upload-fields/binary-field/`) still
+  passes.
+
+**Verification method**:
+
+- Jest/Spectator (Red first, per Principle V):
+  `cd core-web && pnpm nx test image-editor` for AC-001, AC-002, AC-004, AC-010, AC-011;
+  `pnpm nx test edit-content` for AC-012.
+- Playwright E2E: the existing binary-field image-editor spec under
+  `apps/dotcms-ui-e2e/src/tests/edit-content/fields/file-upload-fields/binary-field/` for AC-013.
+- Manual, once per host, for AC-005 through AC-009: reproduce the steps above in the side panel,
+  then with the side-panel flag off, then from the full-screen route — each time exercising Save,
+  Cancel, Download and the unsaved-changes confirm, and checking the console for `NG0201`.
+
+## Assumptions
+
+- `<dot-toast />` (`libs/ui/src/lib/components/dot-toast/dot-toast.component.ts`) is the correct
+  outlet to reuse, as `DotAssetPickerComponent` does; the plan confirms whether it needs a
+  specific `position` or `z-index` treatment to sit above a PrimeNG `DynamicDialog`.
+- "Every Angular Edit Content host" means exactly the three hosts enumerated in the table above.
+  Any additional consumer of `@dotcms/image-editor` found during planning inherits AC-001 through
+  AC-004 for free, since the fix makes the library self-sufficient rather than patching hosts.
+- The issue's report is treated as accurate and was re-verified against `main` during scoping: the
+  `inject(MessageService)` site, the three hosts' `providers`, the `DotAssetPickerComponent`
+  precedent, and the mocked-child specs were all confirmed in the codebase.
+- The centered-dialog fix (AC-006) is in scope because it shares the same root — hosts not
+  declaring what the editor needs — even though its user-visible symptom differs.


### PR DESCRIPTION
## Problem
Opening the new image editor from inside UVE showed a completely blank dialog, with the console throwing `NG0201: No provider found for MessageService`. The editor only worked from the full-screen Edit Content route because that was the only host that happened to provide a `MessageService`. A related, quieter bug: with the side-panel flag off, UVE's centered dialog host was missing `DialogService` and `IMAGE_EDITOR_LAUNCHER`, so it silently fell back to the legacy Dojo image editor instead of the new one.

## Solution
Make the image editor self-sufficient instead of relying on its host to supply dependencies it needs. `DotImageEditorComponent` now provides its own `MessageService` and renders its own `<dot-toast />` outlet (matching the existing `DotAssetPickerComponent` pattern), so it no longer depends on an ancestor injector having one. `DotEditContentDialogComponent` now also provides `DialogService` and `IMAGE_EDITOR_LAUNCHER`, matching the shell and side-panel hosts, so it opens the new editor instead of falling back to legacy Dojo.

### Details
- `dot-image-editor.component.ts`/`.html`: add `MessageService` to `providers` and render `<dot-toast position="top-center" />`.
- `dot-create-content-dialog.component.ts`: add `DialogService` and `{ provide: IMAGE_EDITOR_LAUNCHER, useClass: AngularImageEditorLauncher }`.
- Regression tests added across all three Angular Edit Content hosts (shell, side panel, dialog) asserting `IMAGE_EDITOR_LAUNCHER` and `DialogService` resolve correctly, plus a new suite mounting the real (unmocked) image editor tree with no ambient `MessageService` to lock in host independence.
- Spec-kit artifacts (`spec.md`, `data-model.md`, contract doc) documenting the DI contract a host must satisfy to embed `@dotcms/image-editor`.

### Testing
- Jest/Spectator specs updated and added for `image-editor` and `edit-content` libs covering AC-001, AC-002, AC-004, AC-010, AC-011, AC-012 from the spec.

### Not in scope
- No changes to the legacy Dojo image editor or its fallback path.
- No move of `MessageService`/launcher tokens to a root-level provider.

This PR fixes: #37398
