### PR TITLE
feat(auth): offer to pre-fill Google Workspace group lookup after OIDC discovery

### DIFF
--- a/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/dot-auth-config.component.spec.ts
+++ b/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/dot-auth-config.component.spec.ts
@@ -110,6 +110,8 @@ describe('DotAuthConfigComponent', () => {
                 update: jest.fn(),
                 setProtocol: jest.fn(),
                 runOidcDiscovery: jest.fn(),
+                applyGoogleGroupsPreset: jest.fn(),
+                dismissGooglePrefill: jest.fn(),
                 revokeAllSessionRefs: jest.fn(),
                 addAllowedOrigin: jest.fn(),
                 removeAllowedOrigin: jest.fn(),
@@ -125,7 +127,8 @@ describe('DotAuthConfigComponent', () => {
                 errorCount: jest.fn().mockReturnValue(0),
                 dirty: jest.fn().mockReturnValue(false),
                 ssoDirty: jest.fn().mockReturnValue(false),
-                isSystem: jest.fn().mockReturnValue(true)
+                isSystem: jest.fn().mockReturnValue(true),
+                googlePrefillPending: jest.fn().mockReturnValue(false)
             })
         ],
         providers: [
@@ -141,22 +144,60 @@ describe('DotAuthConfigComponent', () => {
                 useValue: new MockDotMessageService({
                     'dotauth.config.sso.title': 'Single sign-on',
                     'dotauth.config.headless.title': 'Headless token exchange',
-                    'dotauth.config.trusted-idps.title': 'Trusted IdPs'
+                    'dotauth.config.trusted-idps.title': 'Trusted IdPs',
+                    'dotauth.confirm.google-groups.header': 'Google Workspace detected'
                 })
             }
         ]
     });
 
     beforeEach(() => {
-        spectator = createComponent();
+        spectator = createComponent({ detectChanges: false });
     });
 
     it('loads the route host and renders the SSO track by default', () => {
+        spectator.detectChanges();
         expect(spectator.component.store.load).toHaveBeenCalledWith(DOT_AUTH_SYSTEM_HOST);
         expect(spectator.query(byText('Single sign-on'))).toExist();
     });
 
     it('renders SSO content without tab selection (tabs removed)', () => {
+        spectator.detectChanges();
         expect(spectator.query(byText('Single sign-on'))).toExist();
+    });
+
+    describe('Google Workspace groups pre-fill offer', () => {
+        let store: jest.Mocked<InstanceType<typeof DotAuthConfigStore>>;
+        let confirmSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            store = spectator.inject(DotAuthConfigStore, true) as unknown as jest.Mocked<
+                InstanceType<typeof DotAuthConfigStore>
+            >;
+            confirmSpy = jest.spyOn(spectator.inject(ConfirmationService), 'confirm');
+        });
+
+        it('does not open the dialog when no Google discovery is pending', () => {
+            spectator.detectChanges();
+            expect(confirmSpy).not.toHaveBeenCalled();
+        });
+
+        it('opens the dialog once and clears the pending flag when Google is detected', () => {
+            (store.googlePrefillPending as unknown as jest.Mock).mockReturnValue(true);
+            spectator.detectChanges();
+            expect(store.dismissGooglePrefill).toHaveBeenCalledTimes(1);
+            expect(confirmSpy).toHaveBeenCalledTimes(1);
+            expect(confirmSpy.mock.calls[0][0].header).toBe('Google Workspace detected');
+        });
+
+        it('applies the preset on accept and nothing on reject', () => {
+            (store.googlePrefillPending as unknown as jest.Mock).mockReturnValue(true);
+            spectator.detectChanges();
+            const options = confirmSpy.mock.calls[0][0];
+            options.reject?.();
+            expect(store.applyGoogleGroupsPreset).not.toHaveBeenCalled();
+            options.accept();
+            expect(store.applyGoogleGroupsPreset).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/dot-auth-config.component.ts
+++ b/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/dot-auth-config.component.ts
@@ -5,6 +5,7 @@ import {
     effect,
     inject,
     signal,
+    untracked,
     viewChild
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -79,6 +80,12 @@ export class DotAuthConfigComponent implements OnInit {
 
     constructor() {
         effect(() => {
+            if (this.store.googlePrefillPending()) {
+                untracked(() => this.#offerGoogleGroupsPrefill());
+            }
+        });
+
+        effect(() => {
             if (this.store.status() === 'loaded' && !this.store.isSystem()) {
                 this.isOverriding.set(!this.store.inherited());
             }
@@ -122,6 +129,21 @@ export class DotAuthConfigComponent implements OnInit {
 
     ngOnInit(): void {
         this.store.load(this.#route.snapshot.paramMap.get('hostId') ?? this.SYSTEM_HOST);
+    }
+
+    /**
+     * Google returns no groups in its tokens; offer to fill the Cloud Identity lookup fields.
+     * The flag is cleared before the dialog opens so a dismissed dialog cannot re-trigger it.
+     */
+    #offerGoogleGroupsPrefill(): void {
+        this.store.dismissGooglePrefill();
+        this.#confirm.confirm({
+            header: this.#dotMessageService.get('dotauth.confirm.google-groups.header'),
+            message: this.#dotMessageService.get('dotauth.confirm.google-groups.message'),
+            acceptLabel: this.#dotMessageService.get('dotauth.confirm.google-groups.accept'),
+            rejectLabel: this.#dotMessageService.get('dotauth.confirm.google-groups.reject'),
+            accept: () => this.store.applyGoogleGroupsPreset()
+        });
     }
 
     switchProtocol(protocol: DotAuthUiProtocol): void {

--- a/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/store/dot-auth-config.mappers.spec.ts
+++ b/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/store/dot-auth-config.mappers.spec.ts
@@ -2,6 +2,9 @@ import { DotAuthConfig, DotAuthConfigView, DotAuthDiscoveryView } from '@dotcms/
 
 import {
     DEFAULT_CONFIG,
+    GOOGLE_GROUPS_SCOPE,
+    GOOGLE_GROUPS_URL,
+    applyGoogleGroupsPreset,
     applyOidcDiscovery,
     applyTrustedDiscovery,
     clone,
@@ -671,6 +674,38 @@ describe('dot-auth-config.mappers', () => {
             config.oidc.issuer = 'https://original.example';
             const result = applyOidcDiscovery(config, {});
             expect(result.oidc.issuer).toBe('https://original.example');
+        });
+    });
+
+    describe('applyGoogleGroupsPreset', () => {
+        it('fills the Google groups URL and response path when both are empty', () => {
+            const config = clone(DEFAULT_CONFIG);
+            const result = applyGoogleGroupsPreset(config);
+            expect(result.oidc.groupsUrl).toBe(GOOGLE_GROUPS_URL);
+            expect(result.oidc.groupsResponsePath).toBe('memberships[].groupKey.id');
+            expect(config.oidc.groupsUrl).toBe('');
+        });
+
+        it('leaves a customized groups URL and response path untouched', () => {
+            const config = clone(DEFAULT_CONFIG);
+            config.oidc.groupsUrl = 'https://custom.example/groups';
+            config.oidc.groupsResponsePath = 'items[].name';
+            const result = applyGoogleGroupsPreset(config);
+            expect(result.oidc.groupsUrl).toBe('https://custom.example/groups');
+            expect(result.oidc.groupsResponsePath).toBe('items[].name');
+        });
+
+        it('appends the cloud-identity scope when absent', () => {
+            const config = clone(DEFAULT_CONFIG);
+            const result = applyGoogleGroupsPreset(config);
+            expect(result.oidc.scopes).toBe(`openid email profile ${GOOGLE_GROUPS_SCOPE}`);
+        });
+
+        it('does not duplicate the cloud-identity scope when already present', () => {
+            const config = clone(DEFAULT_CONFIG);
+            config.oidc.scopes = `openid ${GOOGLE_GROUPS_SCOPE} email`;
+            const result = applyGoogleGroupsPreset(config);
+            expect(result.oidc.scopes).toBe(`openid ${GOOGLE_GROUPS_SCOPE} email`);
         });
     });
 

--- a/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/store/dot-auth-config.mappers.ts
+++ b/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/store/dot-auth-config.mappers.ts
@@ -318,6 +318,28 @@ export function applyOidcDiscovery(
     return draft;
 }
 
+/** Issuer Google returns from its OIDC discovery document; stable and unique to Google. */
+export const GOOGLE_ISSUER = 'https://accounts.google.com';
+export const GOOGLE_GROUPS_SCOPE = 'https://www.googleapis.com/auth/cloud-identity.groups.readonly';
+export const GOOGLE_GROUPS_URL =
+    "https://cloudidentity.googleapis.com/v1/groups/-/memberships:searchDirectGroups?query=member_key_id=='{email}'";
+
+/**
+ * Google cannot emit groups in token claims, so pre-fill the Cloud Identity groups lookup.
+ * Only empty fields are written, so re-running discovery never clobbers an admin's edits;
+ * the scope is appended once. Draft-only: nothing is persisted until the admin saves.
+ */
+export function applyGoogleGroupsPreset(config: DotAuthConfig): DotAuthConfig {
+    const draft = clone(config);
+    draft.oidc.groupsUrl ||= GOOGLE_GROUPS_URL;
+    draft.oidc.groupsResponsePath ||= 'memberships[].groupKey.id';
+    const scopes = draft.oidc.scopes.split(/\s+/).filter(Boolean);
+    if (!scopes.includes(GOOGLE_GROUPS_SCOPE)) {
+        draft.oidc.scopes = [...scopes, GOOGLE_GROUPS_SCOPE].join(' ');
+    }
+    return draft;
+}
+
 export function applyTrustedDiscovery(
     config: DotAuthConfig,
     path: `headless.trustedIdps.${number}`,

--- a/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/store/dot-auth-config.store.ts
+++ b/core-web/libs/portlets/dot-auth/src/lib/dot-auth-config/store/dot-auth-config.store.ts
@@ -10,6 +10,8 @@ import { DOT_AUTH_SYSTEM_HOST, DotAuthConfig, DotAuthUiProtocol } from '@dotcms/
 
 import {
     DEFAULT_CONFIG,
+    GOOGLE_ISSUER,
+    applyGoogleGroupsPreset,
     applyOidcDiscovery,
     applyTrustedDiscovery,
     clone,
@@ -38,6 +40,8 @@ interface DotAuthConfigState {
     // reload errored (which, per convention, still lands on status 'loaded'), so a failed
     // reload does not masquerade as a successful save with a green toast.
     reloadFailed: boolean;
+    // Set when OIDC discovery returned Google's issuer; the component offers the groups pre-fill.
+    googlePrefillPending: boolean;
 }
 
 const initialState: DotAuthConfigState = {
@@ -48,7 +52,8 @@ const initialState: DotAuthConfigState = {
     inherited: false,
     status: 'init',
     errors: {},
-    reloadFailed: false
+    reloadFailed: false,
+    googlePrefillPending: false
 };
 
 export const DotAuthConfigStore = signalStore(
@@ -249,9 +254,21 @@ export const DotAuthConfigStore = signalStore(
                             draft:
                                 path === 'oidc'
                                     ? applyOidcDiscovery(store.draft(), view)
-                                    : applyTrustedDiscovery(store.draft(), path, view)
+                                    : applyTrustedDiscovery(store.draft(), path, view),
+                            googlePrefillPending: path === 'oidc' && view.issuer === GOOGLE_ISSUER
                         });
                     });
+            },
+
+            applyGoogleGroupsPreset(): void {
+                patchState(store, {
+                    draft: applyGoogleGroupsPreset(store.draft()),
+                    googlePrefillPending: false
+                });
+            },
+
+            dismissGooglePrefill(): void {
+                patchState(store, { googlePrefillPending: false });
             },
 
             fetchSamlMetadata(url: string): void {

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -8522,6 +8522,10 @@ dotauth.confirm.clear.phrase=clear configuration
 dotauth.confirm.clear.instruction=Type <strong>{0}</strong> to confirm
 dotauth.confirm.reset.header=Reset to inherit?
 dotauth.confirm.reset.message=This will revert the site to inheriting the System default configuration.
+dotauth.confirm.google-groups.header=Google Workspace detected
+dotauth.confirm.google-groups.message=Google doesn't include group membership in its sign-in tokens. We can set up dotCMS to look up each user's groups from Google after they sign in, so group-to-role mappings work.<br><br>This fills in the Groups URL, Groups Response Path, and adds one Google scope. You can review or change these in Advanced Settings before saving.
+dotauth.confirm.google-groups.accept=Set up group lookup
+dotauth.confirm.google-groups.reject=Not now
 dotauth.action.reset=Reset
 dotauth.filter.all=All
 dotauth.filter.overrides=Overrides
@@ -8552,7 +8556,7 @@ dotauth.tooltip.audience=The expected audience (aud) claim in tokens. Usually yo
 dotauth.tooltip.scopes=Space-separated. openid is required.
 dotauth.tooltip.groupsUrl=Endpoint called with the user's access token when the IdP cannot emit groups in token claims (e.g. Google Workspace, GitHub). Supports {email} and {sub} placeholders.
 dotauth.tooltip.groupsResponsePath=Dot-path selecting group names from the Groups URL response, with [] marking the array. Example for Google Cloud Identity: memberships[].groupKey.id. Leave empty when the endpoint returns a plain JSON string array.
-dotauth.help.groupsUrl=For Google Workspace: https://cloudidentity.googleapis.com/v1/groups/-/memberships:searchDirectGroups?query=member_key_id=='{email}' with the cloud-identity.groups.readonly scope added to Scopes.
+dotauth.help.groupsUrl=For Google Workspace: https://cloudidentity.googleapis.com/v1/groups/-/memberships:searchDirectGroups?query=member_key_id=='{email}' with the cloud-identity.groups.readonly scope added to Scopes. Google also requires the Cloud Identity API enabled in your Google Cloud project and that scope added to your OAuth consent screen, otherwise sign-in will fail.
 dotauth.tooltip.responseType=code is standard for server-side apps. id_token uses the implicit flow. code id_token is hybrid — only use if your IdP requires it.
 dotauth.tooltip.pkce=Optional for dotCMS (confidential client) — leave off unless your IdP requires it.
 dotauth.tooltip.claimEmail=The JWT claim containing the user's email address. Used as the primary identifier in dotCMS.


### PR DESCRIPTION
### Proposed Changes
* When OIDC discovery returns Google's issuer (`https://accounts.google.com`), the dotAuth portlet opens a confirm dialog offering to set up the Cloud Identity groups lookup added in #37195.
* Accepting sets `groupsUrl` and `groupsResponsePath` (only when empty) and appends the `cloud-identity.groups.readonly` scope (only when absent). The change stays in the draft until the admin saves; declining changes nothing.
* The Groups URL help text now names the Google-side prerequisites (Cloud Identity API enabled, scope on the OAuth consent screen), since a half-enabled setup fails sign-in by design.

Frontend only. The discovery proxy already returns `issuer`, so no backend change. Trusted-IdP discovery on the headless track does not trigger the dialog.

### Checklist
- [x] Tests — mapper specs for fill-when-empty, no-clobber, scope append, scope no-duplicate; component specs for dialog open, flag clearing, accept/reject wiring (`portlets-dot-auth-portlet` suite: 103 passing)
- [x] Translations — four new `dotauth.confirm.google-groups.*` keys plus updated `dotauth.help.groupsUrl`
- [x] Security Implications Contemplated — pre-fill is draft-only and opt-in; a prompt rather than a silent fill because the groups fetch fails login when Google is not fully configured

### Additional Info
Resolves #37371.

### Screenshots

<img width="672" height="376" alt="image-1788534293121" src="https://github.com/user-attachments/assets/e6e120ed-1405-43a8-ac43-ceb11bd7339e" />

This PR fixes: #37371