### PR TITLE
fix(edit-content): open related content in a side panel from the full-screen editor

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.spec.ts
@@ -5,11 +5,15 @@
 jest.mock(
     '../../../../components/dot-edit-content-side-panel/dot-edit-content-side-panel.component',
     () => {
-        const { Component, input, output } = jest.requireActual('@angular/core');
+        const { Component, Input, output } = jest.requireActual('@angular/core');
 
+        // `data` is a decorated property, not a signal input like the real panel's: these tests
+        // run in JIT mode, where the compiler does not see a bare `data = input(...)` field, so
+        // `ComponentRef.setInput('data')` would leave it at its initial value and any assertion on
+        // what the panel was opened with would be vacuous.
         @Component({ selector: 'dot-edit-content-side-panel', standalone: true, template: '' })
         class MockDotEditContentSidePanelComponent {
-            data = input(null);
+            @Input() data: EditContentDialogData | null = null;
             closed = output();
             saved = output();
         }
@@ -22,6 +26,7 @@ import { byTestId, createComponentFactory, mockProvider, Spectator } from '@open
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { AbstractControl, FormControl, FormGroup, NgControl } from '@angular/forms';
 
 import { DialogService } from 'primeng/dynamicdialog';
 
@@ -37,6 +42,7 @@ import { DotRelationshipFieldComponent } from './dot-relationship-field.componen
 
 // Resolves to the mock declared in the jest.mock above (same module path the component imports).
 import { DotEditContentSidePanelComponent } from '../../../../components/dot-edit-content-side-panel/dot-edit-content-side-panel.component';
+import { EditContentDialogData } from '../../../../models/dot-edit-content-dialog.interface';
 import { EDIT_CONTENT_HOST } from '../../../../services/host/edit-content-host.model';
 import { DotEditContentStore } from '../../../../store/edit-content.store';
 import { TableColumn } from '../../models/relationship.models';
@@ -48,6 +54,15 @@ const ENGLISH_LANGUAGE = createFakeLanguage({
     language: 'English',
     languageCode: 'en',
     isoCode: 'en-us'
+});
+
+// A second locale so the by-id lookup is provably keyed on languageId, not just picking the
+// first entry.
+const SPANISH_LANGUAGE = createFakeLanguage({
+    id: 2,
+    language: 'Espanol',
+    languageCode: 'es',
+    isoCode: 'es-es'
 });
 
 const LANGUAGE_COLUMN: TableColumn = {
@@ -81,8 +96,45 @@ const buildItem = (overrides: Partial<DotCMSContentlet> = {}): DotCMSContentlet 
         ...overrides
     });
 
+/**
+ * Stands in for the `NgControl` that `formControlName` supplies in production. The field resolves
+ * it from its own injector to sync its value and reset the control's dirty state after a
+ * programmatic load. Defaults to no control — the same thing `#control()` sees when the field is
+ * mounted without a form around it — and tests that need a real (dirty) form assign one.
+ */
+let ngControlStub: { control: AbstractControl | null };
+
+/**
+ * Stands in for the {@link EDIT_CONTENT_HOST} the surrounding chrome provides. `inPlaceNavigation`
+ * is what tells the two chromes apart — `false` for the full-screen route, `true` for the overlay
+ * behind the side panel — and it decides whether related content opens in a panel or navigates,
+ * so tests set it before mounting. Defaults to full-screen.
+ */
+let hostStub: {
+    inPlaceNavigation: boolean;
+    setContentTitle: jest.Mock;
+    addBreadcrumb: jest.Mock;
+    goToSavedContent: jest.Mock;
+    goToRestoredVersion: jest.Mock;
+    goToRelatedContent: jest.Mock;
+    goToCrumb: jest.Mock;
+};
+
 describe('DotRelationshipFieldComponent', () => {
     let spectator: Spectator<DotRelationshipFieldComponent>;
+
+    beforeEach(() => {
+        ngControlStub = { control: null };
+        hostStub = {
+            inPlaceNavigation: false,
+            setContentTitle: jest.fn(),
+            addBreadcrumb: jest.fn(),
+            goToSavedContent: jest.fn(),
+            goToRestoredVersion: jest.fn(),
+            goToRelatedContent: jest.fn(),
+            goToCrumb: jest.fn()
+        };
+    });
 
     // i18n mock returns the key itself so header/empty-state assertions are deterministic.
     const messageServiceMock = {
@@ -119,6 +171,8 @@ describe('DotRelationshipFieldComponent', () => {
     const createComponent = createComponentFactory({
         component: DotRelationshipFieldComponent,
         detectChanges: false,
+        // Node-level: this is where the component's own injector looks for NgControl.
+        componentProviders: [{ provide: NgControl, useFactory: () => ngControlStub }],
         providers: [
             provideHttpClient(),
             provideHttpClientTesting(),
@@ -128,23 +182,14 @@ describe('DotRelationshipFieldComponent', () => {
                 currentLocale: jest.fn().mockReturnValue(null),
                 isCopyingLocale: jest.fn().mockReturnValue(false),
                 contentlet: jest.fn().mockReturnValue(null),
-                translationSourceInode: jest.fn().mockReturnValue(null)
+                translationSourceInode: jest.fn().mockReturnValue(null),
+                // Every system language, which is what the endpoint behind this slice returns.
+                locales: jest.fn().mockReturnValue([ENGLISH_LANGUAGE, SPANISH_LANGUAGE])
             }),
             mockProvider(DialogService, {
                 open: jest.fn()
             }),
-            {
-                provide: EDIT_CONTENT_HOST,
-                useValue: {
-                    inPlaceNavigation: false,
-                    setContentTitle: jest.fn(),
-                    addBreadcrumb: jest.fn(),
-                    goToSavedContent: jest.fn(),
-                    goToRestoredVersion: jest.fn(),
-                    goToRelatedContent: jest.fn(),
-                    goToCrumb: jest.fn()
-                }
-            }
+            { provide: EDIT_CONTENT_HOST, useFactory: () => hostStub }
         ]
     });
 
@@ -274,6 +319,34 @@ describe('DotRelationshipFieldComponent', () => {
             expect(config.data).toEqual(
                 expect.objectContaining({ mode: 'new', contentTypeId: 'ct-1' })
             );
+        });
+
+        it('resolves the language of the created content so the Locales column renders at once', async () => {
+            storeMock.flags.mockReturnValue({
+                [FeaturedFlags.FEATURE_FLAG_EDIT_CONTENT_SIDE_PANEL]: true
+            });
+            storeMock.data.mockReturnValue([]);
+
+            await spectator.component.showCreateNewContentDialog();
+            spectator.detectChanges();
+
+            // What a workflow action actually returns: `languageId`, no `language` object. Passed
+            // through as-is the new row's Locales cell stays blank until the parent is saved.
+            const created = buildItem({
+                inode: 'created-inode',
+                identifier: 'created-id',
+                title: 'Just created',
+                language: undefined,
+                languageId: 1
+            });
+            spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(created);
+
+            expect(storeMock.setData).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    identifier: 'created-id',
+                    language: ENGLISH_LANGUAGE
+                })
+            ]);
         });
 
         it('destroys the side panel when it emits `closed`', async () => {
@@ -489,6 +562,227 @@ describe('DotRelationshipFieldComponent', () => {
 
             expect(host.goToRelatedContent).not.toHaveBeenCalled();
             expect(host.goToCrumb).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('openRelated (side panel vs navigation)', () => {
+        const CURRENT = { inode: 'current-inode', title: 'Current content' };
+        const RELATED = buildItem({
+            inode: 'related-inode',
+            identifier: 'related-id',
+            title: 'Related content'
+        });
+
+        let host: { goToRelatedContent: jest.Mock; goToCrumb: jest.Mock };
+
+        /**
+         * Mounts the field as it is presented in one of the two editor chromes. `inPlaceNavigation`
+         * is the seam that tells them apart in production: `false` for the full-screen route
+         * (RouterEditContentHost), `true` for the overlay that backs the side panel
+         * (OverlayEditContentHost).
+         */
+        const setupIn = ({
+            inPlaceNavigation,
+            sidePanelEnabled = true
+        }: {
+            inPlaceNavigation: boolean;
+            sidePanelEnabled?: boolean;
+        }) => {
+            hostStub.inPlaceNavigation = inPlaceNavigation;
+
+            setup({
+                flags: jest
+                    .fn()
+                    .mockReturnValue(
+                        sidePanelEnabled
+                            ? { [FeaturedFlags.FEATURE_FLAG_EDIT_CONTENT_SIDE_PANEL]: true }
+                            : {}
+                    ),
+                data: jest.fn().mockReturnValue([RELATED]),
+                paginatedData: jest.fn().mockReturnValue([RELATED])
+            });
+
+            host = spectator.inject(EDIT_CONTENT_HOST) as never;
+            (spectator.inject(DotEditContentStore).contentlet as jest.Mock).mockReturnValue(
+                CURRENT
+            );
+            host.goToRelatedContent.mockClear();
+            host.goToCrumb.mockClear();
+        };
+
+        describe('from the full-screen editor', () => {
+            it('opens the related content in a side panel instead of navigating', async () => {
+                setupIn({ inPlaceNavigation: false });
+
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                // The whole point: no navigation is requested, so the editor is never unmounted
+                // and whatever is unsaved in it — including a relation to content just created
+                // from this field — survives. No unsaved-changes prompt needed.
+                expect(host.goToRelatedContent).not.toHaveBeenCalled();
+                expect(host.goToCrumb).not.toHaveBeenCalled();
+                expect(spectator.query('dot-edit-content-side-panel')).toBeTruthy();
+            });
+
+            it('opens the panel on the clicked content, in edit mode', async () => {
+                setupIn({ inPlaceNavigation: false });
+
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                expect(spectator.query(DotEditContentSidePanelComponent)?.data).toEqual(
+                    expect.objectContaining({
+                        mode: 'edit',
+                        contentletInode: 'related-inode',
+                        title: 'Related content'
+                    })
+                );
+            });
+
+            it('opens the panel regardless of whether the form has unsaved changes', async () => {
+                // The rule is the chrome, not the form state: a pristine editor takes the panel
+                // too. Keying this on `dirty` would make the same click behave differently
+                // depending on whether anything happened to be touched first.
+                const control = new FormControl('related-id');
+                new FormGroup({ [FIELD_MOCK.variable]: control });
+                ngControlStub = { control };
+
+                setupIn({ inPlaceNavigation: false });
+
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                expect(control.dirty).toBe(false);
+                expect(host.goToRelatedContent).not.toHaveBeenCalled();
+                expect(spectator.query('dot-edit-content-side-panel')).toBeTruthy();
+            });
+
+            it('navigates instead when the side panel flag is off', async () => {
+                setupIn({ inPlaceNavigation: false, sidePanelEnabled: false });
+
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                // No panel to open without the flag, so the previous behavior must stand rather
+                // than the click becoming a silent no-op.
+                expect(host.goToRelatedContent).toHaveBeenCalledTimes(1);
+                expect(spectator.query('dot-edit-content-side-panel')).toBeFalsy();
+            });
+        });
+
+        describe('from inside a side panel', () => {
+            it('navigates with a trail instead of opening another panel', async () => {
+                setupIn({ inPlaceNavigation: true });
+
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                // This chrome navigates in place and keeps its own crumb trail, so related
+                // content is reached through the breadcrumb — not a second panel on top.
+                expect(host.goToRelatedContent).toHaveBeenCalledWith(
+                    { inode: 'current-inode', title: 'Current content' },
+                    { inode: 'related-inode', title: 'Related content' }
+                );
+                expect(spectator.query('dot-edit-content-side-panel')).toBeFalsy();
+            });
+        });
+
+        describe('the panel it opens', () => {
+            beforeEach(() => setupIn({ inPlaceNavigation: false }));
+
+            it('is destroyed when it emits `closed`', async () => {
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                spectator.query(DotEditContentSidePanelComponent)?.closed.emit();
+                spectator.detectChanges();
+
+                expect(spectator.query('dot-edit-content-side-panel')).toBeFalsy();
+            });
+
+            it('refreshes the edited row by identifier when it reports a save', async () => {
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                const saved = buildItem({
+                    inode: 'new-inode-after-save',
+                    identifier: 'related-id',
+                    title: 'Related content (edited)'
+                });
+                spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
+
+                // Matched by identifier (stable across saves), so the row shows the new
+                // title/inode while the field's value — a list of identifiers — is unchanged.
+                expect(storeMock.setData).toHaveBeenCalledWith([saved]);
+            });
+
+            it('resolves the language of the refreshed row so the Locales column still renders', async () => {
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                // A workflow action returns `languageId` but no `language` object, so passing it
+                // straight through would blank the Locales column until the parent is saved.
+                const saved = buildItem({
+                    inode: 'new-inode-after-save',
+                    identifier: 'related-id',
+                    title: 'Related content (edited)',
+                    language: undefined,
+                    languageId: 2
+                });
+                spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
+
+                expect(storeMock.setData).toHaveBeenCalledWith([
+                    expect.objectContaining({
+                        inode: 'new-inode-after-save',
+                        language: SPANISH_LANGUAGE
+                    })
+                ]);
+            });
+
+            it('leaves an already-resolved language untouched', async () => {
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                const saved = buildItem({
+                    identifier: 'related-id',
+                    language: ENGLISH_LANGUAGE,
+                    languageId: 1
+                });
+                spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
+
+                expect(storeMock.setData).toHaveBeenCalledWith([
+                    expect.objectContaining({ language: ENGLISH_LANGUAGE })
+                ]);
+            });
+
+            it('leaves the row as-is when the language id matches no known locale', async () => {
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                const saved = buildItem({
+                    identifier: 'related-id',
+                    language: undefined,
+                    languageId: 999
+                });
+                spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
+
+                // Blank column beats a wrong locale.
+                expect(storeMock.setData).toHaveBeenCalledWith([
+                    expect.objectContaining({ language: undefined })
+                ]);
+            });
+
+            it('leaves the table untouched when the save reports an unrelated identifier', async () => {
+                await spectator.component.openRelated(RELATED);
+                spectator.detectChanges();
+
+                spectator
+                    .query(DotEditContentSidePanelComponent)
+                    ?.data?.onContentSaved?.(buildItem({ identifier: 'someone-else' }));
+
+                expect(storeMock.setData).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.spec.ts
@@ -159,6 +159,7 @@ describe('DotRelationshipFieldComponent', () => {
         flags: jest.fn().mockReturnValue({}),
         initialize: jest.fn(),
         setData: jest.fn(),
+        refreshItem: jest.fn(),
         deleteItem: jest.fn(),
         reorderData: jest.fn(),
         nextPage: jest.fn(),
@@ -712,9 +713,10 @@ describe('DotRelationshipFieldComponent', () => {
                 });
                 spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
 
-                // Matched by identifier (stable across saves), so the row shows the new
-                // title/inode while the field's value — a list of identifiers — is unchanged.
-                expect(storeMock.setData).toHaveBeenCalledWith([saved]);
+                // Handed to the store's in-place replace — which keeps the current page and does
+                // not dirty the form — rather than setData, which resets pagination to page 1.
+                expect(storeMock.refreshItem).toHaveBeenCalledWith(saved);
+                expect(storeMock.setData).not.toHaveBeenCalled();
             });
 
             it('resolves the language of the refreshed row so the Locales column still renders', async () => {
@@ -732,12 +734,12 @@ describe('DotRelationshipFieldComponent', () => {
                 });
                 spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
 
-                expect(storeMock.setData).toHaveBeenCalledWith([
+                expect(storeMock.refreshItem).toHaveBeenCalledWith(
                     expect.objectContaining({
                         inode: 'new-inode-after-save',
                         language: SPANISH_LANGUAGE
                     })
-                ]);
+                );
             });
 
             it('leaves an already-resolved language untouched', async () => {
@@ -751,9 +753,9 @@ describe('DotRelationshipFieldComponent', () => {
                 });
                 spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
 
-                expect(storeMock.setData).toHaveBeenCalledWith([
+                expect(storeMock.refreshItem).toHaveBeenCalledWith(
                     expect.objectContaining({ language: ENGLISH_LANGUAGE })
-                ]);
+                );
             });
 
             it('leaves the row as-is when the language id matches no known locale', async () => {
@@ -768,19 +770,24 @@ describe('DotRelationshipFieldComponent', () => {
                 spectator.query(DotEditContentSidePanelComponent)?.data?.onContentSaved?.(saved);
 
                 // Blank column beats a wrong locale.
-                expect(storeMock.setData).toHaveBeenCalledWith([
+                expect(storeMock.refreshItem).toHaveBeenCalledWith(
                     expect.objectContaining({ language: undefined })
-                ]);
+                );
             });
 
-            it('leaves the table untouched when the save reports an unrelated identifier', async () => {
+            it('forwards the save to the store, which ignores an unrelated identifier', async () => {
                 await spectator.component.openRelated(RELATED);
                 spectator.detectChanges();
 
+                // Whether the row exists is the store's call (covered in its own spec); the
+                // component's job is only to resolve the language and hand it over.
                 spectator
                     .query(DotEditContentSidePanelComponent)
                     ?.data?.onContentSaved?.(buildItem({ identifier: 'someone-else' }));
 
+                expect(storeMock.refreshItem).toHaveBeenCalledWith(
+                    expect.objectContaining({ identifier: 'someone-else' })
+                );
                 expect(storeMock.setData).not.toHaveBeenCalled();
             });
         });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -141,7 +141,7 @@ export class DotRelationshipFieldComponent
      */
     readonly #dialogService = inject(DialogService);
 
-    /** Used to create the Edit Content side panel imperatively (see {@link showCreateNewContentDialog}). */
+    /** Used to create the Edit Content side panel imperatively (see {@link openSidePanel}). */
     readonly #viewContainerRef = inject(ViewContainerRef);
 
     /**
@@ -288,17 +288,21 @@ export class DotRelationshipFieldComponent
 
     /**
      * Opens the editor for a related content, restoring the legacy editor's
-     * related-content navigation. The current content is seeded as the origin of
-     * the navigation trail so the "Relating content" banner shows the full path.
-     * The host performs the navigation: a route change in full-screen, an in-place
-     * reload in a dialog.
+     * related-content navigation.
+     *
+     * From the **full-screen** editor it does not navigate at all: the content opens in a side
+     * panel over the editor, which therefore stays mounted with its edits intact (see
+     * {@link opensInSidePanel}).
+     *
+     * From **inside a panel** it navigates: the host reloads in place and the current content is
+     * seeded as the origin of the trail, so the breadcrumb shows the full path.
      *
      * No-op when navigation is disabled (a disabled field), when the item has no
      * inode, or when it points at the content already open.
      *
      * @param item The related contentlet whose title was clicked.
      */
-    openRelated(item: DotCMSContentlet): void {
+    async openRelated(item: DotCMSContentlet): Promise<void> {
         if (!this.$canNavigate() || !item?.inode) {
             return;
         }
@@ -306,6 +310,19 @@ export class DotRelationshipFieldComponent
         const current = this.#editContentStore.contentlet();
         // Navigating to the content already open is a no-op.
         if (current?.inode === item.inode) {
+            return;
+        }
+
+        // From the full-screen editor, related content opens in a side panel over it instead of
+        // navigating away (see {@link opensInSidePanel}).
+        if (this.#opensInSidePanel()) {
+            await this.#openSidePanel({
+                mode: 'edit',
+                contentletInode: item.inode,
+                title: item.title ?? '',
+                onContentSaved: (contentlet) => this.#refreshRelatedItem(contentlet)
+            });
+
             return;
         }
 
@@ -331,6 +348,77 @@ export class DotRelationshipFieldComponent
             { inode: originInode, title: originTitle },
             { inode: item.inode, title: item.title ?? '' }
         );
+    }
+
+    /**
+     * Whether related content opens in a side panel instead of navigating. Decided purely by
+     * where this editor is presented:
+     *
+     * - **Full-screen** — always the panel. Navigating away would unmount the editor and discard
+     *   whatever is unsaved in it, which is what made "create content from this field, then open
+     *   it" impossible: the new relation lives only in that unsaved form. The panel opens over
+     *   the editor, so it stays mounted and closing the panel returns to it untouched. Nothing
+     *   stacks here — the layer underneath is a route, not a panel.
+     * - **Inside a panel** — never. That context navigates in place and builds its own crumb
+     *   trail, so related content is reached through the breadcrumb rather than a second panel
+     *   on top of the first.
+     *
+     * Without the side panel flag there is no panel to open, so the previous navigation (and its
+     * unsaved-changes prompt) stands.
+     */
+    #opensInSidePanel(): boolean {
+        const sidePanelEnabled =
+            this.store.flags()[FeaturedFlags.FEATURE_FLAG_EDIT_CONTENT_SIDE_PANEL] ?? false;
+
+        return sidePanelEnabled && !this.#host.inPlaceNavigation;
+    }
+
+    /**
+     * Refreshes the row of a related content that was just edited in a side panel, so the table
+     * shows its new title and status instead of the version from before the edit.
+     *
+     * Matched by identifier, which is stable across saves (a save mints a new inode). That keeps
+     * this field's value — a list of identifiers — unchanged, so refreshing a row never marks the
+     * form dirty on its own.
+     */
+    #refreshRelatedItem(contentlet: DotCMSContentlet): void {
+        const data = this.store.data();
+        const index = data.findIndex((item) => item.identifier === contentlet.identifier);
+
+        if (index === -1) {
+            return;
+        }
+
+        this.store.setData(
+            data.map((item, i) => (i === index ? this.#withResolvedLanguage(contentlet) : item))
+        );
+    }
+
+    /**
+     * Fills in a saved contentlet's `language` object so the Locales column can render it.
+     *
+     * Related items normally reach the table through the parent's `depth` fetch, where each child
+     * carries a full `DotLanguage` (`{ language: 'English', languageCode: 'en', ... }`) — which is
+     * what the `language` pipe formats. A contentlet returned by a workflow action does NOT: it
+     * carries only `languageId`, so the pipe yields an empty label and the column renders blank
+     * until the parent is saved and the field re-initializes from a depth fetch.
+     *
+     * Both paths that put a just-saved contentlet in the table (creating content from this field,
+     * and refreshing a row edited in a side panel) therefore resolve the language here, from the
+     * locales the editor has already loaded — every system language, so a lookup by id always
+     * resolves. Left untouched when the contentlet already has one, or when the id cannot be
+     * matched (the column stays blank rather than showing something wrong).
+     */
+    #withResolvedLanguage(contentlet: DotCMSContentlet): DotCMSContentlet {
+        if (contentlet.language) {
+            return contentlet;
+        }
+
+        const locale = this.#editContentStore
+            .locales()
+            ?.find((candidate) => candidate.id === contentlet.languageId);
+
+        return locale ? { ...contentlet, language: locale } : contentlet;
     }
 
     /**
@@ -455,7 +543,7 @@ export class DotRelationshipFieldComponent
             onContentSaved: (contentlet: DotCMSContentlet) => {
                 // Add the created contentlet to the relationship
                 const currentData = this.store.data();
-                this.store.setData([...currentData, contentlet]);
+                this.store.setData([...currentData, this.#withResolvedLanguage(contentlet)]);
             }
         };
 
@@ -468,7 +556,7 @@ export class DotRelationshipFieldComponent
             this.store.flags()[FeaturedFlags.FEATURE_FLAG_EDIT_CONTENT_SIDE_PANEL] ?? false;
 
         if (sidePanelEnabled) {
-            await this.#openCreateContentSidePanel(dialogData);
+            await this.#openSidePanel(dialogData);
 
             return;
         }
@@ -496,12 +584,16 @@ export class DotRelationshipFieldComponent
     }
 
     /**
-     * Creates the Edit Content side panel imperatively. The component is loaded via dynamic
+     * Creates an Edit Content side panel imperatively. The component is loaded via dynamic
      * `import()` (not a static template import) to avoid a module cycle — see the `import type`
      * note at the top of this file. The panel fires `dialogData.onContentSaved` (last save) and
      * `dialogData.onCancel` on close; `(closed)` tears the component down.
+     *
+     * Shared by both entry points: creating content to relate ({@link showCreateNewContentDialog})
+     * and opening an already-related content without leaving the full-screen editor
+     * ({@link openRelated}) — in both cases the editor behind the panel stays mounted.
      */
-    async #openCreateContentSidePanel(dialogData: EditContentDialogData): Promise<void> {
+    async #openSidePanel(dialogData: EditContentDialogData): Promise<void> {
         const { DotEditContentSidePanelComponent } =
             await import('../../../../components/dot-edit-content-side-panel/dot-edit-content-side-panel.component');
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -377,21 +377,11 @@ export class DotRelationshipFieldComponent
      * Refreshes the row of a related content that was just edited in a side panel, so the table
      * shows its new title and status instead of the version from before the edit.
      *
-     * Matched by identifier, which is stable across saves (a save mints a new inode). That keeps
-     * this field's value — a list of identifiers — unchanged, so refreshing a row never marks the
-     * form dirty on its own.
+     * The store does the replacing (see its `refreshItem`); this only resolves the language first,
+     * since that needs the editor's locales and the relationship store has no access to them.
      */
     #refreshRelatedItem(contentlet: DotCMSContentlet): void {
-        const data = this.store.data();
-        const index = data.findIndex((item) => item.identifier === contentlet.identifier);
-
-        if (index === -1) {
-            return;
-        }
-
-        this.store.setData(
-            data.map((item, i) => (i === index ? this.#withResolvedLanguage(contentlet) : item))
-        );
+        this.store.refreshItem(this.#withResolvedLanguage(contentlet));
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -252,6 +252,63 @@ describe('RelationshipFieldStore', () => {
             });
         });
 
+        describe('refreshItem', () => {
+            it('should replace the matching item by identifier, keeping the current page', () => {
+                const eightItems = Array.from({ length: 8 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `refresh-inode-${i + 1}`,
+                        identifier: `refresh-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
+                store.setData(eightItems);
+
+                // The user is on page 2, looking at the row they just edited elsewhere.
+                store.nextPage();
+                expect(store.pagination().currentPage).toBe(2);
+
+                // A save mints a new inode; the identifier is what stays stable.
+                store.refreshItem(
+                    createFakeContentlet({
+                        inode: 'inode-after-save',
+                        identifier: 'refresh-identifier-7',
+                        title: 'Edited elsewhere'
+                    })
+                );
+
+                // Snapping back to page 1 would lose the user's place — this is why the method
+                // exists instead of reusing setData.
+                expect(store.pagination().currentPage).toBe(2);
+                expect(store.pagination().offset).toBe(6);
+                expect(store.data()[6].inode).toBe('inode-after-save');
+                expect(store.data()[6].title).toBe('Edited elsewhere');
+                expect(store.data().length).toBe(8);
+            });
+
+            it('should mark the change as a load so it never dirties the form', () => {
+                store.setData(mockData);
+                expect(store.lastChangeSource()).toBe('user');
+
+                store.refreshItem(
+                    createFakeContentlet({ inode: 'new-inode', identifier: 'identifier1' })
+                );
+
+                // The relationship itself did not change — only the version of one entry.
+                expect(store.lastChangeSource()).toBe('load');
+            });
+
+            it('should be a no-op when the identifier is not in the list', () => {
+                store.setData(mockData);
+                const before = store.data();
+
+                store.refreshItem(
+                    createFakeContentlet({ inode: 'x', identifier: 'not-related-here' })
+                );
+
+                expect(store.data()).toBe(before);
+            });
+        });
+
         describe('deleteItem', () => {
             it('should delete item by inode', () => {
                 store.setData(mockData);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -278,6 +278,35 @@ export const RelationshipFieldStore = signalStore(
                 }
             },
             /**
+             * Replaces one item in place, matched by identifier — identifiers are stable across
+             * saves, so this finds the row even though a save mints a new inode. Used when a
+             * related content is edited elsewhere (e.g. in a side panel) and comes back saved, so
+             * its row shows the new title and status.
+             *
+             * Deliberately not `setData`, for two reasons:
+             * - it keeps the current page, like {@link reorderData}: the user is looking at the row
+             *   that changed, and snapping back to page 1 would lose their place;
+             * - it marks the change as `'load'`, because the relationship itself did not change —
+             *   only the version of one entry — so this must never dirty the form.
+             *
+             * A no-op when the identifier is not in the list.
+             *
+             * @param {DotCMSContentlet} contentlet - The saved contentlet to put in place of its row.
+             */
+            refreshItem(contentlet: DotCMSContentlet) {
+                const data = store.data();
+                const index = data.findIndex((item) => item.identifier === contentlet.identifier);
+
+                if (index === -1) {
+                    return;
+                }
+
+                patchState(store, {
+                    data: data.map((item, i) => (i === index ? contentlet : item)),
+                    lastChangeSource: 'load'
+                });
+            },
+            /**
              * Reorders the data without resetting the current pagination.
              * Used after drag-and-drop row reorder to preserve the current page.
              * @param {DotCMSContentlet[]} data - The reordered data array.

--- a/specs/37385-relationship-nav-unsaved/spec.md
+++ b/specs/37385-relationship-nav-unsaved/spec.md
@@ -1,0 +1,118 @@
+# Issue Resolution Specification: Relationship field — navigating to content just created from the field triggers the unsaved-changes prompt
+
+**Feature Branch**: `37385-relationship-nav-unsaved`
+
+**Created**: 2026-09-03
+
+**Status**: Draft
+
+**Type**: Issue / Bug Resolution
+
+**Related GitHub Issue**: [#37385](https://github.com/dotCMS/core/issues/37385)
+
+**Input**: User description: "Relationship field: navigating to content just created from the field triggers the unsaved-changes prompt. Frontend (core-web, libs/edit-content). Team Falcon."
+
+## Problem Statement *(mandatory)*
+
+Content created directly from a Relationship field cannot be opened right after creating it. Clicking the new row raises the "unsaved changes" dialog, which offers only *Keep editing* or *Discard changes* — so the user either abandons the navigation or throws away the relation they just built.
+
+The prompt is technically correct, which is what makes this a design dead end rather than a stray dialog: creating content from a Relationship field adds the new contentlet to the field's value, marking the editor's form dirty, and that relation exists **only** in the unsaved form. Opening the new content destroys the editor (full-screen) or reloads it in place (overlay), so the relation — plus any other in-flight edits — genuinely would be lost. The guard fires exactly as designed.
+
+A second, independent defect surfaces in the same flow: the row added for the newly created content shows an **empty Locales column**. It only fills in after the parent is saved. Same root flow, different cause (see Root-Cause Hypothesis), and it is fixed here because the row-refresh introduced by this change would otherwise reproduce it on every save.
+
+**Severity / Impact**: Medium — some functionality impacted. Affects every content type with a Relationship field in the new Edit Content editor. It is not a silent data loss (the dialog does warn), but a flow users are directed into ("create the related content from here, then go look at it") cannot be completed, and the only way forward discards a change the user just made deliberately.
+
+## Reproduction *(mandatory)*
+
+**Environment**: dotCMS admin UI (Angular), new Edit Content editor. Latest from `main` (`23.4.0-next.1`). Browser-agnostic; reproduced on Chrome / macOS.
+
+**Steps to Reproduce**:
+
+1. Open a content item whose content type has a Relationship field, in the new Edit Content editor.
+2. In the Relationship field, choose **Create new content**.
+3. Fill in the new content and save it. It now shows as a row in the parent's Relationship field.
+4. Click that new row to open the content that was just created.
+
+**Expected Behavior**: The content just created opens, and the work in progress in the editor behind it is preserved.
+
+**Actual Behavior**: The "unsaved changes" dialog appears. The user must either discard the relation just created (losing it) or cancel and not open the content at all.
+
+**Reproducibility**: Always, whenever the editor has unsaved changes. Creating content from the field always leaves it in that state, so this path reproduces 100% of the time.
+
+**Second defect (empty Locales column)** — same steps 1–3, then observe the new row: its Locales cell is blank while the pre-existing rows show their locale (e.g. "English (en)"). Save or publish the parent and the cell fills in. Also always reproducible.
+
+## Scope of Investigation *(mandatory)*
+
+- **Affected area**: Admin UI — new Edit Content editor, Relationship field and its related-content navigation. Frontend only; no backend change is anticipated.
+- **Suspected surface**: Modern frontend (`core-web/libs/edit-content`). No `com.dotmarketing.*` or `com.dotcms.*` Java code is expected to be touched; the legacy Dojo editor is not involved.
+- **Related known decisions**: Related-content navigation with a breadcrumb trail was introduced by issue #36349 (URL-driven `rc` query param for the full-screen editor, per-instance in-memory trail for overlays). This fix must not regress that behavior for editors with no unsaved changes. The plan formally consults `dotCMS/platform-adrs`.
+
+## Root-Cause Hypothesis
+
+The relation between the parent content and the content created from the field is never persisted at creation time — it lives only in the parent's unsaved form value. Two observations support this:
+
+1. On a successful create, the field appends the new contentlet to its store data, which marks the form control (and therefore the editor's form) dirty.
+2. The dialog data carries a `relationshipInfo` payload (parent id, relationship name, isParent) that is **declared but never consumed** — nothing sends it to the backend.
+
+Related-content navigation is a real navigation: the full-screen host performs a router navigation and the overlay host reloads in place. Either way the current editor's form is discarded, so the unsaved-changes guard is correct to intervene. The defect is therefore in the interaction design, not in the guard: the user is asked to choose between two losses in a flow that should have neither.
+
+**Empty Locales column** — confirmed against a running instance, not inferred. The column formats the item's full language object (`{ language: 'English', languageCode: 'en', … }`). Related items normally arrive through the parent's `depth` fetch, where each child carries that object. A contentlet returned by a **workflow action** does not: it carries only `languageId`. The row added on create therefore has nothing for the column to format, and stays blank until the parent is saved and the field re-reads its items from a `depth` fetch.
+
+## Fix Scope & Non-Goals *(mandatory)*
+
+**In scope**:
+
+- From the **full-screen** editor, related content opens in a side panel over it instead of navigating away, so the editor stays mounted and nothing unsaved is discarded or prompted about.
+- From **inside a side panel**, related content keeps navigating in place with its own crumb trail — no second panel on top.
+- Closing the panel returns to the editor exactly as left: same values, same unsaved state, the new item still listed.
+- Refreshing a related row (title, status) in the parent's Relationship field after that content is edited and saved, without that refresh marking the parent form dirty by itself.
+- Filling in the Locales column for a just-saved contentlet, in both paths that put one in the table (creating content from the field, and refreshing a row edited in the panel).
+
+**Explicitly out of scope / non-goals**:
+
+- Persisting the relationship at creation time (wiring `relationshipInfo` to a backend relate call, or auto-saving the parent). That changes save semantics and needs its own decision.
+- Snapshotting and restoring form state across a navigation that unmounts the editor. Evaluated and rejected for this fix: the per-field-type restore cost (binary/file, category, block editor, custom field) is large and the failure mode is silent.
+- Changing the unsaved-changes prompt itself. It must keep firing when the user genuinely leaves an editor with unsaved changes (closing it, navigating away, tab close/refresh via `beforeunload`).
+- Stacking a second panel on top of the first. Navigation from inside a panel stays as it is today.
+- Adding a limit to how deep related content can be opened. Explicitly decided against (see Assumptions).
+- Making the panel show a crumb trail for the hop that opened it. The panel header names the content but that hop appears in no trail — a known gap, deferred (see Assumptions).
+
+## Regression Risk *(mandatory)*
+
+- **Blast radius**:
+  - Related-content navigation and its breadcrumb trail (#36349) — the pristine path must be untouched.
+  - The unsaved-changes guard, in all its entry points: route `canDeactivate`, the host navigation guard for same-route moves, the editor's close guard, and `beforeunload`.
+  - The "create content from a Relationship field" flow, which shares the code that opens the editor.
+  - Cross-cutting state that is already reference-counted or stacked per open editor: main-navigation collapse, the form bridge, ESC/click-outside handling for the frontmost layer only.
+- **Backward compatibility**: The `rc` trail query param, breadcrumb rendering and shareable/deep links must keep working for the pristine path. No API, DB or ES contract is touched; nothing here is rollback-unsafe.
+- **Data considerations**: None. No migration, no repair of existing data. The fix changes only how the editor is presented during navigation.
+- **Resource risk**: Keeping the previous editor alive means more than one full editor (form + sidebar + workflow) mounted at once. With no depth limit this grows with how deep the user navigates. The plan must state how this is measured and what the acceptable ceiling is in practice.
+
+## Acceptance & Verification *(mandatory)*
+
+- **AC-001**: The reproduction steps above no longer produce the actual behavior — clicking the newly created row opens that content with no unsaved-changes dialog.
+- **AC-002**: The full-screen editor keeps its unsaved changes while the related content is open in the panel, including the relation to the content just created.
+- **AC-003**: Closing the panel returns to that editor with the form exactly as left: same values, same unsaved state, the new item still listed in the Relationship field.
+- **AC-004**: From the full-screen editor, the panel opens for any related content — whether or not the form has unsaved changes and whether or not that relation was already saved.
+- **AC-005**: Editing a related content and saving it updates that row's title and status in the parent's Relationship field.
+- **AC-006**: Refreshing that row does not, by itself, mark the parent form as having unsaved changes.
+- **AC-007**: From inside a side panel, opening a related content navigates in place and shows the crumb trail — it does not open another panel.
+- **AC-008**: The Locales column is populated as soon as content created from the field appears in the table, without waiting for the parent to be saved.
+- **AC-009**: The Locales column stays populated after a related content is edited and saved in the panel. A language id that matches no known locale leaves the cell blank rather than showing a wrong locale.
+- **AC-010** *(regression)*: Without the side panel flag, related-content navigation behaves exactly as before — router navigation, trail, breadcrumb, deep links, and the unsaved-changes prompt.
+- **AC-011** *(regression)*: The unsaved-changes prompt still fires when the user genuinely leaves an editor with unsaved changes: closing it, navigating away from it, or a tab close/refresh.
+
+- **Verification method**:
+  - Jest/Spectator specs in `core-web/libs/edit-content`, covering: the dirty path does not delegate to the navigation host; the pristine path still does; the previous editor stays mounted and dirty across a navigation and back; a related row refreshes by identifier after a save without dirtying the form; the close/exit guard still prompts.
+    `pnpm nx test edit-content --testPathPatterns="relationship-field"`
+  - Full library regression: `pnpm nx test edit-content` and `pnpm nx lint edit-content`.
+  - Manual: the reproduction steps above, plus a two-level-deep navigation with unsaved changes at each level, verified back to the root editor.
+
+## Assumptions
+
+- The new Edit Content side panel presentation is enabled by default and is the presentation this fix targets.
+- **No depth limit.** A prototype capped how deep related content could be opened; the decision (dev, 2026-09-03) is to have no limit, on the grounds that a limit is a surprising behavior change mid-flow. The resource cost of unlimited depth is recorded under Regression Risk so the plan can address measurement rather than a hard cap.
+- **The rule is the chrome, not the state.** Two narrower rules were built and rejected in review (dev, 2026-09-04): keying on "the form is dirty" hijacked every related-content click as soon as anything on the page was touched, losing the trail and breadcrumb; keying on "this relation is not saved yet" still diverted clicks unpredictably. The accepted rule is positional — full-screen always opens the panel, inside a panel always navigates — so the same click always behaves the same way in the same place.
+- **The hop that opens the panel leaves no crumb.** The panel's own trail starts at the panel's content, so the editor underneath does not appear in it. Accepted for now; a panel-header trail was scoped and deferred.
+- The relation created from the field is expected to be persisted when the user saves the parent, as it is today. This fix does not change when the relation is written.
+- **TDD note (Constitution Principle V):** an exploratory prototype of this fix already exists on the working branch, with passing Jest specs. Those tests must be reviewed and dev-approved, and confirmed to FAIL against the unfixed code (Red), before being accepted as the fix's test suite. The plan and tasks phases must re-establish that ordering rather than inherit green tests.


### PR DESCRIPTION
Fixes #37385.

## The problem

Creating content from a Relationship field and then clicking it raised the "unsaved changes" dialog. Navigating away unmounts the editor, and the relation to the content you just created lives only in that unsaved form — so the guard was right to warn, and the user was left choosing between losing the relation and not opening the content.

## The fix

**From the full-screen editor, related content now opens in a side panel** instead of navigating. The editor stays mounted, so nothing is lost and there is nothing to warn about; closing the panel returns to it untouched.

**From inside a panel, nothing changes** — it navigates in place and keeps its crumb trail, so no second panel is stacked.

The rule is positional, not based on form or item state, so the same click always behaves the same way in the same place.

Editing a related content in the panel also refreshes its row (title, status), keeping the current page and without dirtying the form.

### Small extra, found while testing

A contentlet returned by a workflow action carries only `languageId`, not the language object the Locales column formats — so a row for content just created from the field showed a blank locale until the parent was saved. Both paths that add a just-saved contentlet to the table now resolve the language from the editor's already-loaded locales, by id, with no extra request.

## Testing

```
edit-content (full library)   114 suites, 2294 tests   ✅
lint edit-content             0 errors                 ✅
```

Known gaps: no automated test proves the editor's form survives the panel round-trip (the spec proves no navigation is requested, which is indirect) — covered by the manual steps below. The hop that opens the panel leaves no crumb; a panel-header trail was scoped and deferred. Inside a panel the original prompt still appears, since that context does not stack.

## How to test

1. Open a content item whose type has a Relationship field (side panel flag on).
2. Edit another field (e.g. the title) so there are pending changes.
3. Relationship field → **Create new content** → fill and save. It appears as a row, **with its Locales cell already filled**.
4. Click that row → opens in a side panel, **no dialog**.
5. Close the panel (✕ or ESC) → the editor still shows your pending title change and lists the new item.
6. From inside the panel, click one of *its* related contents → navigates in place with the crumb trail, no second panel.
7. Regression: with pending changes, close the editor or navigate away → the unsaved-changes prompt still appears.

This PR fixes: #37385