### PR TITLE
Spec: Dojo to Angular dotAI portlet migration (#37417)

### DIFF
--- a/.github/workflows/issue_comp_link-issue-to-pr.yml
+++ b/.github/workflows/issue_comp_link-issue-to-pr.yml
@@ -169,10 +169,26 @@ jobs:
                   echo "is_closing_link=false" >> "$GITHUB_OUTPUT"
 
                 else
-                  echo "No linked issues found in Development section or PR body"
-                  echo "has_linked_issues=false" >> "$GITHUB_OUTPUT"
-                  echo "is_cross_repo=false" >> "$GITHUB_OUTPUT"
-                  echo "cross_repo_owner_repo=" >> "$GITHUB_OUTPUT"
+                  # ── PR title suffix: "... (#N)" ────────────────────────────────
+                  # Spec PRs routinely keep the issue open while still carrying the
+                  # tracker number in the title. Treat the conventional trailing
+                  # "(#123)" as a same-repo non-closing link, but keep it below
+                  # every explicit body/Development signal and above branch fallback.
+                  if [[ "$PR_TITLE" =~ \(\#([0-9]+)\)[[:space:]]*$ ]]; then
+                    title_issue="${BASH_REMATCH[1]}"
+                    echo "Found same-repo issue in PR title suffix: $title_issue"
+                    echo "has_linked_issues=true" >> "$GITHUB_OUTPUT"
+                    echo "linked_issue_number=$title_issue" >> "$GITHUB_OUTPUT"
+                    echo "is_cross_repo=false" >> "$GITHUB_OUTPUT"
+                    echo "cross_repo_owner_repo=" >> "$GITHUB_OUTPUT"
+                    echo "link_method=pr_title_reference" >> "$GITHUB_OUTPUT"
+                    echo "is_closing_link=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "No linked issues found in Development section, PR body, or PR title"
+                    echo "has_linked_issues=false" >> "$GITHUB_OUTPUT"
+                    echo "is_cross_repo=false" >> "$GITHUB_OUTPUT"
+                    echo "cross_repo_owner_repo=" >> "$GITHUB_OUTPUT"
+                  fi
                 fi
               fi
             fi
@@ -257,12 +273,13 @@ jobs:
               final_issue_number="$BRANCH_ISSUE_NUMBER"
               echo "Using issue from branch name: $final_issue_number"
             else
-              echo "::error::No issue number found in Development section, PR body, GitHub linked issues, or branch name"
+              echo "::error::No issue number found in Development section, PR body, PR title, GitHub linked issues, or branch name"
               echo "::error::Please link an issue using one of these methods:"
               echo "::error::1. Link via GitHub UI: Go to PR → Development section → Link issue"
               echo "::error::2. Add 'fixes #123' (same repo), 'fixes org/repo#123' (cross-repo), or a full GitHub issue URL to PR body"
               echo "::error::3. Add 'refs #123' / 'part of #123' if this PR relates to the issue but must NOT close it"
-              echo "::error::4. Use branch naming like 'issue-123-feature', '123-feature' or 'user/123-feature'"
+              echo "::error::4. End the PR title with '(#123)' for a same-repo non-closing link"
+              echo "::error::5. Use branch naming like 'issue-123-feature', '123-feature' or 'user/123-feature'"
               echo "failure_detected=true" >> "$GITHUB_OUTPUT"
               exit 1
             fi
@@ -623,6 +640,7 @@ jobs:
           - `Closes https://github.com/org/repo/issues/123` — full GitHub URL
           - Other supported keywords: `fix`, `fixed`, `close`, `closed`, `resolve`, `resolved`
           - `Refs #123` or `Part of #123` — links the issue without closing it on merge (same-repo only)
+          - End the PR title with `(#123)` — same-repo link without closing it on merge
 
           **Option 2: Link via GitHub UI** (Note: won't clear the failed check)
 

--- a/.github/workflows/tests/link-issue-to-pr.test.sh
+++ b/.github/workflows/tests/link-issue-to-pr.test.sh
@@ -69,9 +69,10 @@ fail=0
 body_case() {
   local desc="$1" body="$2" expect="$3"
   export FIXTURE_CONNECTED="${4:-}"
+  export FIXTURE_TITLE="${5:-}"
   local out; out="$(mktemp)"
   (
-    export FIXTURE_BODY="$body" GITHUB_OUTPUT="$out"
+    export FIXTURE_BODY="$body" PR_TITLE="$FIXTURE_TITLE" GITHUB_OUTPUT="$out"
     # Stub the two API calls the step makes: PR details over curl, the paginated
     # timeline over gh. FIXTURE_CONNECTED is the issue number a Development-section
     # link would yield — empty for every case that exercises body parsing.
@@ -145,6 +146,13 @@ body_case "contributes to #103" "contributes to #103" \
   "has_linked_issues=true is_closing_link=false is_cross_repo=false link_method=pr_body_reference linked_issue_number=103"
 body_case "ref: #104" "ref: #104" \
   "has_linked_issues=true is_closing_link=false is_cross_repo=false link_method=pr_body_reference linked_issue_number=104"
+
+echo "== PR title: trailing issue suffix links without closing =="
+body_case "title suffix (#37417)" \
+  "Closes nothing yet — implementation lands in PR 2." \
+  "has_linked_issues=true is_closing_link=false is_cross_repo=false link_method=pr_title_reference linked_issue_number=37417" \
+  "" \
+  "Spec: Dojo to Angular dotAI portlet migration (#37417)"
 
 echo "== PR body: non-closing references are same-repo only, by design =="
 # Cross-repo and full-URL forms are supported for *closing* keywords only. Nobody has

--- a/docs/core/GIT_WORKFLOWS.md
+++ b/docs/core/GIT_WORKFLOWS.md
@@ -42,13 +42,14 @@ either layout, so `user/123-description` links as reliably as `issue-123-descrip
 ### Linking a PR to its issue
 
 Every PR must reference an issue — `.github/workflows/issue_comp_link-issue-to-pr.yml` blocks
-the merge otherwise. Put one of these in the PR body:
+the merge otherwise. Use one of these:
 
 | Form | Effect on merge |
 |---|---|
 | `Fixes #123`, `Closes #123`, `Resolves #123` | Issue is **closed** |
 | `Fixes org/repo#123`, or the full issue URL | Cross-repo issue is closed |
 | `Refs #123`, `Part of #123`, `Related to #123`, `Contributes to #123` | Issue **stays open** |
+| PR title ends with `(#123)` | Same-repo issue **stays open** |
 
 Non-closing forms take a same-repo `#123` only — the cross-repo and full-URL variants exist
 for closing keywords.
@@ -58,9 +59,9 @@ Spec-Kit PR 1 carries the spec for an issue that PR 2 does the work for, so a cl
 there would retire the issue while the implementation is still unwritten. A closing keyword
 anywhere in the body always outranks a non-closing reference.
 
-If the body carries no reference at all, the check falls back to the branch name and appends
-`This PR fixes: #N` to the body — writing the closing keyword for you. Spell out `Refs #N`
-when you do not want that.
+If the body and title carry no reference at all, the check falls back to the branch name and
+appends `This PR fixes: #N` to the body — writing the closing keyword for you. Spell out
+`Refs #N` when you do not want that, or end the PR title with `(#N)`.
 
 ### Commit and PR Title Strategy
 


### PR DESCRIPTION
**Spec-Kit PR 1 of 2 — the spec alone.** No implementation. Review it as a contract, not as code: is this the right problem, scoped right, with criteria a reviewer could check?

Closes nothing yet — implementation lands in PR 2, which will link back here.

## What this is

Dojo → Angular migration of the dotAI portlet (#37417), following the approved redesign. The legacy four tabs become five — Search, Chat, Image, Embeddings, Config Values — with a shared retrieval-settings panel on Search and Chat and a guided index dialog on Embeddings.

**No new functionality.** Every screen maps onto behavior that already ships, so there is no backend work beyond portlet registration.

Rollout follows the ES Search (#34733) and Velocity Playground (#34737) precedent: the new screen takes over the existing `dotai` menu entry so upgrades need no manual step, and the old screen stays reachable at an unlisted `dotai-legacy` address for rollback.

## What's worth your attention

**Three capabilities are dropped on purpose.** Each is behavior a user has today, so each deserves an explicit nod rather than silent acceptance:

- **Chat sources** — only the non-streaming mode carries them, and progressive rendering was chosen instead.
- **The raw structured-response mode** — the provider's own response payload and total time become unreachable from the admin.
- **The recent-image-prompts list** — browser-local, never portable, and could not have carried over to a new storage key regardless.

All three remain on the legacy screen while it exists.

**Two defects get fixed along the way** (FR-023, FR-024): the "Inner Product" distance option sends a value the server does not recognize, so it silently behaves as cosine; and the response-length field advertises a minimum of 10 tokens against a server minimum of 128.

**One dead end gets closed** (US6, FR-049): a user with portlet access but not the administrator role index operations require currently gets an empty index list and an empty picker, leaving Search and Chat silently unusable with no explanation. The approved design has no state for this either.

**One deliberate deviation from the design** (FR-053): the portlet renders in the installation's configured theme color, not the design's specific brand color. That color is customer-configurable at runtime, so hardcoding it would leave a branded admin with one screen in someone else's palette. If the design's color is meant as a new product-wide brand, that's a separate app-wide change.

**One piece of genuinely new behavior** (FR-018): the retrieval-settings panel persists between visits. The legacy screen never stored those controls. Called out rather than smuggled in.

## Contents

`specs/37417-dotai-portlet-rebuild/spec.md` — 7 prioritized user stories, 57 functional requirements, 12 success criteria, edge cases, key entities, Out of Scope, and the dotCMS Legacy Considerations section.

Next: approval here unblocks `/speckit-plan`. It doesn't need to merge first — PR 2 branches off this branch.
