### PR TITLE
fix(workflows): restore Task Detail completion callback for comment/assign actions

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/workflows/workflows_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/workflows/workflows_js_inc.jsp
@@ -197,6 +197,14 @@
 		document.dispatchEvent(customEvent);
 	}
 
+	// Completion callback for the commentable/assignable/push/moveable path opened via
+	// PushHandler.showWorkflowEnabledDialog (see executeWfAction above). Mirrors
+	// fileActionCallback's success branch so both paths signal completion the same way.
+	function angularWorkflowEventCallback () {
+		showDotCMSSystemMessage("<%=LanguageUtil.get(pageContext, "Workflow-executed")%>");
+		executeEditTaskExecutedWorkflowEvent();
+	}
+
 	var contentAdmin = new dotcms.dijit.contentlet.ContentAdmin();
 
 </script>


### PR DESCRIPTION
## Summary

- Workflow actions with `Allow Comments` and/or `User can Assign` fired from the Tasks portlet's **Task Detail** dialog executed successfully server-side (step advanced, comment persisted) but never signaled the Angular shell — the dialog stayed open, no confirmation appeared, and the displayed step stayed stale.
- Root cause: `DotWorkflowEventHandlerService` calls back into the iframe via `angularWorkflowEventCallback` after firing the action, but that function was never defined anywhere under the workflows portlet JSPs — the call was a silent no-op. It's already defined for Content Search (`view_contentlets_js_inc.jsp`) and Site Browser (`view_browser_js_inc.jsp`), which is why those portlets work correctly.
- Fix: define `angularWorkflowEventCallback` in `workflows_js_inc.jsp`, reusing the exact same completion signal (`showDotCMSSystemMessage` + `edit-task-executed-workflow` event) already used by the non-commentable action path in the same file, so both paths behave identically.
- This is the Tasks-portlet equivalent of #34234 / #34343 (Pages portlet), one layer deeper: the Angular-side event fallthrough (`DotCustomEventHandlerService`) in `dot-workflow-task.component.ts` was already correct; only the JSP-side callback was missing.

Fixes #36779

## Test plan

- [x] Manually reproduced and verified fix: Blogs → Save as Draft → Send for Review → Tasks → open task → Approve (comment-enabled action) → dialog closes/refreshes, confirmation message shown, step updates to Published
- [x] Verified non-commentable actions from Task Detail continue to work (separate in-page path, unaffected)
- [x] Verified content editor and Content Search portlets remain unaffected (already-working callback definitions untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36779