### PR TITLE
DO NOT MERGE: #34154: refactor(json) batch with windowFixed instead of a shared accumulator

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtil.java
@@ -36,7 +36,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Gatherers;
 
 /**
  * Utility class to populate the contentlet_as_json column in the contentlet table.
@@ -276,7 +278,6 @@ public class PopulateContentletAsJSONUtil {
                                  final MutableInt totalRecords
     ) throws SQLException, DotDataException {
 
-        final Collection<Params> paramsInsert = new ArrayList<>();
         final MutableInt totalInsertAffected = new MutableInt(0);
 
         var foundData = false;
@@ -324,14 +325,12 @@ public class PopulateContentletAsJSONUtil {
                                 )// Transform the contentlets into a list of json strings
                                 .orElse(Collections.emptyList());
 
-                        for (var jsonData : jsonDataArray) {
-                            // Insert the json representation of the contentlet into the temp table
-                            this.processInsertRecord(jsonData._1(), jsonData._2(), paramsInsert, totalInsertAffected);
-                        }
+                        final List<Params> params = jsonDataArray.stream()
+                                .map(jsonData -> new Params(jsonData._1(), jsonData._2()))
+                                .collect(Collectors.toList());
 
-                        if (!paramsInsert.isEmpty()) {
-                            this.doInsertBatch(paramsInsert, totalInsertAffected);
-                        }
+                        inBatchesOf(params,
+                                batch -> this.doInsertBatch(batch, totalInsertAffected));
 
                     } else {
                         hasRows = false;
@@ -361,7 +360,6 @@ public class PopulateContentletAsJSONUtil {
     @WrapInTransaction
     private void processRecords() throws SQLException, DotDataException {
 
-        final Collection<Params> paramsUpdate = new ArrayList<>();
         final MutableInt totalUpdateAffected = new MutableInt(0);
 
         Logger.info(this, "Updating records with missing Contentlet as JSON of any sub-type");
@@ -392,17 +390,14 @@ public class PopulateContentletAsJSONUtil {
 
                         hasRows = true;
 
-                        loadedResults.forEach(
-                                record -> this.processUpdateRecord(
+                        final List<Params> params = loadedResults.stream()
+                                .map(record -> toUpdateParams(
                                         (String) record.get("inode"),
-                                        (String) record.get("json"),
-                                        paramsUpdate,
-                                        totalUpdateAffected)
-                        );
+                                        (String) record.get("json")))
+                                .collect(Collectors.toList());
 
-                        if (!paramsUpdate.isEmpty()) {
-                            this.doUpdateBatch(paramsUpdate, totalUpdateAffected);
-                        }
+                        inBatchesOf(params,
+                                batch -> this.doUpdateBatch(batch, totalUpdateAffected));
 
                     } else {
                         hasRows = false;
@@ -456,20 +451,6 @@ public class PopulateContentletAsJSONUtil {
      * @param totalInsertAffected A MutableInt object to keep track of the total number of affected
      *                            rows in batch inserts.
      */
-    private void processInsertRecord(
-            final String inode,
-            final String json,
-            final Collection<Params> paramsInsert,
-            final MutableInt totalInsertAffected
-    ) {
-
-        paramsInsert.add(new Params(inode, json));
-
-        // Execute the batch for the inserts if we have reached the max batch size
-        if (paramsInsert.size() >= MAX_BATCH_SIZE) {
-            this.doInsertBatch(paramsInsert, totalInsertAffected);
-        }
-    }
 
     /**
      * Processes a record by preparing the parameters for a batch update.
@@ -482,12 +463,12 @@ public class PopulateContentletAsJSONUtil {
      *                            rows in batch updates.
      * @throws JsonProcessingException If there is an error while processing the JSON.
      */
-    private void processUpdateRecord(
-            final String inode,
-            final String json,
-            final Collection<Params> paramsUpdate,
-            final MutableInt totalUpdateAffected
-    ) {
+    /**
+     * Builds the update parameters for one record. Formerly this appended to a shared accumulator
+     * and flushed it when full; it is now a pure mapping, and the batching lives in
+     * {@link #inBatchesOf(List, Consumer)}.
+     */
+    private static Params toUpdateParams(final String inode, final String json) {
 
         final Object contentletAsJSON;
         if (DbConnectionFactory.isPostgres()) {
@@ -498,12 +479,27 @@ public class PopulateContentletAsJSONUtil {
             contentletAsJSON = json;
         }
 
-        paramsUpdate.add(new Params(contentletAsJSON, inode));
+        return new Params(contentletAsJSON, inode);
+    }
 
-        // Execute the batch for the updates if we have reached the max batch size
-        if (paramsUpdate.size() >= MAX_BATCH_SIZE) {
-            this.doUpdateBatch(paramsUpdate, totalUpdateAffected);
-        }
+    /**
+     * Feeds {@code params} to {@code executor} in batches of {@link #MAX_BATCH_SIZE}, the final
+     * partial batch included.
+     *
+     * <p>This replaces a mutable accumulator that was passed down into the per-record method: that
+     * method appended to it and flushed when it filled, and the caller had to remember a second
+     * flush afterwards for whatever was left. The cut and the leftover were two pieces of code in
+     * two places, and keeping them in step was a convention. {@code windowFixed} emits the short
+     * final window on its own, so they become one expression.</p>
+     *
+     * <p>Each window is an unmodifiable list, which is why the batch executors no longer clear
+     * their argument — they never owned the buffer, they only appeared to.</p>
+     */
+    static void inBatchesOf(final List<Params> params, final Consumer<List<Params>> executor) {
+
+        params.stream()
+                .gather(Gatherers.windowFixed(MAX_BATCH_SIZE))
+                .forEach(executor);
     }
 
     /**
@@ -543,7 +539,7 @@ public class PopulateContentletAsJSONUtil {
     /**
      * Executes the batch of updates to fill the contentlet_as_json column.
      */
-    private void doUpdateBatch(final Collection<Params> paramsUpdate, final MutableInt totalUpdateAffected) {
+    private void doUpdateBatch(final List<Params> paramsUpdate, final MutableInt totalUpdateAffected) {
 
         try {
             final List<Integer> batchResult =
@@ -556,15 +552,13 @@ public class PopulateContentletAsJSONUtil {
         } catch (DotDataException e) {
             Logger.error(this, "Couldn't update these rows: " + paramsUpdate);
             Logger.error(this, e.getMessage(), e);
-        } finally {
-            paramsUpdate.clear();
         }
     }
 
     /**
      * Executes the batch of inserts to populate the temporal tmp_contentlet_json table.
      */
-    private void doInsertBatch(final Collection<Params> paramsInsert, final MutableInt totalInsertAffected) {
+    private void doInsertBatch(final List<Params> paramsInsert, final MutableInt totalInsertAffected) {
 
         try {
             final List<Integer> batchResult =
@@ -577,8 +571,6 @@ public class PopulateContentletAsJSONUtil {
         } catch (DotDataException e) {
             Logger.error(this, "Couldn't insert these rows: " + paramsInsert);
             Logger.error(this, e.getMessage(), e);
-        } finally {
-            paramsInsert.clear();
         }
     }
 

--- a/dotCMS/src/test/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtilBatchingTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/content/json/PopulateContentletAsJSONUtilBatchingTest.java
@@ -1,0 +1,125 @@
+package com.dotcms.util.content.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.dotmarketing.common.db.Params;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+/**
+ * Covers the batching contract of
+ * {@link PopulateContentletAsJSONUtil#inBatchesOf(List, java.util.function.Consumer)}.
+ *
+ * <p>The behaviour under test used to be spread over two places — a per-record method that appended
+ * to a shared accumulator and flushed it when full, and a caller that had to remember a second flush
+ * for the remainder. These tests pin the part that mattered and was easiest to get wrong: the short
+ * final batch.</p>
+ */
+public class PopulateContentletAsJSONUtilBatchingTest {
+
+    /** Whatever the configured batch size is, these tests derive their expectations from it. */
+    private static final int BATCH = 200;
+
+    private static List<Params> params(final int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> new Params("inode-" + i, "{\"n\":" + i + "}"))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    private static List<List<Params>> collectBatches(final int count) {
+        final List<List<Params>> batches = new ArrayList<>();
+        PopulateContentletAsJSONUtil.inBatchesOf(params(count), batches::add);
+        return batches;
+    }
+
+    /**
+     * Method to test: {@link PopulateContentletAsJSONUtil#inBatchesOf(List, java.util.function.Consumer)}
+     * Given scenario: a record count that is not a multiple of the batch size.
+     * Expected result: full batches, and a final short batch holding the remainder.
+     */
+    @Test
+    public void test_inBatchesOf_partialFinalBatch_isEmitted() {
+
+        final List<List<Params>> batches = collectBatches((BATCH * 2) + 50);
+
+        assertEquals("two full batches plus the remainder", 3, batches.size());
+        assertEquals(BATCH, batches.get(0).size());
+        assertEquals(BATCH, batches.get(1).size());
+        assertEquals("the short tail is emitted, not dropped", 50, batches.get(2).size());
+    }
+
+    /**
+     * Method to test: {@link PopulateContentletAsJSONUtil#inBatchesOf(List, java.util.function.Consumer)}
+     * Given scenario: a record count that is an exact multiple of the batch size.
+     * Expected result: only full batches, and no trailing empty one.
+     */
+    @Test
+    public void test_inBatchesOf_exactMultiple_emitsNoEmptyTail() {
+
+        final List<List<Params>> batches = collectBatches(BATCH * 2);
+
+        assertEquals(2, batches.size());
+        batches.forEach(batch -> assertEquals(BATCH, batch.size()));
+    }
+
+    /**
+     * Method to test: {@link PopulateContentletAsJSONUtil#inBatchesOf(List, java.util.function.Consumer)}
+     * Given scenario: fewer records than one batch.
+     * Expected result: a single short batch. The old shape reached this only through the caller's
+     * separate leftover flush, which is the line that was easy to forget.
+     */
+    @Test
+    public void test_inBatchesOf_fewerThanOneBatch_stillEmits() {
+
+        final List<List<Params>> batches = collectBatches(7);
+
+        assertEquals(1, batches.size());
+        assertEquals(7, batches.get(0).size());
+    }
+
+    /**
+     * Method to test: {@link PopulateContentletAsJSONUtil#inBatchesOf(List, java.util.function.Consumer)}
+     * Given scenario: no records at all.
+     * Expected result: the executor is never invoked — no empty batch reaches the database.
+     */
+    @Test
+    public void test_inBatchesOf_empty_neverCallsTheExecutor() {
+
+        assertTrue(collectBatches(0).isEmpty());
+    }
+
+    /**
+     * Method to test: {@link PopulateContentletAsJSONUtil#inBatchesOf(List, java.util.function.Consumer)}
+     * Given scenario: every record is delivered exactly once, in order.
+     * Expected result: flattening the batches reproduces the input.
+     */
+    @Test
+    public void test_inBatchesOf_deliversEveryRecordOnce_inOrder() {
+
+        final int count = (BATCH * 3) + 1;
+        final List<Params> flattened = collectBatches(count).stream()
+                .flatMap(List::stream)
+                .collect(java.util.stream.Collectors.toList());
+
+        assertEquals(count, flattened.size());
+        assertEquals(params(count).toString(), flattened.toString());
+    }
+
+    /**
+     * Method to test: {@link PopulateContentletAsJSONUtil#inBatchesOf(List, java.util.function.Consumer)}
+     * Given scenario: a consumer that tries to mutate the batch it was handed.
+     * Expected result: it fails. This is why the batch executors no longer clear their argument —
+     * a window is unmodifiable, and the old {@code finally { params.clear(); }} would now throw.
+     */
+    @Test
+    public void test_inBatchesOf_windowIsUnmodifiable() {
+
+        final List<List<Params>> batches = collectBatches(10);
+
+        assertThrows(UnsupportedOperationException.class, () -> batches.get(0).clear());
+    }
+}


### PR DESCRIPTION
## Why this exists

A proof of concept for the Lunch & Learn (#34154): what a stream gatherer actually buys on real
dotCMS code, rather than on a toy example. **DO NOT MERGE** — the change is small and green, but it
touches an upgrade task and belongs behind its own review if we ever want it.

## The shape it replaces

`PopulateContentletAsJSONUtil` batched its inserts and updates through a mutable
`Collection<Params>` that was declared in the outer method and passed *down* into the per-record
method. That method appended to it and flushed when it filled; the caller then had to remember a
second flush for the remainder:

```java
private void processInsertRecord(String inode, String json,
        Collection<Params> paramsInsert, MutableInt totalInsertAffected) {

    paramsInsert.add(new Params(inode, json));

    if (paramsInsert.size() >= MAX_BATCH_SIZE) {     // the cut
        this.doInsertBatch(paramsInsert, totalInsertAffected);
    }
}
```

```java
for (var jsonData : jsonDataArray) {
    this.processInsertRecord(jsonData._1(), jsonData._2(), paramsInsert, totalInsertAffected);
}
if (!paramsInsert.isEmpty()) {                       // the leftover, 130 lines away
    this.doInsertBatch(paramsInsert, totalInsertAffected);
}
```

Four places, and duplicated again for updates: the buffer, the cut, the leftover, and the
`clear()` hidden in the executor's `finally`. Keeping them in step was a convention.

## What it becomes

```java
static void inBatchesOf(final List<Params> params, final Consumer<List<Params>> executor) {

    params.stream()
            .gather(Gatherers.windowFixed(MAX_BATCH_SIZE))
            .forEach(executor);
}
```

`windowFixed` emits the short final window on its own, so **the cut and the leftover are the same
thing**. The accumulator is gone, `processInsertRecord` is gone, and `processUpdateRecord` becomes
the pure mapper `toUpdateParams`.

**Net −8 lines** (+41/−49).

## The part worth noticing

`doInsertBatch` and `doUpdateBatch` used to end in `finally { params.clear(); }` — because the
caller reused one buffer. A window is **unmodifiable**, so that line would now throw. It had to go,
and its removal is the honest summary of the change: those methods never owned the buffer, they
only appeared to. One test pins that:

```java
assertThrows(UnsupportedOperationException.class, () -> batches.get(0).clear());
```

## Tests

Six unit tests, no database, `PopulateContentletAsJSONUtilBatchingTest` — pinning the behaviour the
old code got right by convention:

| | |
|---|---|
| partial final batch is emitted | 450 records → 200 / 200 / 50 |
| exact multiple emits no empty tail | 400 → 200 / 200 |
| fewer than one batch still emits | 7 → one batch of 7 |
| empty input never calls the executor | 0 → no batches |
| every record delivered once, in order | 601 records, flattened, compared |
| the window rejects mutation | `UnsupportedOperationException` |

**6/6 green**; `test-compile -pl :dotcms-core --am` passes.

## Not in scope

- The other 12 `Lists.partition` sites. `OSIndexAPIImpl:855` materialises a list purely to cut it
  up and is the next obvious one, but it has no leftover to forget, so it makes a weaker point.
- `ContentTypeDestroyAPIImpl:380` calls `Lists.partition(..., 1)` — partitioning into batches of
  one. That does not want a gatherer, it wants the line deleted.
- No behaviour change intended: same batch size, same SQL, same order.

Refs #34154
