### PR TITLE
fix(network): handle IPv6 addresses in IPUtils checks

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/util/network/IPUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/network/IPUtils.java
@@ -2,6 +2,7 @@ package com.dotcms.util.network;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import com.dotcms.repackage.org.apache.commons.net.util.SubnetUtils;
@@ -94,11 +95,34 @@ public class IPUtils {
         }
     }
 
+    private static final String REMOTE_CALL_SUBNET_BLACKLIST = "REMOTE_CALL_SUBNET_BLACKLIST";
+
     private static final String[] REMOTE_CALL_SUBNET_BLACKLIST_DEFAULT = {"127.0.0.1/32","10.0.0.0/8","172.16.0.0/12", "192.168.0.0/16", "169.254.169.254/32"};
 
-    static final Lazy<String[]> disallowedSubnets = Lazy.of(() ->
-                    Try.of(() -> Config.getStringArrayProperty("REMOTE_CALL_SUBNET_BLACKLIST", REMOTE_CALL_SUBNET_BLACKLIST_DEFAULT))
-                    .getOrElse(REMOTE_CALL_SUBNET_BLACKLIST_DEFAULT));
+    /**
+     * The subnets from {@code REMOTE_CALL_SUBNET_BLACKLIST}, or {@code null} when the property is
+     * not set. The distinction matters: an explicitly configured list is treated as the whole
+     * policy, so a deployment can keep permitting specific internal ranges by narrowing it.
+     */
+    static final Lazy<String[]> configuredSubnets = Lazy.of(() -> {
+
+        final String[] configured =
+                Try.of(() -> Config.getStringArrayProperty(REMOTE_CALL_SUBNET_BLACKLIST, null))
+                        .getOrNull();
+
+        if (isSet(configured) && Arrays.stream(configured).noneMatch(subnet -> subnet.indexOf(':') >= 0)) {
+            Logger.warn(IPUtils.class, REMOTE_CALL_SUBNET_BLACKLIST + " is set and lists IPv4 ranges only. "
+                    + "An explicit list replaces the built-in address checks, so IPv6 ranges are not "
+                    + "covered unless listed. Add the IPv6 ranges in use, for example ::1/128, "
+                    + "fc00::/7 and fe80::/10.");
+        }
+
+        return configured;
+    });
+
+    private static boolean isSet(final String[] subnets) {
+        return subnets != null && subnets.length > 0;
+    }
 
     /**
      * It is important when we allow calling to remote endpoints that we verify that the remote
@@ -108,6 +132,10 @@ public class IPUtils {
      * <p>Every address the host resolves to is checked, across both address families, including
      * hosts that resolve to IPv6 addresses only. A host that resolves to any internal address is
      * treated as private.</p>
+     *
+     * <p>When {@code REMOTE_CALL_SUBNET_BLACKLIST} is set it defines the policy on its own and the
+     * built-in address checks are not applied, so a deployment can permit specific internal ranges
+     * by narrowing the list. When it is not set, the built-in checks apply.</p>
      *
      * <p>Resolution failures fail closed and return {@code true}.</p>
      *
@@ -139,7 +167,7 @@ public class IPUtils {
             }
 
             for (final InetAddress address : resolvedAddresses) {
-                if (isInternalAddress(address)) {
+                if (isInternalAddress(address, configuredSubnets.get())) {
                     return true;
                 }
             }
@@ -151,10 +179,30 @@ public class IPUtils {
     }
 
     /**
-     * Whether a single resolved address belongs to a range that must never be reachable from a
+     * Whether a single resolved address belongs to a range that must not be reachable from a
      * user-supplied URL.
+     *
+     * @param address    the resolved address to classify
+     * @param configured the explicitly configured subnets, or {@code null} when the property is
+     *                   unset. When present it is the whole policy and replaces the built-in
+     *                   checks, which is what keeps a narrowed list able to permit internal ranges.
      */
-    private static boolean isInternalAddress(final InetAddress address) {
+    static boolean isInternalAddress(final InetAddress address, final String[] configured) {
+
+        final String hostAddress = stripScopeId(address.getHostAddress());
+
+        if (isSet(configured)) {
+            return matchesAny(hostAddress, configured);
+        }
+
+        return isInternalByCategory(address) || matchesAny(hostAddress, REMOTE_CALL_SUBNET_BLACKLIST_DEFAULT);
+    }
+
+    /**
+     * Built-in classification of the ranges that are internal by definition rather than by
+     * configuration. Applied only when {@code REMOTE_CALL_SUBNET_BLACKLIST} is not set.
+     */
+    private static boolean isInternalByCategory(final InetAddress address) {
 
         if (address.isAnyLocalAddress()      // 0.0.0.0 and ::
                 || address.isLoopbackAddress()   // 127.0.0.0/8 and ::1
@@ -167,19 +215,18 @@ public class IPUtils {
         // Unique-local addresses, fc00::/7. These are the IPv6 counterpart of the RFC1918 ranges
         // and the JDK exposes no predicate for them, so they are matched here. This range also
         // covers IPv6 instance-metadata addresses.
-        if (address instanceof Inet6Address && (address.getAddress()[0] & 0xFE) == 0xFC) {
-            return true;
-        }
+        return address instanceof Inet6Address && (address.getAddress()[0] & 0xFE) == 0xFC;
+    }
 
-        // Site-specific ranges from REMOTE_CALL_SUBNET_BLACKLIST apply on top of the categories
-        // above, and may be expressed as either IPv4 or IPv6 CIDRs.
-        final String hostAddress = stripScopeId(address.getHostAddress());
-        for (final String subnet : disallowedSubnets.get()) {
+    /**
+     * Whether the address falls in any of the given CIDR ranges. Accepts IPv4 and IPv6 CIDRs.
+     */
+    private static boolean matchesAny(final String hostAddress, final String[] subnets) {
+        for (final String subnet : subnets) {
             if (isIpInCIDR(hostAddress, subnet)) {
                 return true;
             }
         }
-
         return false;
     }
 

--- a/dotCMS/src/main/java/com/dotcms/util/network/IPUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/util/network/IPUtils.java
@@ -1,40 +1,38 @@
 package com.dotcms.util.network;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.xbill.DNS.Address;
 import com.dotcms.repackage.org.apache.commons.net.util.SubnetUtils;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
+import org.xbill.DNS.Address;
 
 public class IPUtils {
     private static final AtomicBoolean disabledIpPrivateSubnet = new AtomicBoolean(false);
-    
+
     private IPUtils() {
         throw new IllegalStateException("static Utility class");
     }
-    
-    
-    
+
     /**
-     * Determines whether an IP address is in a specific CIDR.  IPv4 & IPv6 supported
+     * Determines whether an IP address is in a specific CIDR. IPv4 and IPv6 are both supported.
      *
-     * @param ip
-     *            - The IP address to validate.
-     * @param CIDR
-     *            - The CIDR-notation CIDR - i.e. ({@code "192.168.1.2/24"}
-     * @return If the IP address matches the given CIDR, returns {@code true}
-     *         . Otherwise, returns {@code false}.
+     * @param ip   The IP address to validate.
+     * @param CIDR The CIDR-notation range, e.g. {@code "192.168.1.2/24"} or {@code "fc00::/7"}.
+     * @return If the IP address matches the given CIDR, returns {@code true}. Otherwise,
+     *         returns {@code false}. Cross-family comparisons never match.
      */
     public static boolean isIpInCIDR(final String ip, final String CIDR) {
 
-        if (UtilMethods.isEmpty(ip) ||  UtilMethods.isEmpty(CIDR)) {
+        if (UtilMethods.isEmpty(ip) || UtilMethods.isEmpty(CIDR)) {
             return false;
         }
-        
+
         if (Objects.equals(ip, CIDR)) {
             return true;
         }
@@ -43,63 +41,105 @@ public class IPUtils {
             return true;
         }
 
-        try{
+        // SubnetUtils only understands IPv4, so IPv6 ranges are evaluated separately.
+        if (CIDR.indexOf(':') >= 0) {
+            return isIpInCidrIpV6(ip, CIDR);
+        }
+
+        try {
             final SubnetUtils utils = new SubnetUtils(CIDR);
             utils.setInclusiveHostCount(true);
             return utils.getInfo().isInRange(ip);
-        }catch(Exception e){
-            Logger.warnAndDebug(IPUtils.class,"subnet:" + CIDR  + ", ip:" + ip + ", error:" + e.getMessage(), e);
+        } catch (Exception e) {
+            Logger.warnAndDebug(IPUtils.class, "subnet:" + CIDR + ", ip:" + ip + ", error:" + e.getMessage(), e);
         }
         return false;
-
-
-
-
-
-
-
-
-
-
-
-
     }
-    
+
+    /**
+     * Prefix match for IPv6, comparing the first {@code prefixLength} bits of both addresses.
+     * Parsing is literal-only (no name resolution), so this never triggers a DNS lookup.
+     */
+    private static boolean isIpInCidrIpV6(final String ip, final String cidr) {
+        final int slash = cidr.indexOf('/');
+        if (slash < 0) {
+            return false;
+        }
+        try {
+            final byte[] address = Address.toByteArray(ip, Address.IPv6);
+            final byte[] network = Address.toByteArray(cidr.substring(0, slash), Address.IPv6);
+            if (address == null || network == null) {
+                // one side is not a valid IPv6 literal, so this is a cross-family comparison
+                return false;
+            }
+            final int prefixLength = Integer.parseInt(cidr.substring(slash + 1).trim());
+            if (prefixLength < 0 || prefixLength > 128) {
+                return false;
+            }
+            final int wholeBytes = prefixLength / 8;
+            for (int i = 0; i < wholeBytes; i++) {
+                if (address[i] != network[i]) {
+                    return false;
+                }
+            }
+            final int remainingBits = prefixLength % 8;
+            if (remainingBits == 0) {
+                return true;
+            }
+            final int mask = (0xFF << (8 - remainingBits)) & 0xFF;
+            return (address[wholeBytes] & mask) == (network[wholeBytes] & mask);
+        } catch (Exception e) {
+            Logger.warnAndDebug(IPUtils.class, "subnet:" + cidr + ", ip:" + ip + ", error:" + e.getMessage(), e);
+            return false;
+        }
+    }
+
     private static final String[] REMOTE_CALL_SUBNET_BLACKLIST_DEFAULT = {"127.0.0.1/32","10.0.0.0/8","172.16.0.0/12", "192.168.0.0/16", "169.254.169.254/32"};
-    
-    
-    static final Lazy<String[]> disallowedSubnets = Lazy.of(() -> 
+
+    static final Lazy<String[]> disallowedSubnets = Lazy.of(() ->
                     Try.of(() -> Config.getStringArrayProperty("REMOTE_CALL_SUBNET_BLACKLIST", REMOTE_CALL_SUBNET_BLACKLIST_DEFAULT))
                     .getOrElse(REMOTE_CALL_SUBNET_BLACKLIST_DEFAULT));
 
-    
-    
     /**
-     * It is important when we allow calling to remote endpoints that we verify
-     * that the remote endpoint is not in our corprate or private network.
-     * This method checks if the ip or hostname passed in is on the private network
-     * which can be blocked if needed.
-     * @param ipOrHostName
-     * @return
+     * It is important when we allow calling to remote endpoints that we verify that the remote
+     * endpoint is not in our corporate or private network. This method checks if the ip or hostname
+     * passed in is on the private network, which can be blocked if needed.
+     *
+     * <p>Every address the host resolves to is checked, across both address families, including
+     * hosts that resolve to IPv6 addresses only. A host that resolves to any internal address is
+     * treated as private.</p>
+     *
+     * <p>Resolution failures fail closed and return {@code true}.</p>
+     *
+     * <p>This is evaluated at validation time against the addresses the host resolves to at that
+     * moment. Callers that need the guarantee to hold for the connection itself should pin the
+     * validated address rather than resolving the host a second time.</p>
+     *
+     * @param ipOrHostName the IP literal or hostname to check
+     * @return {@code true} when the host is internal, unresolvable, or empty
      */
     public static boolean isIpPrivateSubnet(final String ipOrHostName) {
 
-        
         if (disabledIpPrivateSubnet.get()) {
             return false;
         }
 
-        if (ipOrHostName == null) {
+        if (!UtilMethods.isSet(ipOrHostName)) {
             return true;
         }
 
         try {
+            // getAllByName resolves both A and AAAA records, accepts bracketed IPv6 literals as
+            // URL.getHost() reports them, and normalises IPv4-mapped forms to Inet4Address. It is
+            // also the resolver the outbound HTTP client uses, so validation and connection agree.
+            final InetAddress[] resolvedAddresses = InetAddress.getAllByName(ipOrHostName.trim());
 
-            final String ip = "localhost".equals(ipOrHostName) ? "127.0.0.1" : Address.getByName(ipOrHostName).getHostAddress();
+            if (resolvedAddresses == null || resolvedAddresses.length == 0) {
+                return true;
+            }
 
-
-            for (String subnet : disallowedSubnets.get()) {
-                if (isIpInCIDR(ip, subnet)) {
+            for (final InetAddress address : resolvedAddresses) {
+                if (isInternalAddress(address)) {
                     return true;
                 }
             }
@@ -108,12 +148,49 @@ public class IPUtils {
             return true;
         }
         return false;
-
-
-
     }
 
+    /**
+     * Whether a single resolved address belongs to a range that must never be reachable from a
+     * user-supplied URL.
+     */
+    private static boolean isInternalAddress(final InetAddress address) {
 
+        if (address.isAnyLocalAddress()      // 0.0.0.0 and ::
+                || address.isLoopbackAddress()   // 127.0.0.0/8 and ::1
+                || address.isLinkLocalAddress()  // 169.254.0.0/16 (incl. metadata) and fe80::/10
+                || address.isSiteLocalAddress()  // 10/8, 172.16/12, 192.168/16 and fec0::/10
+                || address.isMulticastAddress()) {
+            return true;
+        }
+
+        // Unique-local addresses, fc00::/7. These are the IPv6 counterpart of the RFC1918 ranges
+        // and the JDK exposes no predicate for them, so they are matched here. This range also
+        // covers IPv6 instance-metadata addresses.
+        if (address instanceof Inet6Address && (address.getAddress()[0] & 0xFE) == 0xFC) {
+            return true;
+        }
+
+        // Site-specific ranges from REMOTE_CALL_SUBNET_BLACKLIST apply on top of the categories
+        // above, and may be expressed as either IPv4 or IPv6 CIDRs.
+        final String hostAddress = stripScopeId(address.getHostAddress());
+        for (final String subnet : disallowedSubnets.get()) {
+            if (isIpInCIDR(hostAddress, subnet)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes the interface suffix that {@link Inet6Address#getHostAddress()} appends for scoped
+     * addresses, e.g. {@code fe80::1%lo0}, so the value can be parsed as a plain literal.
+     */
+    private static String stripScopeId(final String hostAddress) {
+        final int scopeSeparator = hostAddress.indexOf('%');
+        return scopeSeparator < 0 ? hostAddress : hostAddress.substring(0, scopeSeparator);
+    }
 
     public static void disabledIpPrivateSubnet(final boolean disabledIpPrivateSubnet) {
         IPUtils.disabledIpPrivateSubnet.set(disabledIpPrivateSubnet);

--- a/dotCMS/src/test/java/com/dotcms/util/network/IPUtilsTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/network/IPUtilsTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.util.network;
 
 import static org.junit.Assert.*;
+import java.net.InetAddress;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -118,6 +119,39 @@ public class IPUtilsTest {
             assertTrue( "Must be a private subnets: " + testCase, IPUtils.isIpPrivateSubnet(testCase));
         }
     }
+    /**
+     * An explicitly configured REMOTE_CALL_SUBNET_BLACKLIST defines the policy on its own. A
+     * deployment that narrows the list to permit specific internal ranges must keep working, so
+     * the built-in address checks must not be applied on top of a configured list.
+     */
+    @Test
+    public void test_configured_blacklist_is_not_overridden_by_builtin_checks() throws Exception {
+        final String[] onlyMetadata = {"169.254.169.254/32"};
+
+        assertTrue("the configured range must still match",
+                IPUtils.isInternalAddress(InetAddress.getByName("169.254.169.254"), onlyMetadata));
+
+        for (final String permitted : new String[]{"10.0.0.1", "192.168.1.1", "172.16.3.5", "127.0.0.1"}) {
+            assertFalse(permitted + " is outside the configured list, so it must stay permitted",
+                    IPUtils.isInternalAddress(InetAddress.getByName(permitted), onlyMetadata));
+        }
+    }
+
+    /**
+     * With no configured list, the built-in checks apply and cover both address families.
+     */
+    @Test
+    public void test_builtin_checks_apply_when_no_blacklist_configured() throws Exception {
+        for (final String internal : new String[]{"10.0.0.1", "127.0.0.1", "169.254.169.254", "::1", "fc00::1"}) {
+            assertTrue(internal + " must be internal when no list is configured",
+                    IPUtils.isInternalAddress(InetAddress.getByName(internal), null));
+        }
+        for (final String publicAddress : new String[]{"2.2.2.2", "2606:4700:4700::1111"}) {
+            assertFalse(publicAddress + " must stay public",
+                    IPUtils.isInternalAddress(InetAddress.getByName(publicAddress), null));
+        }
+    }
+
     @Test
     public void test_ipv6_private_subnets() {
         for (final String testCase : ipv6AddressesOnPrivateSubnets) {

--- a/dotCMS/src/test/java/com/dotcms/util/network/IPUtilsTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/network/IPUtilsTest.java
@@ -17,6 +17,12 @@ public class IPUtilsTest {
             {"192.168.1.0/24", "192.168.1.255"},
             {"192.168.0.0/16", "192.168.1.255"},
             {"192.0.0.0/8", "192.168.1.255"},
+            // IPv6 CIDRs
+            {"fc00::/7", "fc00::1"},
+            {"fc00::/7", "fd00:ec2::254"},
+            {"::1/128", "::1"},
+            {"2001:db8::/32", "2001:db8:0:0:0:0:0:1"},
+            {"fe80::/10", "fe80::1"},
 
     };
 
@@ -30,6 +36,11 @@ public class IPUtilsTest {
             {"192.169.1.0/24", "192.168.1.255"},
             {"192.169.0.0/16", "192.168.1.255"},
             {"192.0.0.0/8", "193.168.1.255"},
+            {"2001:db8::/32", "2001:db9:0:0:0:0:0:1"},
+            {"fc00::/7", "2001:4860:4860:0:0:0:0:8888"},
+            // cross-family comparisons must not match
+            {"10.0.0.0/8", "fc00::1"},
+            {"fc00::/7", "10.0.0.1"},
 
     };
 
@@ -68,6 +79,29 @@ public class IPUtilsTest {
             "127.0.0.1"
     };
     
+    /**
+     * Addresses that must be classified as internal. Covers the IPv6 ranges that carry no
+     * equivalent in the IPv4-only default blacklist, so the classification cannot regress to
+     * depending on that list alone.
+     */
+    final static String[] ipv6AddressesOnPrivateSubnets = {
+            "::1",                      // IPv6 loopback
+            "[::1]",                    // as URL.getHost() hands it over, brackets included
+            "0:0:0:0:0:0:0:1",          // expanded loopback
+            "fc00::1",                  // unique-local, not covered by the JDK helpers
+            "fd00::1",                  // unique-local, upper half of fc00::/7
+            "fd00:ec2::254",            // IPv6 instance metadata
+            "fe80::1",                  // link-local
+            "::ffff:127.0.0.1",         // IPv4-mapped loopback
+            "::ffff:10.0.0.1",          // IPv4-mapped private
+            "::",                       // unspecified
+    };
+
+    final static String[] ipv6AddressesOnPublicSubnets = {
+            "2001:4860:4860::8888",
+            "2606:4700:4700::1111",
+    };
+
     final static String[] ipsOnPublicSubnets= {
             "2.2.2.2",
             "3.22.136.122",
@@ -84,6 +118,22 @@ public class IPUtilsTest {
             assertTrue( "Must be a private subnets: " + testCase, IPUtils.isIpPrivateSubnet(testCase));
         }
     }
+    @Test
+    public void test_ipv6_private_subnets() {
+        for (final String testCase : ipv6AddressesOnPrivateSubnets) {
+            assertTrue("Must be treated as a private subnet: " + testCase,
+                    IPUtils.isIpPrivateSubnet(testCase));
+        }
+    }
+
+    @Test
+    public void test_ipv6_public_subnets() {
+        for (final String testCase : ipv6AddressesOnPublicSubnets) {
+            assertFalse("Must NOT be treated as a private subnet: " + testCase,
+                    IPUtils.isIpPrivateSubnet(testCase));
+        }
+    }
+
     @Test
     
     public void test_ip_public_subnets() {


### PR DESCRIPTION
### What

Adds IPv6 handling to the address classification and CIDR matching in `IPUtils`.

`IPUtils` evaluated addresses with an IPv4-only matcher against an IPv4-only default
list, so IPv6 addresses were not classified correctly. This makes the classification
family-aware and lets `REMOTE_CALL_SUBNET_BLACKLIST` accept IPv6 CIDRs.

### Changes

- `isIpPrivateSubnet` resolves with `InetAddress.getAllByName` and evaluates every
  resolved address in both families, rather than only the first. That is also the
  resolver used for outbound connections, so classification and connection agree.
- Classification uses the JDK predicates for unspecified, loopback, link-local,
  site-local and multicast, plus an explicit `fc00::/7` match, which the JDK does
  not expose.
- `isIpInCIDR` gains IPv6 prefix matching. Parsing is literal-only, so it triggers
  no DNS lookups. The IPv4 path and both short circuits are unchanged, and
  cross-family comparisons do not match.

### Configuration compatibility

`REMOTE_CALL_SUBNET_BLACKLIST` keeps its existing meaning. When the property is set it
defines the policy on its own and the built-in checks are skipped, so a deployment that
narrows the list to permit specific internal ranges continues to work unchanged. The
built-in checks apply only when the property is unset.

A deployment that sets an IPv4-only list therefore gets no IPv6 coverage. That is the
cost of honouring the override and is unchanged from current behaviour, and it now logs
a warning naming the ranges to add.

### Reviewer note

`MonitorHelper.isAccessGranted` uses `isIpInCIDR` as an allowlist. An IPv6 CIDR in
its ACL previously failed to parse and therefore never matched; it now matches as
configured, which is the documented intent of the property.

### Testing

`IPUtilsTest` covers IPv6 loopback, unique-local, link-local, IPv4-mapped and
unspecified addresses, IPv6 CIDR matching, and cross-family non-matching. Verified
failing before the change and passing after. `MonitorHelperTest` run alongside for
regression. Also exercised against a running instance to confirm public
destinations, including public IPv6, remain reachable.

Closes dotCMS/private-issues#677
