### PR TITLE
fix(sdk): pin examples/nextjs to 1.2.0 instead of floating latest

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,11 +9,11 @@
         "lint": "next lint"
     },
     "dependencies": {
-        "@dotcms/client": "26.9.3-1",
-        "@dotcms/experiments": "26.9.3-1",
-        "@dotcms/react": "26.9.3-1",
-        "@dotcms/types": "26.9.3-1",
-        "@dotcms/uve": "26.9.3-1",
+        "@dotcms/client": "1.2.0",
+        "@dotcms/experiments": "1.2.0",
+        "@dotcms/react": "1.2.0",
+        "@dotcms/types": "1.2.0",
+        "@dotcms/uve": "1.2.0",
         "@tinymce/tinymce-react": "6.2.1",
         "next": "15.3.2",
         "react": "19.1.0",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,11 +9,11 @@
         "lint": "next lint"
     },
     "dependencies": {
-        "@dotcms/client": "latest",
-        "@dotcms/experiments": "latest",
-        "@dotcms/react": "latest",
-        "@dotcms/types": "latest",
-        "@dotcms/uve": "latest",
+        "@dotcms/client": "26.9.3-1",
+        "@dotcms/experiments": "26.9.3-1",
+        "@dotcms/react": "26.9.3-1",
+        "@dotcms/types": "26.9.3-1",
+        "@dotcms/uve": "26.9.3-1",
         "@tinymce/tinymce-react": "6.2.1",
         "next": "15.3.2",
         "react": "19.1.0",


### PR DESCRIPTION
## Summary
- Part of the fix for #36891 (SDK packaging: malformed version strings and floating/orphaned dist-tags in SDK sources and example apps)
- LTS-branch half of Defect B3: `examples/nextjs`'s `@dotcms/*` dependencies pinned `"latest"`, which drifts ahead of this LTS server over time and can produce GraphQL `FieldUndefined` errors — the exact root cause of the live customer ticket (Freshdesk #38677).
- Pinned to **`1.2.0`**, confirmed schema-compatible with this LTS branch via **static source analysis** (not a live-server test — see Test plan for why).

## Test plan

⚠️ **This PR originally pinned `26.9.3-1`, verified against a Docker container that turned out to be running `dotcms/dotcms:trunk`, not a real 25.07.10 LTS server — an invalid test (trunk already has every GraphQL field the SDK query needs, so nothing failed). That commit has been superseded by the one now on this branch.**

The corrected verification, done statically instead of against a live server:
- [x] Confirmed `release-25.07.10_lts_v12`'s GraphQL schema (`PageAPIGraphQLTypesProvider.java` and related files) does **not** define `lockedBy`, `lockedByName`, `numberContents`, `styleEditorSchemas`, or a layout `metadata` field
- [x] Confirmed (via `git log -S` on `core-web/libs/sdk/client/src/lib/client/page/utils.ts`) that `@dotcms/client`'s `DotCMSPage` query has requested all five unconditionally since 2025-11-26 through 2026-05-07 (PRs #33905, #34966, #34173, #35528) — so any version published after that range, including the previously-pinned `26.9.3-1`, requests fields this schema doesn't have
- [x] Confirmed `@dotcms/client@1.2.0` published 2025-10-24 (via npm registry metadata), over a month before the first of those additions, with no other stable version published in between (only `1.2.0-next.*` prereleases) — so `1.2.0`'s query requests none of the five fields, making it schema-compatible with this branch by construction
- [x] Confirmed `1.2.0` is published for all five `@dotcms/*` packages this example depends on (`client`, `experiments`, `react`, `types`, `uve`), and that a clean `npm install` resolves to exactly one deduped copy of each
- [x] Confirmed the new SDK package.json shape validator (`.github/scripts/validate-sdk-package-shapes`, added in the companion PR against `main`) passes against this pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36891