### PR TITLE
fix(sdk): pin examples/nextjs to 1.2.0 instead of floating latest

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,11 +9,11 @@
         "lint": "next lint"
     },
     "dependencies": {
-        "@dotcms/client": "latest",
-        "@dotcms/experiments": "latest",
-        "@dotcms/react": "latest",
-        "@dotcms/types": "latest",
-        "@dotcms/uve": "latest",
+        "@dotcms/client": "1.2.0",
+        "@dotcms/experiments": "1.2.0",
+        "@dotcms/react": "1.2.0",
+        "@dotcms/types": "1.2.0",
+        "@dotcms/uve": "1.2.0",
         "@tinymce/tinymce-react": "6.2.1",
         "next": "15.3.2",
         "react": "19.1.0",


### PR DESCRIPTION
## Summary
- Part of the fix for #36891 (SDK packaging: malformed version strings and floating/orphaned dist-tags in SDK sources and example apps)
- LTS-branch half of Defect B3 for `release-25.07.10_lts_v16` — mirrors the `_v12` backport (#37475)
- Pinned to `1.2.0`, verified via static source analysis (no live server — see Test plan)

## Test plan
- [x] Confirmed `release-25.07.10_lts_v16`'s GraphQL schema (`PageAPIGraphQLTypesProvider.java` and the rest of `com.dotcms.graphql`, 80 files) does **not** define `lockedBy`, `lockedByName`, `numberContents`, `styleEditorSchemas`, or a layout `metadata` field — same gap confirmed on `_v12`
- [x] Confirmed `@dotcms/client`'s `DotCMSPage` query has requested all five unconditionally since 2025-11-26 through 2026-05-07 (PRs #33905, #34966, #34173, #35528)
- [x] Confirmed `@dotcms/client@1.2.0` published 2025-10-24, over a month before any of those additions, with no other stable version published in between — its query requests none of the five fields
- [x] Confirmed `1.2.0` is published for all five `@dotcms/*` packages this example depends on, and that a clean `npm install` resolves to exactly one deduped copy of each
- [x] Confirmed the new SDK package.json shape validator (`.github/scripts/validate-sdk-package-shapes`, added in the companion PR against `main`) passes against this pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36891