### PR TITLE
fix(cicd): exclude spec- and docs-only PRs from the Release QA report

### DIFF
--- a/.github/scripts/release-qa-status/src/exclusions.test.ts
+++ b/.github/scripts/release-qa-status/src/exclusions.test.ts
@@ -1,4 +1,4 @@
-import { classifyExclusion } from './exclusions';
+import { classifyExclusion, isDocumentationPath } from './exclusions';
 import { PRDetails } from './types';
 
 function pr(overrides: Partial<PRDetails> = {}): PRDetails {
@@ -75,5 +75,114 @@ describe('classifyExclusion', () => {
       excluded: true,
       reason: 'release-machinery',
     });
+  });
+});
+
+describe('isDocumentationPath', () => {
+  it.each([
+    'specs/37376-uve-edit-pencil-permission/spec.md',
+    'specs/36985-block-editor-selection-guard/contracts/report.schema.json',
+    'docs/backend/JAVA_STANDARDS.md',
+    'docs/images/architecture.png',
+    'README.md',
+    'CONTRIBUTING.md',
+    'core-web/libs/sdk/react/CHANGELOG.MD',
+    'examples/nextjs/docs.mdx',
+  ])('treats %s as documentation', (path) => {
+    expect(isDocumentationPath(path)).toBe(true);
+  });
+
+  it.each([
+    'dotCMS/src/main/java/com/dotcms/rest/Foo.java',
+    'core-web/libs/dotcms-ui/src/lib/foo.component.html',
+    'bom/application/pom.xml',
+    '.github/workflows/cicd_6-release.yml',
+  ])('treats %s as implementation', (path) => {
+    expect(isDocumentationPath(path)).toBe(false);
+  });
+
+  // Agent/dev tooling ships as markdown in this repo but is the deliverable,
+  // not prose about one — PR #37309 added a whole Claude skill in markdown alone.
+  it.each([
+    '.claude/skills/dot-test-plan/SKILL.md',
+    '.claude/commands/create-issue.md',
+    '.agents/skills/angular-developer/references/signals.md',
+    '.cursor/rules/java.mdc',
+    '.specify/memory/constitution.md',
+    '.specify/templates/tasks-template.md',
+    'CLAUDE.md',
+    'core-web/CLAUDE.md',
+    'dotCMS/src/main/java/com/dotcms/rest/CLAUDE.md',
+    'core-web/apps/dotcms-ui/AGENTS.md',
+  ])('keeps agent tooling %s in QA scope', (path) => {
+    expect(isDocumentationPath(path)).toBe(false);
+  });
+});
+
+describe('classifyExclusion — path heuristics', () => {
+  it('excludes a Spec-Kit PR 1 as spec-only', () => {
+    expect(
+      classifyExclusion(
+        pr({
+          title: 'Spec: UVE contentlet permission gating',
+          changedFiles: [
+            'specs/37376-uve-edit-pencil-permission/spec.md',
+            'specs/37376-uve-edit-pencil-permission/data-model.md',
+          ],
+        })
+      )
+    ).toEqual({ excluded: true, reason: 'spec-only' });
+  });
+
+  it('excludes a pure docs PR as docs-only', () => {
+    expect(
+      classifyExclusion(pr({ changedFiles: ['docs/core/SPEC_KIT_QUICK_START.md', 'README.md'] }))
+    ).toEqual({ excluded: true, reason: 'docs-only' });
+  });
+
+  it('reports specs mixed with other docs as docs-only, not spec-only', () => {
+    expect(
+      classifyExclusion(
+        pr({ changedFiles: ['specs/37376-uve-edit-pencil-permission/spec.md', 'README.md'] })
+      )
+    ).toEqual({ excluded: true, reason: 'docs-only' });
+  });
+
+  it('keeps a PR that ships a spec alongside implementation', () => {
+    expect(
+      classifyExclusion(
+        pr({
+          changedFiles: [
+            'specs/37376-uve-edit-pencil-permission/spec.md',
+            'dotCMS/src/main/java/com/dotcms/rest/ContentResource.java',
+          ],
+        })
+      )
+    ).toEqual({ excluded: false });
+  });
+
+  it('keeps a markdown-only PR that ships agent tooling', () => {
+    // PR #37309: `feat(skills): add dot-pr-spec-summary` — markdown, but a feature.
+    expect(
+      classifyExclusion(
+        pr({ changedFiles: ['.claude/skills/dot-pr-spec-summary/SKILL.md', 'CLAUDE.md'] })
+      )
+    ).toEqual({ excluded: false });
+  });
+
+  it('keeps a PR whose file list is unknown', () => {
+    // Fetch failed or the PR has more files than one page holds. Over-report
+    // rather than silently hide what might be a code change.
+    expect(classifyExclusion(pr({ changedFiles: undefined }))).toEqual({ excluded: false });
+    expect(classifyExclusion(pr({ changedFiles: [] }))).toEqual({ excluded: false });
+  });
+
+  it('prefers an earlier reason over the path check', () => {
+    // A bot that only writes specs is still excluded as a bot.
+    expect(
+      classifyExclusion(
+        pr({ authorType: 'Bot', changedFiles: ['specs/37376-foo/spec.md'] })
+      )
+    ).toEqual({ excluded: true, reason: 'bot-author' });
   });
 });

--- a/.github/scripts/release-qa-status/src/exclusions.ts
+++ b/.github/scripts/release-qa-status/src/exclusions.ts
@@ -1,6 +1,7 @@
 /**
  * Determine whether a PR should be excluded from QA evaluation because it's
- * a bot, dependency bump, or release-machinery change.
+ * a bot, dependency bump, release-machinery change, or carries no
+ * implementation at all (spec / documentation only).
  */
 
 import { ExclusionReason, PRDetails } from './types';
@@ -39,6 +40,42 @@ const RELEASE_MACHINERY_PATTERNS: RegExp[] = [
   /^merge pull request/i,
 ];
 
+/**
+ * Agent/dev tooling that happens to ship as markdown. It reads like
+ * documentation but *is* the deliverable — PR #37309 added a whole Claude
+ * skill without touching a single non-markdown file — so it stays in QA scope.
+ * Checked before the documentation patterns, or `.claude/skills/x/SKILL.md`
+ * would match DOC_FILE_PATTERN and drop out of the report.
+ */
+const IMPLEMENTATION_PREFIXES = ['.claude/', '.agents/', '.cursor/', '.specify/'];
+const IMPLEMENTATION_BASENAMES = ['claude.md', 'agents.md'];
+
+/** Spec-Kit feature directories: `specs/<issue>-<slug>/{spec,plan,tasks}.md`, contracts, etc. */
+const SPEC_PREFIX = 'specs/';
+
+/** Documentation trees — every file under them is prose, whatever the extension. */
+const DOC_PREFIXES = ['docs/'];
+
+/** Loose prose anywhere else in the tree: README.md, CONTRIBUTING.md, a library's *.mdx. */
+const DOC_FILE_PATTERN = /\.mdx?$/i;
+
+/**
+ * True when a path carries no implementation — nothing QA could exercise.
+ * Case-insensitive: paths come straight from the GitHub API and casing varies
+ * (`CLAUDE.md`, `SKILL.md`, `README.MD`).
+ */
+export function isDocumentationPath(path: string): boolean {
+  const lower = path.toLowerCase();
+
+  if (IMPLEMENTATION_PREFIXES.some((p) => lower.startsWith(p))) return false;
+  const basename = lower.slice(lower.lastIndexOf('/') + 1);
+  if (IMPLEMENTATION_BASENAMES.includes(basename)) return false;
+
+  if (lower.startsWith(SPEC_PREFIX)) return true;
+  if (DOC_PREFIXES.some((p) => lower.startsWith(p))) return true;
+  return DOC_FILE_PATTERN.test(lower);
+}
+
 export interface ExclusionResult {
   excluded: boolean;
   reason?: ExclusionReason;
@@ -69,6 +106,22 @@ export function classifyExclusion(pr: PRDetails): ExclusionResult {
   }
   if (RELEASE_MACHINERY_PATTERNS.some((p) => p.test(pr.title))) {
     return { excluded: true, reason: 'release-machinery' };
+  }
+
+  // 4) Path heuristics — last, so a bot-authored spec PR still reads
+  //    `bot-author` rather than `spec-only`.
+  //
+  //    Spec-Kit ships every feature as two PRs, and PR 1 carries spec.md alone.
+  //    It has nothing runnable, so it never earns a QA label, and without this
+  //    it lands in `missing`/`unlinked` and pages its author on every release.
+  //
+  //    Fail safe: only exclude on a file list we actually have in full. An
+  //    absent list (fetch failed, or too many files to page) leaves the PR in
+  //    QA scope — over-reporting beats silently hiding a code change.
+  const files = pr.changedFiles;
+  if (files && files.length > 0 && files.every(isDocumentationPath)) {
+    const allSpecs = files.every((f) => f.toLowerCase().startsWith(SPEC_PREFIX));
+    return { excluded: true, reason: allSpecs ? 'spec-only' : 'docs-only' };
   }
 
   return { excluded: false };

--- a/.github/scripts/release-qa-status/src/format.test.ts
+++ b/.github/scripts/release-qa-status/src/format.test.ts
@@ -1,4 +1,4 @@
-import { renderMarkdown, renderSlack } from './format';
+import { renderMarkdown, renderSlack, renderText } from './format';
 import { PRQAResult, ReleaseQAReport, SlackMapping } from './types';
 
 function pr(
@@ -218,5 +218,46 @@ describe('renderMarkdown', () => {
   it('shows the all-clean message when nothing is flagged', () => {
     const out = renderMarkdown(report());
     expect(out).toContain('All non-excluded PRs have a recognized QA verdict');
+  });
+});
+
+describe('spec/docs-only exclusions', () => {
+  // The whole point of the path heuristics: a release whose only "gaps" were
+  // Spec-Kit PR 1s must not page anyone. renderSlack keys off
+  // failed+missing+unlinked+external, so excluded PRs drop out for free —
+  // this locks that in against a future refactor folding excluded into flagged.
+  const specOnlyRelease = () =>
+    report({
+      summary: { failed: 0, missing: 0, unlinked: 0, external: 0, passed: 1, excluded: 2 },
+      passed: [pr(37423, 'Dojo to Angular: dotAI Portlet', 'passed')],
+      excluded: [
+        pr(37404, 'Spec: UVE contentlet permission gating', 'excluded', {
+          exclusionReason: 'spec-only',
+        }),
+        pr(37115, 'docs(speckit): link the quick start walkthrough video', 'excluded', {
+          exclusionReason: 'docs-only',
+        }),
+      ],
+    });
+
+  it('stays silent on Slack', () => {
+    expect(renderSlack(specOnlyRelease(), { mappings: [] })).toBe('');
+  });
+
+  it('lists the reasons in the markdown excluded table', () => {
+    const out = renderMarkdown(specOnlyRelease());
+    expect(out).toContain('## Excluded (2)');
+    expect(out).toContain('`spec-only`');
+    expect(out).toContain('`docs-only`');
+    // The blurb above the table must name them, or a reader sees an
+    // unexplained reason in a section that only ever meant "bot / bump".
+    expect(out).toMatch(/spec-only.*docs-only/s);
+  });
+
+  it('lists the reasons in the text excluded section', () => {
+    const out = renderText(specOnlyRelease());
+    expect(out).toContain('Excluded (2)');
+    expect(out).toContain('#37404 Spec: UVE contentlet permission gating — @alice [spec-only]');
+    expect(out).toContain('[docs-only]');
   });
 });

--- a/.github/scripts/release-qa-status/src/format.ts
+++ b/.github/scripts/release-qa-status/src/format.ts
@@ -81,9 +81,13 @@ export function renderText(report: ReleaseQAReport): string {
     report.summary.missing +
     report.summary.unlinked +
     report.summary.external;
+  // The Excluded section still renders below on a clean release: it is the only
+  // record of which PRs were skipped and why, and after the spec/docs-only rules
+  // the common case is exactly this one — nothing flagged *because* the gaps were
+  // spec PRs. Returning early here would leave that drop unexplained.
   if (totalFlagged === 0) {
     lines.push(':white_check_mark: All non-excluded PRs have a recognized QA verdict.');
-    return lines.join('\n');
+    lines.push('');
   }
 
   for (const key of ['failed', 'missing', 'unlinked', 'external'] as const) {
@@ -99,7 +103,8 @@ export function renderText(report: ReleaseQAReport): string {
   if (report.excluded.length > 0) {
     lines.push(`Excluded (${report.excluded.length})`);
     lines.push(
-      '  Bot / dependency-bump / version-bump / release-machinery PRs (skipped before QA check).'
+      '  Bot / dependency-bump / version-bump / release-machinery / spec-only / docs-only PRs\n' +
+        '  (skipped before QA check).'
     );
     for (const pr of report.excluded) lines.push(renderExcludedTextLine(pr));
     lines.push('');
@@ -161,10 +166,12 @@ export function renderMarkdown(report: ReleaseQAReport): string {
   out.push(`| Excluded | ${s.excluded} |`);
   out.push('');
 
+  // See renderText: the Excluded section below must survive a clean release,
+  // so this reports the all-clear instead of returning on it.
   const flagged = s.failed + s.missing + s.unlinked + s.external;
   if (flagged === 0) {
     out.push(':white_check_mark: All non-excluded PRs have a recognized QA verdict.');
-    return out.join('\n');
+    out.push('');
   }
 
   const sections: Array<{ bucket: PRQAResult[]; key: BucketKey }> = [
@@ -200,7 +207,11 @@ export function renderMarkdown(report: ReleaseQAReport): string {
   if (report.excluded.length > 0) {
     out.push(`## Excluded (${report.excluded.length})`);
     out.push('');
-    out.push('Bot / dependency-bump / version-bump / release-machinery PRs.');
+    out.push(
+      'Bot / dependency-bump / version-bump / release-machinery PRs, plus PRs that ' +
+        'change only specs or documentation (`spec-only` / `docs-only`) and so carry ' +
+        'nothing for QA to exercise.'
+    );
     out.push('');
     out.push('| PR | Title | Author | Reason |');
     out.push('|---|---|---|---|');

--- a/.github/scripts/release-qa-status/src/github.test.ts
+++ b/.github/scripts/release-qa-status/src/github.test.ts
@@ -1,4 +1,4 @@
-import { findPreviousTag } from './github';
+import { findPreviousTag, parseChangedFilesResponse } from './github';
 
 // Guards against drift from gather-release-data/src/github.ts, which resolves the
 // same release boundary. If these two disagree, the QA status and the changelog
@@ -28,5 +28,39 @@ describe('findPreviousTag', () => {
     const releases = [{ tag: 'v26.08.19-01', hasNotes: true }];
     expect(findPreviousTag(releases, 'v26.08.20-01')).toBeUndefined();
     expect(findPreviousTag(releases, 'v26.08.19-01')).toBeUndefined();
+  });
+});
+
+describe('parseChangedFilesResponse', () => {
+  const files = (paths: string[], hasNextPage = false) => ({
+    files: { nodes: paths.map((path) => ({ path })), pageInfo: { hasNextPage } },
+  });
+
+  it('maps each alias to its paths', () => {
+    const data = { repository: { pr1: files(['specs/foo/spec.md', 'README.md']) } };
+    expect(parseChangedFilesResponse(data, [1])).toEqual(
+      new Map([[1, ['specs/foo/spec.md', 'README.md']]])
+    );
+  });
+
+  // Everything below must yield `undefined`, never `[]`. An empty array reads as
+  // "changed nothing", which classifyExclusion would be free to exclude on; the
+  // point of these cases is that we do not know, so the PR stays in QA scope.
+  it('returns undefined when the list is truncated', () => {
+    const spy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const data = { repository: { pr2: files(['a.md'], true) } };
+    expect(parseChangedFilesResponse(data, [2]).get(2)).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('#2'));
+    spy.mockRestore();
+  });
+
+  it('returns undefined for a missing alias, a null PR, and a null files connection', () => {
+    const data = { repository: { pr4: null, pr5: { files: null } } };
+    const out = parseChangedFilesResponse(data, [3, 4, 5]);
+    expect(out.get(3)).toBeUndefined();
+    expect(out.get(4)).toBeUndefined();
+    expect(out.get(5)).toBeUndefined();
+    // Present-but-unknown, not absent: classifyExclusion reads every PR.
+    expect(out.size).toBe(3);
   });
 });

--- a/.github/scripts/release-qa-status/src/github.ts
+++ b/.github/scripts/release-qa-status/src/github.ts
@@ -312,6 +312,136 @@ export async function fetchClosingIssueRefs(
   return results;
 }
 
+interface GraphQLFilesResponse {
+  repository: Record<
+    string,
+    {
+      files: {
+        nodes: Array<{ path: string }>;
+        pageInfo: { hasNextPage: boolean };
+      } | null;
+    } | null
+  >;
+}
+
+/** Max paths one GraphQL page returns — GitHub caps `first` at 100. */
+const FILES_PAGE_SIZE = 100;
+
+/**
+ * Shape one GraphQL batch response into per-PR path lists.
+ *
+ * `undefined` means "we don't know what this PR changed" and is deliberately
+ * distinct from `[]`. A PR whose alias is missing, whose `files` connection is
+ * null, or that has more files than one page holds all resolve to `undefined`
+ * so the caller keeps it in QA scope. Not paginating past 100 is a judgement
+ * call, not an oversight: this list exists only to answer "is every file
+ * documentation?", and a 100+ file PR is never documentation-only.
+ *
+ * Exported for tests — pure, so it needs no network.
+ */
+export function parseChangedFilesResponse(
+  data: GraphQLFilesResponse,
+  prNumbers: number[]
+): Map<number, string[] | undefined> {
+  const results = new Map<number, string[] | undefined>();
+
+  for (const n of prNumbers) {
+    const pr = data.repository?.[`pr${n}`];
+    if (!pr || !pr.files) {
+      results.set(n, undefined);
+      continue;
+    }
+    if (pr.files.pageInfo.hasNextPage) {
+      process.stderr.write(
+        `Note: PR #${n} changed more than ${FILES_PAGE_SIZE} files — ` +
+          `treating its file list as unknown (stays in QA scope).\n`
+      );
+      results.set(n, undefined);
+      continue;
+    }
+    results.set(
+      n,
+      pr.files.nodes.map((f) => f.path)
+    );
+  }
+
+  return results;
+}
+
+/**
+ * Fetch the changed paths for a batch of PRs, so `classifyExclusion` can tell
+ * a spec/docs-only PR from one carrying implementation.
+ *
+ * Batched GraphQL rather than one REST `pulls.listFiles` per PR: the report
+ * already spends 3+ REST calls per PR, and this adds roughly one request per
+ * twenty instead of one per PR.
+ *
+ * Unlike `fetchClosingIssueRefs`, a GraphQL failure here is swallowed rather
+ * than re-thrown. There, an empty result silently demotes PRs to `unlinked`
+ * and floods Slack with bogus warnings, so failing loudly is right. Here the
+ * failure mode is the opposite and harmless: an unknown file list simply means
+ * no path-based exclusion, which is exactly how the report behaved before this
+ * existed. Killing the whole QA section over it would be the worse trade.
+ */
+export async function fetchChangedFiles(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumbers: number[]
+): Promise<Map<number, string[] | undefined>> {
+  const results = new Map<number, string[] | undefined>();
+  const BATCH = 20;
+
+  for (let i = 0; i < prNumbers.length; i += BATCH) {
+    const batch = prNumbers.slice(i, i + BATCH);
+    // GraphQL aliases must be static field names (no $variables), so PR numbers
+    // are interpolated. They come from the commits→pulls API and are already
+    // integers; re-check anyway before building the query.
+    const safeBatch = batch.filter((n) => Number.isInteger(n) && n > 0);
+    if (safeBatch.length === 0) continue;
+
+    const aliases = safeBatch
+      .map(
+        (n) =>
+          `  pr${n}: pullRequest(number: ${n}) {\n` +
+          `    files(first: ${FILES_PAGE_SIZE}) {\n` +
+          `      nodes { path }\n` +
+          `      pageInfo { hasNextPage }\n` +
+          `    }\n` +
+          `  }`
+      )
+      .join('\n');
+
+    const query =
+      `query($owner: String!, $repo: String!) {\n` +
+      `  repository(owner: $owner, name: $repo) {\n` +
+      aliases +
+      `\n  }\n}`;
+
+    try {
+      const data = await octokit.graphql<GraphQLFilesResponse>(query, {
+        owner,
+        repo,
+      });
+      for (const [n, files] of parseChangedFilesResponse(data, safeBatch)) {
+        results.set(n, files);
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `Warning: could not fetch changed files for PR(s) ` +
+          `${safeBatch.map((n) => `#${n}`).join(', ')}: ${msg}. ` +
+          `They stay in QA scope (no path-based exclusion).\n`
+      );
+      for (const n of safeBatch) results.set(n, undefined);
+    }
+
+    if (i + BATCH < prNumbers.length) await sleep(500);
+  }
+
+  return results;
+}
+
 export async function fetchPRDetails(
   octokit: Octokit,
   owner: string,
@@ -366,18 +496,21 @@ export async function fetchPRDetails(
     );
   }
 
-  const refs = await fetchClosingIssueRefs(
-    octokit,
-    owner,
-    repo,
-    Array.from(results.keys())
-  );
+  const prNumbersFetched = Array.from(results.keys());
+
+  const refs = await fetchClosingIssueRefs(octokit, owner, repo, prNumbersFetched);
   for (const [n, pr] of results) {
     const r = refs.get(n);
     if (r) {
       pr.linkedIssues = r.sameRepo;
       pr.externalRefs = r.external;
     }
+  }
+
+  const changed = await fetchChangedFiles(octokit, owner, repo, prNumbersFetched);
+  for (const [n, pr] of results) {
+    // Leave `changedFiles` undefined when unknown — see classifyExclusion.
+    pr.changedFiles = changed.get(n);
   }
 
   return results;

--- a/.github/scripts/release-qa-status/src/qa.test.ts
+++ b/.github/scripts/release-qa-status/src/qa.test.ts
@@ -39,6 +39,42 @@ describe('computePRQA', () => {
     expect(result.linkedIssues).toEqual([]);
   });
 
+  it('excludes a spec-only PR even when it does link an issue', () => {
+    // A Spec-Kit PR 1 usually closes nothing, but when it does the linked issue
+    // is the *feature* issue, which QA will label once the implementation PR
+    // ships. Reading its label here would report the spec PR as un-QA'd.
+    const result = computePRQA(
+      pr({
+        linkedIssues: [37376],
+        changedFiles: ['specs/37376-uve-edit-pencil-permission/spec.md'],
+      }),
+      new Map([[37376, issue(37376, [])]])
+    );
+    expect(result.status).toBe('excluded');
+    expect(result.exclusionReason).toBe('spec-only');
+    expect(result.linkedIssues).toEqual([]);
+  });
+
+  it('excludes a docs-only PR', () => {
+    const result = computePRQA(
+      pr({ changedFiles: ['docs/core/GIT_WORKFLOWS.md'] }),
+      new Map()
+    );
+    expect(result.status).toBe('excluded');
+    expect(result.exclusionReason).toBe('docs-only');
+  });
+
+  it('still evaluates QA for a PR that ships a spec plus implementation', () => {
+    const result = computePRQA(
+      pr({
+        linkedIssues: [37376],
+        changedFiles: ['specs/37376-foo/spec.md', 'dotCMS/src/main/java/Foo.java'],
+      }),
+      new Map([[37376, issue(37376, ['QA : Passed'])]])
+    );
+    expect(result.status).toBe('passed');
+  });
+
   it('returns unlinked when no closing refs of either kind exist', () => {
     const result = computePRQA(pr(), new Map());
     expect(result.status).toBe('unlinked');

--- a/.github/scripts/release-qa-status/src/types.ts
+++ b/.github/scripts/release-qa-status/src/types.ts
@@ -16,7 +16,9 @@ export type ExclusionReason =
   | 'bot-author'
   | 'dependency-bump'
   | 'version-bump'
-  | 'release-machinery';
+  | 'release-machinery'
+  | 'spec-only'
+  | 'docs-only';
 
 /** Label resolution for a single linked issue. */
 export interface LinkedIssueInfo {
@@ -49,6 +51,13 @@ export interface PRDetails {
   linkedIssues: number[];
   /** Cross-repo closing-issue references. */
   externalRefs: ExternalRef[];
+  /**
+   * Paths changed by the PR. `undefined` means the list is unknown — the API
+   * call failed, or the PR has more files than one page returns. Never exclude
+   * a PR on an unknown list: a missing list must degrade to today's behaviour,
+   * not silently hide a code change from QA.
+   */
+  changedFiles?: string[];
 }
 
 /** A single PR with its computed QA result. */


### PR DESCRIPTION
Closes #37486

### Proposed Changes

The release QA report (`.github/scripts/release-qa-status`) flags every merged PR whose linked issue lacks a `QA : Passed` / `QA : Not Needed` / `QA : Failed` label. Since Spec-Kit landed, every feature ships **two** PRs and PR 1 carries `spec.md` alone under `specs/<issue>-<slug>/`. Those PRs contain nothing runnable, so QA has nothing to exercise and they never earn a QA label — yet the report counted them as un-QA'd, inflating the `:rotating_light:` Slack warning and @-mentioning their authors on every release. Pure documentation PRs had the same problem.

The report had no idea what files a PR touched: `classifyExclusion` only ever read `authorType`, `author`, `labels` and `title`. So:

* **`github.ts`** — new `fetchChangedFiles`: batched GraphQL (20 PRs per query) rather than one REST `listFiles` per PR, so the cost is roughly one extra request per twenty on top of the 3+ REST calls per PR the tool already makes. Unlike its sibling `fetchClosingIssueRefs` it **swallows** GraphQL errors instead of re-throwing — there, an empty result silently demotes PRs to `unlinked` and floods Slack, so failing loudly is right; here an unknown file list just means no path-based exclusion, i.e. exactly the previous behaviour, and killing the whole QA section over it would be the worse trade.
* **`exclusions.ts`** — new `isDocumentationPath()` plus a 4th rule in `classifyExclusion`, applied **after** the title heuristics so a bot-authored spec PR still reads `bot-author`.
* **`types.ts`** — two new `ExclusionReason` values (`spec-only`, `docs-only`) and `changedFiles?: string[]`, where `undefined` means *unknown* and is deliberately distinct from `[]`.
* **`format.ts`** — Excluded-section blurbs name the new reasons, and that section now renders on a clean release (see *Additional Info*).

**What counts as documentation:** `specs/**`, `docs/**`, and loose `*.md` / `*.mdx`.

**What stays in QA scope** — agent tooling is checked *first*: `.claude/`, `.agents/`, `.cursor/`, `.specify/`, and any `CLAUDE.md` / `AGENTS.md` at any depth. In this repo that markdown **is** the deliverable — #37309 (`feat(skills): add dot-pr-spec-summary`) shipped a whole feature without touching a non-markdown file. Without the exception, `.claude/skills/x/SKILL.md` would match the markdown pattern and drop a real feature out of the report.

**Fail safe throughout:** a PR is excluded only when its file list was fetched in full *and* every path is documentation. An absent or truncated list keeps the PR in QA scope — over-reporting beats silently hiding a code change. GitHub caps `first` at 100 and this isn't paginated past that, which is a judgement call rather than an oversight: the list exists only to answer "is every file documentation?", and a 100+ file PR never is.

Blast radius is CI tooling only — a standalone TypeScript CLI run by `.github/workflows/cicd_6-release.yml`. No new files, no changes to the workflow, and nothing under `dotCMS/` or `core-web/`.

### Checklist
- [x] Tests
- [ ] Translations — n/a, no user-facing strings
- [x] Security Implications Contemplated — no new secrets or permissions; the new GraphQL query is read-only and PR numbers are re-validated with `Number.isInteger(n) && n > 0` before alias interpolation, matching the existing guard in `fetchClosingIssueRefs`

### Additional Info

**Verified against a real release** — `v26.09.03-01...v26.09.09-01`, 38 PRs, run before and after the change:

| bucket | before | after |
|---|---|---|
| failed | 0 | 0 |
| missing | 25 | **17** |
| unlinked | 0 | 0 |
| external | 0 | 0 |
| passed | 13 | 12 |
| excluded | 0 | **9** |

All 9 newly-excluded PRs were re-checked **independently via `gh`**, not through the code under test: every one is genuinely spec/docs-only (#37103, #37188, #37189, #37190, #37392, #37404, #37430, #37434, #37437). The reverse check found no false negatives — no docs-only PR was left in the flagged buckets. The truncation guard also fired for real on #37423 (>100 files), which correctly stayed in QA scope.

78 tests pass (`cd .github/scripts/release-qa-status && npm ci && npm test`); `npx tsc --noEmit` is clean.

**Two things a reviewer should weigh:**

1. **I removed an early return in `renderText` / `renderMarkdown`.** Both bailed on `flagged === 0` *before* the Excluded section. After this change the common case is exactly that — nothing flagged *because* the gaps were spec PRs — so the drop in counts would go unexplained. The Excluded table now renders on clean releases too, keeping the skip list auditable. `renderSlack` is untouched and still returns the empty string when nothing needs review, so this adds no Slack noise. This is a small behaviour change beyond the strict minimum; easy to revert if you'd rather keep the early return.
2. **#37392 moved `passed` → `excluded`.** A spec PR whose linked issue already carried `QA : Passed`. Correct under the new rules, but it does mean `passed` no longer counts spec PRs that happened to be labelled.

**Unrelated observation, not fixed here:** `npm start -- --format json > file` writes npm's own banner ahead of the JSON, so a redirect isn't valid JSON. Pre-existing and harmless in the workflow (markdown into `$GITHUB_STEP_SUMMARY`), but worth knowing if anyone scripts against the JSON output.

### Screenshots

n/a — CLI output only. Text format on the verification run:

```
Summary:
  failed:   0
  missing:  16
  unlinked: 0
  external: 0
  passed:   13
  excluded: 9

Excluded (9)
  Bot / dependency-bump / version-bump / release-machinery / spec-only / docs-only PRs
  (skipped before QA check).
  - #37103 docs(opensearch): add the ES → OpenSearch migration runbook … [docs-only]
  - #37404 Spec: UVE contentlet permission gating — @rjvelazco [spec-only]
  - #37434 docs(block-editor): revise the #37340 spec to an editor-only fix [spec-only]
  …
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

