### PR TITLE
fix(content-drive): close the timing gap that lets a fast double click fire two page requests (#37212)

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.spec.ts
@@ -528,6 +528,47 @@ describe('DotFolderListViewComponent', () => {
             expect(paginateSpy).toHaveBeenCalledWith({ first: 20, rows: 20, page: 2 });
         });
 
+        it('should not fire a second request from a rapid second click before loading catches up', () => {
+            // `loading` only flips to `true` after this component's `paginate` output round-trips
+            // through the caller's store, at least one microtask away. A second `onPage` call in
+            // that gap must not slip past the `$loading()` guard the way a real fast double click
+            // would (issue #37212) -- exercised here without advancing the input at all, which is
+            // the whole point: this proves the guard does not depend on `loading` having caught up.
+            spectator.setInput('items', manyItems);
+            spectator.setInput('totalItems', 100);
+            spectator.setInput('loading', false);
+            spectator.detectChanges();
+            const paginateSpy = vi.spyOn(spectator.component.paginate, 'emit');
+
+            spectator.component.onPage({ first: 20, rows: 20 });
+            spectator.component.onPage({ first: 20, rows: 20 });
+
+            expect(paginateSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should accept a new page change once loading reflects the first one', () => {
+            spectator.setInput('items', manyItems);
+            spectator.setInput('totalItems', 100);
+            spectator.setInput('loading', false);
+            spectator.detectChanges();
+            const paginateSpy = vi.spyOn(spectator.component.paginate, 'emit');
+
+            spectator.component.onPage({ first: 20, rows: 20 });
+
+            // The caller's store has now caught up and reflects the in-flight request.
+            spectator.setInput('loading', true);
+            spectator.detectChanges();
+
+            // The caller's store has settled -- the local guard must have been released by the
+            // `loading` transition above, not still be holding from the first click.
+            spectator.setInput('loading', false);
+            spectator.detectChanges();
+
+            spectator.component.onPage({ first: 40, rows: 20 });
+
+            expect(paginateSpy).toHaveBeenCalledTimes(2);
+        });
+
         it('should take the paginator out of play while loading', () => {
             spectator.setInput('items', manyItems);
             spectator.setInput('totalItems', 100);

--- a/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-folder-list-view/dot-folder-list-view.component.ts
@@ -879,6 +879,14 @@ export class DotFolderListViewComponent implements OnInit, AfterViewInit, OnDest
         this.#seedRovingTabStop();
         this.#applyRovingTabStop();
         this.#trackFocusIntent();
+
+        // Hands the local page-change guard back to `$loading()` the moment the store's own status
+        // catches up with the click that set it (found in review, issue #37212).
+        effect(() => {
+            if (this.$loading()) {
+                this.#pageChangeAccepted = false;
+            }
+        });
     }
 
     readonly #onKeydownCapture = (event: KeyboardEvent): void => {
@@ -1178,6 +1186,20 @@ export class DotFolderListViewComponent implements OnInit, AfterViewInit, OnDest
     }
 
     /**
+     * True from the moment a page-change click is accepted until `$loading()` first reflects it.
+     *
+     * `$loading()` mirrors the caller's request lifecycle one round trip away: this component emits
+     * `paginate`, the caller patches its store, and only once that store's own reactive pipeline
+     * reacts does `loading` flip to `true` and propagate back down here as an input. That round
+     * trip is at least one microtask, and during it `$loading()` still reads `false` — so a second
+     * click in that gap (a fast double click, or two rapid keyboard activations) would sail past the
+     * `$loading()` guard below and queue a second request the first click already started (found in
+     * review, issue #37212). This flag closes exactly that gap; once `$loading()` catches up (see the
+     * constructor's effect), that guard alone is sufficient for the rest of the request's lifetime.
+     */
+    #pageChangeAccepted = false;
+
+    /**
      * Handles pagination events from the PrimeNG Table
      * @param event The lazy load event containing pagination info
      */
@@ -1188,14 +1210,17 @@ export class DotFolderListViewComponent implements OnInit, AfterViewInit, OnDest
             return;
         }
 
-        // A search is already in flight. The paginator stays mounted while the rows are replaced by
-        // skeletons, so without this every further click fires another search for a page the user
-        // cannot see yet, and the last response to arrive wins regardless of which page was asked
-        // for last. The controls are also visually disabled via `$ptConfig`, but this is the part
-        // that has to hold: a keyboard activation or a fast double click does not wait for CSS.
-        if (this.$loading()) {
+        // A search is already in flight, or one was just accepted and the caller's `loading` has not
+        // caught up yet (see `#pageChangeAccepted`). The paginator stays mounted while the rows are
+        // replaced by skeletons, so without this every further click fires another search for a page
+        // the user cannot see yet, and the last response to arrive wins regardless of which page was
+        // asked for last. The controls are also visually disabled via `$ptConfig`, but this is the
+        // part that has to hold: a keyboard activation or a fast double click does not wait for CSS.
+        if (this.$loading() || this.#pageChangeAccepted) {
             return;
         }
+
+        this.#pageChangeAccepted = true;
 
         const page = event.first && event.rows ? Math.floor(event.first / event.rows) + 1 : 1;
         this.paginate.emit({ ...event, page });


### PR DESCRIPTION
## Summary
- Content Drive's pagination guard (`if (this.$loading()) return;` in `DotFolderListViewComponent#onPage`) already blocks a second click once the caller's `loading` input reflects the in-flight request — but that input takes at least one microtask to catch up (it round-trips through the caller's store via `paginate` → `setPagination` → a reactive effect → `loadItems()`). A fast double click, or two rapid keyboard activations, can both land inside that gap and slip past the guard, firing two requests for the same navigation action.
- Adds a synchronous local flag (`#pageChangeAccepted`) that closes exactly this gap: set the instant a page change is accepted, cleared by an effect the moment `$loading()` first reflects it. The existing guard is untouched and remains the sole gate for the rest of a request's lifetime.

Fixes #37212.

## Test plan
- [x] `pnpm nx test ui -- dot-folder-list-view` — 241/241 passing, including 2 new tests:
  - a rapid second `onPage()` call before `loading` catches up fires exactly one `paginate` emit
  - a page change is accepted again once `loading` reflects the first one (guard correctly releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #37212